### PR TITLE
Move sanitization to the markdown renderer, *after* the math processing.

### DIFF
--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -38,10 +38,6 @@ import {
 } from '../output-area';
 
 import {
-  sanitize
-} from 'sanitizer';
-
-import {
   IMetadataCursor
 } from '../common/metadata';
 
@@ -468,7 +464,6 @@ class MarkdownCellWidget extends BaseCellWidget {
       let text = model.source || DEFAULT_MARKDOWN_TEXT;
       // Do not re-render if the text has not changed.
       if (text !== this._prev) {
-        text = sanitize(text);
         let bundle: MimeMap<string> = { 'text/markdown': text };
         this._renderer.dispose();
         this._renderer = this._rendermime.render(bundle) || new Widget();

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -21,6 +21,10 @@ import {
 } from 'phosphor-messaging';
 
 import {
+  sanitize
+} from 'sanitizer';
+
+import {
   typeset, removeMath, replaceMath
 } from './latex';
 
@@ -202,6 +206,7 @@ class MarkdownRenderer implements IRenderer<Widget> {
   render(mimetype: string, text: string): Widget {
     let data = removeMath(text);
     let html = marked(data['text']);
-    return new HTMLWidget(replaceMath(html, data['math']));
+    let sanitized = sanitize(replaceMath(html, data['math']));
+    return new HTMLWidget(sanitized);
   }
 }


### PR DESCRIPTION
When the sanitization was before the math processing, any < signs were being double-escaped - getting converted to &lt; in sanitization, and then getting converted to &amp;lt; in the math processing.

Fixes #63.