### PR TITLE
Use a base_url valid for both single and multiuser server

### DIFF
--- a/jupyterlab/__init__.py
+++ b/jupyterlab/__init__.py
@@ -7,6 +7,7 @@ import os
 from tornado import web
 from notebook.base.handlers import IPythonHandler, FileFindHandler
 from jinja2 import FileSystemLoader
+from notebook.utils import url_path_join as ujoin
 
 HERE = os.path.dirname(__file__)
 FILE_LOADER = FileSystemLoader(HERE)
@@ -19,7 +20,7 @@ class LabHandler(IPythonHandler):
     @web.authenticated
     def get(self):
         self.write(self.render_template('lab.html',
-            static_prefix=PREFIX,
+            static_prefix=ujoin(self.application.settings['base_url'], PREFIX),
             page_title='Pre-Alpha Jupyter Lab Demo',
             terminals_available=self.settings['terminals_available'],
             mathjax_url=self.mathjax_url,
@@ -45,8 +46,9 @@ def _jupyter_server_extension_paths():
         "module": "jupyterlab"
     }]
     
+
 def load_jupyter_server_extension(nbapp):
     nbapp.log.info('Pre-alpha version of JupyterLab extension loaded from %s'%HERE)
     webapp = nbapp.web_app
-    #base_url = webapp.settings['base_url']
-    webapp.add_handlers(".*$", default_handlers)
+    base_url = webapp.settings['base_url']
+    webapp.add_handlers(".*$", [(ujoin(base_url, h[0]),) + h[1:] for h in default_handlers])


### PR DESCRIPTION
fix the base_url path so to be able to load the jupyterlab  in a jupyterhub multiuser environment. I tested few functionalities new notebooks, terminal and new text file are working properly.

I installed the jupyterlub system wide with:

```sudo python3 setup.py install```

and enabled the extension for each user logging in with a fresh ssh session and then issuing the command:
```jupyter serverextension enable --py jupyterlab```


Thanks @jcb91 for suggesting the needed changes!