### PR TITLE
Start JupyterLab with  'jupyter lab'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ An extensible computational environment for Jupyter.
 
 <img src="jupyter-plugins-demo.gif" alt="JupyterLab Demo" style="width: 100%;"/>
 
-Jupyter Notebook Extension
---------------------------
+Jupyter Server Extension
+------------------------
 
-The Jupyter notebook extension source files are in the `jupyterlab/` subdirectory. To use this extension, you need Jupyter notebook version 4.2 or later.
+The Jupyter server extension source files are in the `jupyterlab/` subdirectory. To use this extension, you need the Jupyter notebook server version 4.2 or later.
 
 ### User installation
 ```
@@ -20,7 +20,7 @@ pip install jupyterlab
 jupyter serverextension enable --py jupyterlab
 ```
 
-Start up the Jupyter notebook and open a browser to the server's URL with the path `/lab` (e.g., `http://localhost:8888/lab`).
+Start up Jupyterlab with the command `jupyter lab`, open a browser to the server's URL (e.g., `http://localhost:8888`).
 
 
 ### Developer Installation
@@ -34,7 +34,7 @@ pip install -e . # will take a long time to build everything
 jupyter serverextension enable --py jupyterlab
 ```
 
-Start up the Jupyter notebook, and then open a browser to the server's URL with path `/lab` (e.g., `http://localhost:8888/lab`).
+Start up Jupyterlab with the command `jupyter lab`, open a browser to the server's URL (e.g., `http://localhost:8888`).
 
 When you make a change to JupyterLab npm package source files, run `python setup.py jsdeps` to build the changes and refresh your browser to see the changes.
 
@@ -46,7 +46,7 @@ The npm package source files are in the `src/` subdirectory.
 
 **Prerequisites**
 - [node](http://nodejs.org/) (preferably version 5 or later)
-- Jupyter notebook version 4.2 or later (to run examples)
+- Jupyter notebook server version 4.2 or later (to run examples)
 
 ```bash
 npm install --save jupyterlab

--- a/jupyterlab/labapp.py
+++ b/jupyterlab/labapp.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+"""A tornado based Jupyter lab server."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+# TODO: import base server app
+from notebook.notebookapp import NotebookApp
+from traitlets import Unicode
+
+
+class LabApp(NotebookApp):
+
+    default_url = Unicode('/lab', config=True,
+        help="The default URL to redirect to from `/`"
+    )
+
+#-----------------------------------------------------------------------------
+# Main entry point
+#-----------------------------------------------------------------------------
+
+main = launch_new_instance = LabApp.launch_instance

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,11 @@ setup_args = {
         'sdist': js_prerelease(sdist, strict=True),
         'jsdeps': NPM,
     },
+    'entry_points': {
+        'console_scripts': [
+            'jupyter-lab = jupyterlab.labapp:main',
+        ]
+    },
     'author': 'Jupyter Development Team',
     'author_email': 'jupyter@googlegroups.com',
     'url': 'http://jupyter.org',


### PR DESCRIPTION
On the notebook repo side, we should create a base class for `NotebookApp`, `ServerApp` which does not hold anything notebook specific.