### PR TITLE
OutputArea refactor and tests

### DIFF
--- a/src/notebook/cells/model.ts
+++ b/src/notebook/cells/model.ts
@@ -29,7 +29,7 @@ import {
 } from '../common/metadata';
 
 import {
-  ObservableOutputs
+  OutputAreaModel
 } from '../output-area';
 
 
@@ -104,7 +104,7 @@ interface ICodeCellModel extends ICellModel {
   /**
    * The cell outputs.
    */
-  outputs: ObservableOutputs;
+  outputs: OutputAreaModel;
 }
 
 
@@ -327,10 +327,12 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
    */
   constructor(cell?: nbformat.IBaseCell) {
     super(cell);
-    this._outputs = new ObservableOutputs();
+    this._outputs = new OutputAreaModel();
     if (cell && cell.cell_type === 'code') {
       this.executionCount = (cell as nbformat.ICodeCell).execution_count;
-      this._outputs.assign((cell as nbformat.ICodeCell).outputs);
+      for (let output of (cell as nbformat.ICodeCell).outputs) {
+        this._outputs.add(output);
+      }
     }
     this._outputs.changed.connect(() => {
       this.contentChanged.emit(void 0);
@@ -369,7 +371,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
    * #### Notes
    * This is a read-only property.
    */
-  get outputs(): ObservableOutputs {
+  get outputs(): OutputAreaModel {
     return this._outputs;
   }
 
@@ -399,7 +401,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
     return cell;
   }
 
-  private _outputs: ObservableOutputs = null;
+  private _outputs: OutputAreaModel = null;
   private _executionCount: number = null;
 }
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -321,7 +321,9 @@ class CodeCellWidget extends BaseCellWidget {
    * Create an output area widget.
    */
   static createOutput(outputs: ObservableOutputs, rendermime: RenderMime<Widget>): OutputAreaWidget {
-    return new OutputAreaWidget(outputs, rendermime);
+    let output = new OutputAreaWidget({ rendermime });
+    output.outputs = outputs;
+    return output;
   }
 
   /**

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -320,9 +320,9 @@ class CodeCellWidget extends BaseCellWidget {
   /**
    * Create an output area widget.
    */
-  static createOutput(outputs: ObservableOutputs, rendermime: RenderMime<Widget>): OutputAreaWidget {
+  static createOutput(model: ObservableOutputs, rendermime: RenderMime<Widget>): OutputAreaWidget {
     let output = new OutputAreaWidget({ rendermime });
-    output.outputs = outputs;
+    output.model = model;
     return output;
   }
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -34,7 +34,7 @@ import {
 } from '../notebook/nbformat';
 
 import {
-  OutputAreaWidget, ObservableOutputs, executeCode
+  OutputAreaWidget, OutputAreaModel, executeCode
 } from '../output-area';
 
 import {
@@ -320,7 +320,7 @@ class CodeCellWidget extends BaseCellWidget {
   /**
    * Create an output area widget.
    */
-  static createOutput(model: ObservableOutputs, rendermime: RenderMime<Widget>): OutputAreaWidget {
+  static createOutput(model: OutputAreaModel, rendermime: RenderMime<Widget>): OutputAreaWidget {
     let output = new OutputAreaWidget({ rendermime });
     output.model = model;
     return output;

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -18,7 +18,7 @@ import {
 } from 'phosphor-panel';
 
 import {
-  Widget
+  ChildMessage, Widget
 } from 'phosphor-widget';
 
 import {
@@ -110,17 +110,41 @@ class OutputAreaWidget extends Widget {
   /**
    * Construct an output area widget.
    */
-  constructor(outputs: ObservableOutputs, rendermime: RenderMime<Widget>) {
+  constructor(options: OutputAreaWidget.IOptions) {
     super();
     this.addClass(OUTPUT_AREA_CLASS);
-    this._rendermime = rendermime;
+    this._rendermime = options.rendermime;
     this.layout = new PanelLayout();
-    for (let i = 0; i < outputs.length; i++) {
-      let widget = this.createOutput(outputs.get(i));
+  }
+
+  /**
+   * The observable outputs for the outputarea widget.
+   */
+  get outputs(): ObservableOutputs {
+    return this._outputs;
+  }
+  set outputs(newValue: ObservableOutputs) {
+    if (!newValue && !this._outputs || newValue === this._outputs) {
+      return;
+    }
+
+    // TODO: Reuse widgets if possible.
+    if (this._outputs) {
+      this._outputs.clear();
+      this._outputs.changed.disconnect(this._onOutputsChanged, this);
+    }
+
+    this._outputs = newValue;
+
+    if (!newValue) {
+      return;
+    }
+
+    for (let i = 0; i < newValue.length; i++) {
+      let widget = this._createOutput(newValue.get(i));
       (this.layout as PanelLayout).addChild(widget);
     }
-    outputs.changed.connect(this.outputsChanged, this);
-    this._outputs = outputs;
+    newValue.changed.connect(this._onOutputsChanged, this);
   }
 
   /**
@@ -135,14 +159,14 @@ class OutputAreaWidget extends Widget {
     }
     this._trusted = value;
     // Re-render only if necessary.
-    if ((this._sanitized && value) || (!value)) {
+    if (!value) {
       let layout = this.layout as PanelLayout;
       for (let i = 0; i < layout.childCount(); i++) {
         layout.childAt(0).dispose();
       }
       let outputs = this._outputs;
       for (let i = 0; i < outputs.length; i++) {
-        layout.addChild(this.createOutput(outputs.get(i)));
+        layout.addChild(this._createOutput(outputs.get(i)));
       }
     }
   }
@@ -185,145 +209,8 @@ class OutputAreaWidget extends Widget {
     }
     this._outputs = null;
     this._rendermime = null;
+    this._factory = null;
     super.dispose();
-  }
-
-  /**
-   * Create an output node from an output model.
-   */
-  protected createOutput(output: nbformat.IOutput): Widget {
-    let widget = new Panel();
-    widget.addClass(OUTPUT_CLASS);
-    let bundle: nbformat.MimeBundle;
-    this._sanitized = false;
-    switch (output.output_type) {
-    case 'execute_result':
-      bundle = (output as nbformat.IExecuteResult).data;
-      widget.addClass(EXECUTE_CLASS);
-      let prompt = new Widget();
-      prompt.addClass(PROMPT_CLASS);
-      let count = (output as nbformat.IExecuteResult).execution_count;
-      prompt.node.textContent = `Out[${count === null ? ' ' : count}]:`;
-      widget.addChild(prompt);
-      break;
-    case 'display_data':
-      bundle = (output as nbformat.IDisplayData).data;
-      widget.addClass(DISPLAY_CLASS);
-      break;
-    case 'stream':
-      bundle = {'application/vnd.jupyter.console-text': (output as nbformat.IStream).text};
-      if ((output as nbformat.IStream).name === 'stdout') {
-        widget.addClass(STDOUT_CLASS);
-      } else {
-        widget.addClass(STDERR_CLASS);
-      }
-      break;
-    case 'error':
-      let out: nbformat.IError = output as nbformat.IError;
-      let traceback = out.traceback.join('\n');
-      bundle = {'application/vnd.jupyter.console-text': traceback || `${out.ename}: ${out.evalue}`};
-      widget.addClass(ERROR_CLASS);
-      break;
-    default:
-      console.error(`Unrecognized output type: ${output.output_type}`);
-      bundle = {};
-    }
-
-    // Sanitize outputs as needed.
-    if (!this.trusted) {
-      let keys = Object.keys(bundle);
-      for (let key of keys) {
-        if (safeOutputs.indexOf(key) !== -1) {
-          continue;
-        } else if (sanitizable.indexOf(key) !== -1) {
-          this._sanitized = true;
-          let out = bundle[key];
-          if (typeof out === 'string') {
-            bundle[key] = sanitize(out);
-          } else {
-            console.log('Ignoring unsanitized ' + key + ' output; could not sanitize because output is not a string.');
-            delete bundle[key];
-          }
-        } else {
-          this._sanitized = true;
-          // Don't display if we don't know how to sanitize it.
-          console.log('Ignoring untrusted ' + key + ' output.');
-          delete bundle[key];
-        }
-      }
-    }
-
-    if (bundle) {
-      let mimemap = this.convertBundle(bundle);
-      let child = this._rendermime.render(mimemap);
-      if (child) {
-        child.addClass(RESULT_CLASS);
-        widget.addChild(child);
-      } else {
-        console.log('Did not find renderer for output mimebundle.');
-        console.log(bundle);
-      }
-    }
-    return widget;
-  }
-
-  /**
-   * Convert a mime bundle to a mime map.
-   */
-  protected convertBundle(bundle: nbformat.MimeBundle): MimeMap<string> {
-    let map: MimeMap<string> = Object.create(null);
-    for (let mimeType in bundle) {
-      let value = bundle[mimeType];
-      if (Array.isArray(value)) {
-        map[mimeType] = (value as string[]).join('\n');
-      } else {
-        map[mimeType] = value as string;
-      }
-    }
-    return map;
-  }
-
-  /**
-   * Follow changes to the outputs list.
-   */
-  protected outputsChanged(sender: ObservableList<nbformat.IOutput>, args: IListChangedArgs<nbformat.IOutput>) {
-    let layout = this.layout as PanelLayout;
-    let widget: Widget;
-    switch (args.type) {
-    case ListChangeType.Add:
-      let value = args.newValue as nbformat.IOutput;
-      layout.insertChild(args.newIndex, this.createOutput(value));
-      break;
-    case ListChangeType.Move:
-      layout.insertChild(args.newIndex, layout.childAt(args.oldIndex));
-      break;
-    case ListChangeType.Remove:
-      widget = layout.childAt(args.oldIndex);
-      layout.removeChild(widget);
-      widget.dispose();
-      break;
-    case ListChangeType.Replace:
-      let oldValues = args.oldValue as nbformat.IOutput[];
-      for (let i = args.oldIndex; i < oldValues.length; i++) {
-        widget = layout.childAt(args.oldIndex);
-        layout.removeChild(widget);
-        widget.dispose();
-      }
-      let newValues = args.newValue as nbformat.IOutput[];
-      for (let i = newValues.length; i < 0; i--) {
-        layout.insertChild(args.newIndex, this.createOutput(newValues[i]));
-      }
-      break;
-    case ListChangeType.Set:
-      widget = layout.childAt(args.newIndex);
-      layout.removeChild(widget);
-      widget.dispose();
-      widget = this.createOutput(args.newValue as nbformat.IOutput);
-      layout.insertChild(args.newIndex, widget);
-      break;
-    default:
-      break;
-    }
   }
 
   /**
@@ -343,10 +230,224 @@ class OutputAreaWidget extends Widget {
     }
   }
 
-  private _sanitized = false; // true if sanitized outputs are displayed
+  /**
+   * Handle `child-removed` messages.
+   */
+  protected onChildRemoved(msg: ChildMessage): void {
+    msg.child.dispose();
+  }
+
+  /**
+   * Follow changes to the outputs list.
+   */
+  private _onOutputsChanged(sender: ObservableList<nbformat.IOutput>, args: IListChangedArgs<nbformat.IOutput>) {
+    let layout = this.layout as PanelLayout;
+    let widget: Widget;
+    switch (args.type) {
+    case ListChangeType.Add:
+      let value = args.newValue as nbformat.IOutput;
+      layout.insertChild(args.newIndex, this._createOutput(value));
+      break;
+    case ListChangeType.Move:
+      layout.insertChild(args.newIndex, layout.childAt(args.oldIndex));
+      break;
+    case ListChangeType.Remove:
+      layout.childAt(args.oldIndex).parent = null;
+      break;
+    case ListChangeType.Replace:
+      let oldValues = args.oldValue as nbformat.IOutput[];
+      for (let i = args.oldIndex; i < oldValues.length; i++) {
+        layout.childAt(args.oldIndex).parent = null;
+      }
+      let newValues = args.newValue as nbformat.IOutput[];
+      for (let i = newValues.length; i < 0; i--) {
+        layout.insertChild(args.newIndex, this._createOutput(newValues[i]));
+      }
+      break;
+    case ListChangeType.Set:
+      layout.childAt(args.newIndex).parent = null;
+      widget = this._createOutput(args.newValue as nbformat.IOutput);
+      layout.insertChild(args.newIndex, widget);
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Convert a mime bundle to a mime map.
+   */
+  private _convertBundle(bundle: nbformat.MimeBundle): MimeMap<string> {
+    let map: MimeMap<string> = Object.create(null);
+    for (let mimeType in bundle) {
+      let value = bundle[mimeType];
+      if (Array.isArray(value)) {
+        map[mimeType] = (value as string[]).join('\n');
+      } else {
+        map[mimeType] = value as string;
+      }
+    }
+    return map;
+  }
+
+  /**
+   * Create an output widget for an output model.
+   */
+  private _createOutput(output: nbformat.IOutput): Widget {
+    let bundle = this._factory.getBundle(output);
+    let map = this._convertBundle(bundle);
+    if (!this.trusted) {
+      this._factory.sanitize(map);
+    }
+    return this._factory.createOutput(output, map, this._rendermime);
+  }
+
   private _trusted = false;
   private _fixedHeight = false;
   private _collapsed = false;
   private _outputs: ObservableOutputs = null;
   private _rendermime: RenderMime<Widget> = null;
+  private _factory: OutputAreaWidget.IOutputRenderer = null;
+}
+
+
+/**
+ * A namespace for OutputAreaWidget statics.
+ */
+export
+namespace OutputAreaWidget {
+  /**
+   * The options to pass to an `OutputAreaWidget.
+   */
+  export
+  interface IOptions {
+    /**
+     * The rendermime instance used by the widget.
+     */
+    rendermime: RenderMime<Widget>;
+
+    /**
+     * The output widget renderer.
+     *
+     * Defaults to a shared `IOutputRenderer` instance.
+     */
+     renderer?: IOutputRenderer;
+  }
+
+  /**
+   * An output widget renderer.
+   */
+  export
+  interface IOutputRenderer {
+    /**
+     * Get the mime bundle for an output.
+     */
+    getBundle(output: nbformat.IOutput): nbformat.MimeBundle;
+
+    /**
+     * Sanitize a mime map.
+     */
+    sanitize(map: MimeMap<string>): void;
+
+    /**
+     * Create an output widget.
+     */
+    createOutput(output: nbformat.IOutput, data: MimeMap<string>, rendermime: RenderMime<Widget>): Widget;
+  }
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+
+  export
+  const defaultRenderer: OutputAreaWidget.IOutputRenderer = {
+    getBundle: (output: nbformat.IOutput) => {
+      let bundle: nbformat.MimeBundle;
+      switch (output.output_type) {
+      case 'execute_result':
+        bundle = (output as nbformat.IExecuteResult).data;
+        break;
+      case 'display_data':
+        bundle = (output as nbformat.IDisplayData).data;
+        break;
+      case 'stream':
+        bundle = {'application/vnd.jupyter.console-text': (output as nbformat.IStream).text};
+        break;
+      case 'error':
+        let out: nbformat.IError = output as nbformat.IError;
+        let traceback = out.traceback.join('\n');
+        bundle = {'application/vnd.jupyter.console-text': traceback || `${out.ename}: ${out.evalue}`};
+        break;
+      default:
+        console.error(`Unrecognized output type: ${output.output_type}`);
+        bundle = {};
+      }
+      return bundle;
+    },
+    createOutput: (output: nbformat.IOutput, map: MimeMap<string>, rendermime: RenderMime<Widget>) => {
+      let widget = new Panel();
+      widget.addClass(OUTPUT_CLASS);
+      switch (output.output_type) {
+      case 'execute_result':
+        widget.addClass(EXECUTE_CLASS);
+        let prompt = new Widget();
+        prompt.addClass(PROMPT_CLASS);
+        let count = (output as nbformat.IExecuteResult).execution_count;
+        prompt.node.textContent = `Out[${count === null ? ' ' : count}]:`;
+        widget.addChild(prompt);
+        break;
+      case 'display_data':
+        widget.addClass(DISPLAY_CLASS);
+        break;
+      case 'stream':
+        if ((output as nbformat.IStream).name === 'stdout') {
+          widget.addClass(STDOUT_CLASS);
+        } else {
+          widget.addClass(STDERR_CLASS);
+        }
+        break;
+      case 'error':
+        widget.addClass(ERROR_CLASS);
+        break;
+      default:
+        console.error(`Unrecognized output type: ${output.output_type}`);
+        map = {};
+      }
+
+      if (map) {
+        let child = rendermime.render(map);
+        if (child) {
+          child.addClass(RESULT_CLASS);
+          widget.addChild(child);
+        } else {
+          console.log('Did not find renderer for output mimebundle.');
+          console.log(map);
+        }
+      }
+      return widget;
+    },
+    sanitize: (map: MimeMap<string>) => {
+      let keys = Object.keys(map);
+      for (let key of keys) {
+        if (safeOutputs.indexOf(key) !== -1) {
+          continue;
+        } else if (sanitizable.indexOf(key) !== -1) {
+          let out = map[key];
+          if (typeof out === 'string') {
+            map[key] = sanitize(out);
+          } else {
+            console.log('Ignoring unsanitized ' + key + ' output; could not sanitize because output is not a string.');
+            delete map[key];
+          }
+        } else {
+          // Don't display if we don't know how to sanitize it.
+          console.log('Ignoring untrusted ' + key + ' output.');
+          delete map[key];
+        }
+      }
+    }
+  };
 }

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -108,6 +108,12 @@ const sanitizable = ['text/svg', 'text/html'];
 
 /**
  * An output area widget.
+ *
+ * #### Notes
+ * The widget model must be set separately and can be changed
+ * at any time.  Consumers of the widget must account for a
+ * `null` model, and may want to listen to the `modelChanged`
+ * signal.
  */
 export
 class OutputAreaWidget extends Widget {
@@ -263,6 +269,8 @@ class OutputAreaWidget extends Widget {
    * Handle a new model.
    *
    * #### Notes
+   * This method is called after the model change has been handled
+   * internally and before the `modelChanged` signal is emitted.
    * The default implementation is a no-op.
    */
   protected onModelChanged(oldValue: OutputAreaModel, newValue: OutputAreaModel): void { }

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -289,7 +289,7 @@ class OutputAreaWidget extends Widget {
       this._updateChild(i);
     }
     // Add new widgets as necessary.
-    for (let i = oldValue.length; i < newValue.length; i++) {
+    for (let i = layout.childCount(); i < newValue.length; i++) {
       this._addChild();
     }
   }
@@ -338,7 +338,7 @@ class OutputAreaWidget extends Widget {
       // Only "clear" is supported by the model.
       let oldValues = args.oldValue as nbformat.IOutput[];
       for (let i = args.oldIndex; i < oldValues.length; i++) {
-        this._removeChild(i);
+        this._removeChild(args.oldIndex);
       }
       break;
     case ListChangeType.Set:

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -14,7 +14,7 @@ import {
 } from 'phosphor-messaging';
 
 import {
-  Panel, PanelLayout
+  PanelLayout
 } from 'phosphor-panel';
 
 import {
@@ -22,7 +22,7 @@ import {
 } from 'phosphor-signaling';
 
 import {
-  ChildMessage, Widget
+  Widget
 } from 'phosphor-widget';
 
 import {

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -141,11 +141,9 @@ class OutputAreaWidget extends Widget {
     }
     let oldValue = this._model;
     this._model = newValue;
-    if (oldValue) {
-      oldValue.changed.disconnect(this._onModelStateChanged, this);
-    }
-    newValue.changed.connect(this._onModelStateChanged, this);
+    // Trigger private, protected, and public updates.
     this._onModelChanged(oldValue, newValue);
+    this.onModelChanged(oldValue, newValue);
     this.modelChanged.emit(void 0);
   }
 
@@ -274,6 +272,10 @@ class OutputAreaWidget extends Widget {
    */
   private _onModelChanged(oldValue: OutputAreaModel, newValue: OutputAreaModel): void {
     let layout = this.layout as PanelLayout;
+    if (oldValue) {
+      oldValue.changed.disconnect(this._onModelStateChanged, this);
+    }
+    newValue.changed.connect(this._onModelStateChanged, this);
     let start = newValue ? newValue.length : 0;
     // Clear unnecessary child widgets.
     for (let i = start; i < layout.childCount(); i++) {

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -11,3 +11,6 @@ import './notebook/notebook/nbformat.spec';
 import './notebook/notebook/model.spec';
 import './notebook/notebook/modelfactory.spec';
 import './notebook/notebook/widget.spec';
+
+import './notebook/output-area/model.spec';
+import './notebook/output-area/widget.spec';

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -12,11 +12,11 @@ import {
 } from '../../../../lib/notebook/output-area/model';
 
 import {
-  IOutput, IStream
+  IStream
 } from '../../../../lib/notebook/notebook/nbformat';
 
 
-describe('jupyter-js-notebook', () => {
+describe('notebook/output-area/model', () => {
 
   describe('OutputAreaModel', () => {
 
@@ -193,7 +193,7 @@ describe('jupyter-js-notebook', () => {
           output_type: 'stream',
           name: 'stdout',
           text: 'foo\nbar'
-        }
+        };
         let model = new OutputAreaModel();
         model.add(output);
         expect(model.outputs.length).to.be(1);
@@ -204,21 +204,21 @@ describe('jupyter-js-notebook', () => {
           output_type: 'stream',
           name: 'stdout',
           text: 'foo\nbar'
-        }
+        };
         let model = new OutputAreaModel();
         model.add(output);
         output = {
           output_type: 'stream',
           name: 'stdout',
           text: 'fizz\buzz'
-        }
+        };
         model.add(output);
         expect(model.outputs.length).to.be(1);
         output  = {
           output_type: 'stream',
           name: 'stderr',
           text: 'oh no!'
-        }
+        };
         model.add(output);
         expect(model.outputs.length).to.be(2);
       });
@@ -232,7 +232,7 @@ describe('jupyter-js-notebook', () => {
           output_type: 'stream',
           name: 'stdout',
           text: 'foo\nbar'
-        }
+        };
         let model = new OutputAreaModel();
         model.add(output);
         model.clear();
@@ -244,7 +244,7 @@ describe('jupyter-js-notebook', () => {
           output_type: 'stream',
           name: 'stdout',
           text: 'foo\nbar'
-        }
+        };
         let model = new OutputAreaModel();
         model.add(output);
         model.clear(true);
@@ -254,8 +254,8 @@ describe('jupyter-js-notebook', () => {
           ename: 'foo',
           evalue: '',
           traceback: ['']
-        }
-        model.add(output);
+        };
+        model.add(output2);
         expect(model.outputs.length).to.be(1);
       });
     });

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  OutputAreaModel, OutputAreaWidget
+} from '../../../../lib/notebook/output-area';
+
+
+describe('notebook/output-area/widget', () => {
+
+  describe('OutputAreaWidget', () => {
+
+  });
+
+});
+
+
+
+

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -4,18 +4,329 @@
 import expect = require('expect.js');
 
 import {
+  Message
+} from 'phosphor-messaging';
+
+import {
+  ChildMessage, Widget
+} from 'phosphor-widget';
+
+import {
   OutputAreaModel, OutputAreaWidget
 } from '../../../../lib/notebook/output-area';
+
+import {
+  defaultRenderMime
+} from '../../rendermime/rendermime.spec';
+
+import {
+  DEFAULT_OUTPUTS
+} from './model.spec';
+
+
+/**
+ * The default rendermime instance to use for testing.
+ */
+const rendermime = defaultRenderMime();
+
+
+
+
+class LogOutputAreaWidget extends OutputAreaWidget {
+
+  methods: string[] = [];
+
+  protected onUpdateRequest(msg: Message): void {
+    super.onUpdateRequest(msg);
+    this.methods.push('onUpdateRequest');
+  }
+
+  protected onChildRemoved(msg: ChildMessage): void {
+    super.onChildRemoved(msg);
+    this.methods.push('onChildRemoved');
+  }
+}
+
+
+function createWidget(): LogOutputAreaWidget {
+  let widget = new LogOutputAreaWidget({ rendermime });
+  let model = new OutputAreaModel();
+  for (let output of DEFAULT_OUTPUTS) {
+    model.add(output);
+  }
+  widget.model = model;
+  return widget;
+}
 
 
 describe('notebook/output-area/widget', () => {
 
   describe('OutputAreaWidget', () => {
 
+    describe('#constructor()', () => {
+
+      it('should take an options object', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(widget).to.be.an(OutputAreaWidget);
+      });
+
+      it('should take an optional renderer', () => {
+        let renderer = Object.create(OutputAreaWidget.defaultRenderer);
+        let widget = new OutputAreaWidget({ rendermime, renderer });
+        expect(widget.renderer).to.be(renderer);
+      });
+
+      it('should add the `jp-OutputArea` class', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(widget.hasClass('jp-OutputArea')).to.be(true);
+      });
+
+    });
+
+    describe('#modelChanged', () => {
+
+      it('should be emitted when the model of the widget changes', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let called = false;
+        widget.modelChanged.connect((sender, args) => {
+          expect(sender).to.be(widget);
+          expect(args).to.be(void 0);
+          called = true;
+        });
+        widget.model = new OutputAreaModel();
+        expect(called).to.be(true);
+      });
+
+    });
+
+    describe('#model', () => {
+
+      it('should default to `null`', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(widget.model).to.be(null);
+      });
+
+      it('should set the model', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let model = new OutputAreaModel();
+        widget.model = model;
+        expect(widget.model).to.be(model);
+      });
+
+      it('should emit `modelChanged` when the model changes', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let called = false;
+        widget.modelChanged.connect(() => { called = true; });
+        widget.model = new OutputAreaModel();
+        expect(called).to.be(true);
+      });
+
+      it('should not emit `modelChanged` when the model does not change', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let called = false;
+        let model = new OutputAreaModel();
+        widget.model = model;
+        widget.modelChanged.connect(() => { called = true; });
+        widget.model = model;
+        expect(called).to.be(false);
+      });
+
+      it('should create widgets for the model items', () => {
+        let widget = createWidget();
+        expect(widget.childCount()).to.be(5);
+      });
+
+      it('should add the `jp-OutputArea-output` class to the child widgets', () => {
+        let widget = createWidget();
+        let child = widget.childAt(0);
+        expect(child.hasClass('jp-OutputArea-output')).to.be(true);
+      });
+
+      context('model `changed` signal', () => {
+
+        it('should add a new widget', () => {
+          let widget = createWidget();
+          widget.model.add(DEFAULT_OUTPUTS[0]);
+          expect(widget.childCount()).to.be(6);
+        });
+
+        it('should clear the widgets', () => {
+          let widget = createWidget();
+          widget.model.clear();
+          expect(widget.childCount()).to.be(0);
+        });
+
+      });
+
+    });
+
+    describe('#rendermime', () => {
+
+      it('should be the rendermime instance used by the widget', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(widget.rendermime).to.be(rendermime);
+      });
+
+      it('should be read-only', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(() => { widget.rendermime = null; }).to.throwError();
+      });
+
+    });
+
+    describe('#renderer', () => {
+
+      it('should be the renderer used by the widget', () => {
+        let renderer = Object.create(OutputAreaWidget.defaultRenderer);
+        let widget = new OutputAreaWidget({ rendermime, renderer });
+        expect(widget.renderer).to.be(renderer);
+      });
+
+      it('should be read-only', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(() => { widget.renderer = null; }).to.throwError();
+      });
+
+    });
+
+    describe('#trusted', () => {
+
+      it('should get the trusted state of the widget', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        expect(widget.trusted).to.be(false);
+      });
+
+      it('should set the trusted state of the widget', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        widget.trusted = true;
+        expect(widget.trusted).to.be(true);
+      });
+
+      it('should re-render if trusted changes', () => {
+        let widget = createWidget();
+        let child = widget.childAt(0);
+        widget.trusted = true;
+        expect(child.isDisposed).to.be(true);
+        expect(widget.childCount()).to.be(7);
+      });
+
+    });
+
+    describe('#collapsed', () => {
+
+      it('should get the collapsed state of the widget', () => {
+        let widget = createWidget();
+        expect(widget.collapsed).to.be(false);
+      });
+
+      it('should set the collapsed state of the widget', () => {
+        let widget = createWidget();
+        widget.collapsed = true;
+        expect(widget.collapsed).to.be(true);
+      });
+
+      it('should post an update request', (done) => {
+        let widget = new LogOutputAreaWidget({ rendermime });
+        widget.collapsed = true;
+        requestAnimationFrame(() => {
+          expect(widget.methods).to.contain('onUpdateRequest');
+          done();
+        });
+      });
+
+    });
+
+    describe('#fixedHeight', () => {
+
+      it('should get the fixed height state of the widget', () => {
+        let widget = createWidget();
+        expect(widget.fixedHeight).to.be(false);
+      });
+
+      it('should set the fixed height state of the widget', () => {
+        let widget = createWidget();
+        widget.fixedHeight = true;
+        expect(widget.fixedHeight).to.be(true);
+      });
+
+      it('should post an update request', (done) => {
+        let widget = new LogOutputAreaWidget({ rendermime });
+        widget.fixedHeight = true;
+        requestAnimationFrame(() => {
+          expect(widget.methods).to.contain('onUpdateRequest');
+          done();
+        });
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the resources held by the widget', () => {
+        let widget = createWidget();
+        widget.dispose();
+        expect(widget.model).to.be(null);
+        expect(widget.rendermime).to.be(null);
+        expect(widget.renderer).to.be(null);
+      });
+
+      it('should be safe to call more than once', () => {
+        let widget = createWidget();
+        widget.dispose();
+        widget.dispose();
+        expect(widget.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#childAt()', () => {
+
+      it('should get the child widget at the specified index', () => {
+        let widget = createWidget();
+        expect(widget.childAt(0)).to.be.a(Widget);
+      });
+
+    });
+
+    describe('#childCount()', () => {
+
+      it('should get the number of child widgets', () => {
+        let widget = createWidget();
+        expect(widget.childCount()).to.be(5);
+        widget.model.clear();
+        expect(widget.childCount()).to.be(0);
+      });
+
+    });
+
+    describe('#onUpdateRequest()', () => {
+
+      it('should set the appropriate classes on the widget', (done) => {
+        let widget = createWidget();
+        widget.collapsed = true;
+        widget.fixedHeight = true;
+        requestAnimationFrame(() => {
+          expect(widget.methods).to.contain('onUpdateRequest');
+          expect(widget.hasClass('jp-mod-fixedHeight')).to.be(true);
+          expect(widget.hasClass('jp-mod-collapsed')).to.be(true);
+          done();
+        });
+      });
+
+    });
+
+    describe('#onChildRemoved()', () => {
+
+      it('should dispose of the child widget', () => {
+        let widget = createWidget();
+        let child = widget.childAt(0);
+        child.parent = null;
+        expect(widget.methods).to.contain('onChildRemoved');
+        expect(child.isDisposed).to.be(true);
+      });
+
+    });
+
   });
 
 });
-
-
-
-

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -83,22 +83,6 @@ describe('notebook/output-area/widget', () => {
 
     });
 
-    describe('#modelChanged', () => {
-
-      it('should be emitted when the model of the widget changes', () => {
-        let widget = new OutputAreaWidget({ rendermime });
-        let called = false;
-        widget.modelChanged.connect((sender, args) => {
-          expect(sender).to.be(widget);
-          expect(args).to.be(void 0);
-          called = true;
-        });
-        widget.model = new OutputAreaModel();
-        expect(called).to.be(true);
-      });
-
-    });
-
     describe('#model', () => {
 
       it('should default to `null`', () => {
@@ -113,27 +97,24 @@ describe('notebook/output-area/widget', () => {
         expect(widget.model).to.be(model);
       });
 
-      it('should emit `modelChanged` when the model changes', () => {
-        let widget = new OutputAreaWidget({ rendermime });
-        let called = false;
-        widget.modelChanged.connect(() => { called = true; });
-        widget.model = new OutputAreaModel();
-        expect(called).to.be(true);
-      });
-
-      it('should not emit `modelChanged` when the model does not change', () => {
-        let widget = new OutputAreaWidget({ rendermime });
-        let called = false;
-        let model = new OutputAreaModel();
-        widget.model = model;
-        widget.modelChanged.connect(() => { called = true; });
-        widget.model = model;
-        expect(called).to.be(false);
-      });
-
       it('should create widgets for the model items', () => {
         let widget = createWidget();
         expect(widget.childCount()).to.be(5);
+      });
+
+      it('should be a no-op if set to the same value', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let model = new OutputAreaModel();
+        widget.model = model;
+        widget.model = model;
+        expect(widget.model).to.be(model);
+      });
+
+      it('should be write-once', () => {
+        let widget = new OutputAreaWidget({ rendermime });
+        let model = new OutputAreaModel();
+        widget.model = model;
+        expect(() => { widget.model = new OutputAreaModel(); }).to.throwError();
       });
 
       it('should add the `jp-OutputArea-output` class to the child widgets', () => {
@@ -264,7 +245,9 @@ describe('notebook/output-area/widget', () => {
 
       it('should dispose of the resources held by the widget', () => {
         let widget = createWidget();
+        let model = widget.model;
         widget.dispose();
+        expect(model.isDisposed).to.be(true);
         expect(widget.model).to.be(null);
         expect(widget.rendermime).to.be(null);
         expect(widget.renderer).to.be(null);

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -62,20 +62,9 @@ class LogOutputAreaWidget extends OutputAreaWidget {
     this.methods.push('onModelChanged');
   }
 
-  protected onTrustedChanged(value: boolean): void {
-    super.onTrustedChanged(value);
-    this.methods.push('onTrustedChanged');
-  }
-
-  protected createOutput(output: nbformat.IOutput): Widget {
-    let widget = super.createOutput(output);
-    this.methods.push('createOutput');
-    return widget;
-  }
-
-  protected onModelChange(sender: OutputAreaModel, args: IListChangedArgs<nbformat.IOutput>) {
-    super.onModelChange(sender, args);
-    this.methods.push('onModelChange');
+  protected onTrustChanged(value: boolean): void {
+    super.onTrustChanged(value);
+    this.methods.push('onTrustChanged');
   }
 }
 
@@ -411,9 +400,13 @@ describe('notebook/output-area/widget', () => {
 
     });
 
-    describe('.convertBundle()', () => {
+    describe('#onModelChange()', () => {
 
-      it('should convert a mime bundle to a mime map', () => {
+      it('should be called when trust changes', () => {
+        let widget = new LogOutputAreaWidget({ rendermime });
+      });
+
+      it('should should call `onModelChanged`', () => {
 
       });
 
@@ -422,6 +415,11 @@ describe('notebook/output-area/widget', () => {
     describe('.Renderer', () => {
 
       describe('#getBundle()', () => {
+
+      });
+
+      describe('#convertBundle()', () => {
+
 
       });
 


### PR DESCRIPTION
Updates the output area model and widget.

- Restricts the interface to the observable list in the output area and renames it to `OutputAreaModel`.
- Allows passing an output widget renderer as a constructor arg to the OutputAreaWidget rather than forcing a subclass to override a static method.
- Takes the model out of the constructor and allows it to be changed.  This is done to prevent calling non-private methods in the constructor and to allow the output area widget to be used by a parent widget that changes models.  Any method using the widget must account for there being a `null` model.
- Changing the model results in a private method call that does the main implementation, a private method call for subclass additional behavior, and finally a signal emit.