### PR TITLE
Make new console command names include “console”.

### DIFF
--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -97,7 +97,7 @@ function activateConsole(app: Application, services: JupyterServices, rendermime
     app.palette.add([{
       command: id,
       category: 'Console',
-      text: `New ${displayName}`
+      text: `New ${displayName} console`
     }]);
   }
 


### PR DESCRIPTION
Fixes #21