### PR TITLE
Update typedoc dependecy to 0.4.2 so `npm install` works

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",
-    "typedoc": "git+https://github.com/SierraSoftworks/typedoc.git#cb5aea2b218b4f773451e2818a48629ee9c5066e",
+    "typedoc": "^0.4.2",
     "typescript": "^1.8.0",
     "url-loader": "^0.5.7",
     "watch": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",
-    "typedoc": "https://github.com/SierraSoftworks/typedoc.git#cb5aea2b218b4f773451e2818a48629ee9c5066e",
+    "typedoc": "git+https://github.com/SierraSoftworks/typedoc.git#cb5aea2b218b4f773451e2818a48629ee9c5066e",
     "typescript": "^1.8.0",
     "url-loader": "^0.5.7",
     "watch": "^0.17.1",


### PR DESCRIPTION
Previously got "npm ERR! not a package" for the typedoc entry.

Ref: https://docs.npmjs.com/files/package.json#git-urls-as-dependencies.