### PR TITLE
Refactor of cell widgets to remove static markup methods.

### DIFF
--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -191,7 +191,7 @@ class ConsoleWidget extends Widget {
    */
   static createBanner() {
     let model = new RawCellModel();
-    return new RawCellWidget(model);
+    return new RawCellWidget({ model });
   }
 
   /**

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -190,16 +190,18 @@ class ConsoleWidget extends Widget {
    * Create a new banner widget given a banner model.
    */
   static createBanner() {
-    let model = new RawCellModel();
-    return new RawCellWidget({ model });
+    let widget = new RawCellWidget();
+    widget.model = new RawCellModel();
+    return widget;
   }
 
   /**
    * Create a new prompt widget given a prompt model and a rendermime.
    */
   static createPrompt(rendermime: RenderMime<Widget>): CodeCellWidget {
-    let model = new CodeCellModel();
-    return new CodeCellWidget({ model, rendermime });
+    let widget = new CodeCellWidget({ rendermime });
+    widget.model = new CodeCellModel();
+    return widget;
   }
 
   /**

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -199,7 +199,7 @@ class ConsoleWidget extends Widget {
    */
   static createPrompt(rendermime: RenderMime<Widget>): CodeCellWidget {
     let model = new CodeCellModel();
-    return new CodeCellWidget(model, rendermime);
+    return new CodeCellWidget({ model, rendermime });
   }
 
   /**

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -453,13 +453,13 @@ class CodeCellWidget extends BaseCellWidget {
     let model = newValue as ICodeCellModel;
     let factory = this._factory;
 
-    if (this._output) {
-      this._output.dispose();
+    if (!this._output) {
+      this._output = factory.createOutputArea(this._rendermime);
+      (this.layout as PanelLayout).addChild(this._output);
     }
 
-    this._output = factory.createOutputArea(model.outputs, this._rendermime);
+    this._output.model = model.outputs;
     this._output.trusted = this.trusted;
-    (this.layout as PanelLayout).addChild(this._output);
     this._collapsedCursor = model.getMetadata('collapsed');
     this._scrolledCursor = model.getMetadata('scrolled');
     this.setPrompt(`${model.executionCount}`);
@@ -533,7 +533,7 @@ namespace CodeCellWidget {
     /**
      * Create a new output area for the widget.
      */
-    createOutputArea(model: OutputAreaModel, rendermime: RenderMime<Widget>): OutputAreaWidget;
+    createOutputArea(rendermime: RenderMime<Widget>): OutputAreaWidget;
   }
 }
 
@@ -726,10 +726,8 @@ namespace Private {
     /**
     * Create an output area widget.
     */
-    createOutputArea: (model: OutputAreaModel, rendermime: RenderMime<Widget>): OutputAreaWidget => {
-      let output = new OutputAreaWidget({ rendermime });
-      output.model = model;
-      return output;
+    createOutputArea: (rendermime: RenderMime<Widget>): OutputAreaWidget => {
+      return new OutputAreaWidget({ rendermime });
     }
   };
 }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -128,9 +128,9 @@ class BaseCellWidget extends Widget {
     this.addClass(CELL_CLASS);
     this.layout = new PanelLayout();
 
-    this._factory = options.cellWidgetFactory || Private.defaultFactory;
-    this._editor = this._factory.createCellEditor(options.model || null);
-    this._input = this._factory.createInputArea(this._editor);
+    let factory = options.cellWidgetFactory || Private.defaultFactory;
+    this._editor = factory.createCellEditor(options.model || null);
+    this._input = factory.createInputArea(this._editor);
 
     (this.layout as PanelLayout).addChild(this._input);
     this.model = options.model || null;
@@ -168,13 +168,6 @@ class BaseCellWidget extends Widget {
     this._trusted = !!this._trustedCursor.getValue();
     this._model.stateChanged.connect(this.onModelStateChanged, this);
     postMessage(this, new Message('model-changed'));
-  }
-
-  /**
-   * The widget renderer factory.
-   */
-  get factory(): BaseCellWidget.ICellWidgetFactory {
-    return this._factory;
   }
 
   /**
@@ -344,7 +337,6 @@ class BaseCellWidget extends Widget {
     }
   }
 
-  private _factory: BaseCellWidget.ICellWidgetFactory;
   private _input: InputAreaWidget = null;
   private _editor: CellEditorWidget = null;
   private _model: ICellModel = null;
@@ -418,6 +410,7 @@ class CodeCellWidget extends BaseCellWidget {
     super(options);
     this.addClass(CODE_CELL_CLASS);
     this._rendermime = options.rendermime;
+    this._factory = options.cellWidgetFactory || Private.defaultFactory;
   }
 
   /**
@@ -470,8 +463,8 @@ class CodeCellWidget extends BaseCellWidget {
    * Handle the widget receiving a new model.
    */
   protected onModelChanged(msg: Message): void {
-    let factory = this.factory as CodeCellWidget.ICellWidgetFactory;
     let model = this.model as ICodeCellModel;
+    let factory = this._factory;
 
     if (this._output) {
       this._output.dispose();
@@ -514,6 +507,7 @@ class CodeCellWidget extends BaseCellWidget {
     super.onMetadataChanged(model, args);
   }
 
+  private _factory: CodeCellWidget.ICellWidgetFactory;
   private _rendermime: RenderMime<Widget> = null;
   private _output: OutputAreaWidget = null;
   private _collapsedCursor: IMetadataCursor = null;

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -34,10 +34,6 @@ import {
 } from 'phosphor-widget';
 
 import {
-  nbformat
-} from '../notebook/nbformat';
-
-import {
   OutputAreaWidget, OutputAreaModel, executeCode
 } from '../output-area';
 
@@ -155,7 +151,7 @@ class BaseCellWidget extends Widget {
   }
 
   /**
-   * A signal emitted when the model of the notebook changes.
+   * A signal emitted when the model of the cell changes.
    */
   get modelChanged(): ISignal<BaseCellWidget, void> {
     return Private.modelChangedSignal.bind(this);

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -533,7 +533,7 @@ namespace CodeCellWidget {
     /**
      * Create a new output area for the widget.
      */
-    createOutputArea(outputs: ObservableOutputs, rendermime: RenderMime<Widget>): OutputAreaWidget;
+    createOutputArea(model: OutputAreaModel, rendermime: RenderMime<Widget>): OutputAreaWidget;
   }
 }
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -91,9 +91,9 @@ const CODE_CELL_CLASS = 'jp-CodeCell';
 const MARKDOWN_CELL_CLASS = 'jp-MarkdownCell';
 
 /**
- * The class name added to the markdown cell rendered widget.
+ * The class name added to the rendered markdown widget.
  */
-const RENDEREDMIME_CLASS = 'jp-MarkdownCell-renderedMime';
+const MARKDOWN_CONTENT_CLASS = 'jp-MarkdownCell-content';
 
 /**
  * The class name added to raw cells.
@@ -588,9 +588,9 @@ class MarkdownCellWidget extends BaseCellWidget {
     // Insist on the Github-flavored markdown mode.
     this.mimetype = 'text/x-ipythongfm';
     this._rendermime = options.rendermime;
-    this._renderedMIME = new Widget();
-    this._renderedMIME.addClass(RENDEREDMIME_CLASS);
-    (this.layout as PanelLayout).addChild(this._renderedMIME);
+    this._markdownWidget = new Widget();
+    this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
+    (this.layout as PanelLayout).addChild(this._markdownWidget);
   }
 
   /**
@@ -614,7 +614,7 @@ class MarkdownCellWidget extends BaseCellWidget {
     if (this.isDisposed) {
       return;
     }
-    this._renderedMIME = null;
+    this._markdownWidget = null;
     super.dispose();
   }
 
@@ -628,17 +628,17 @@ class MarkdownCellWidget extends BaseCellWidget {
       // Do not re-render if the text has not changed.
       if (text !== this._prev) {
         let bundle: MimeMap<string> = { 'text/markdown': text };
-        this._renderedMIME.dispose();
-        this._renderedMIME = this._rendermime.render(bundle) || new Widget();
-        this._renderedMIME.addClass(RENDEREDMIME_CLASS);
-        (this.layout as PanelLayout).addChild(this._renderedMIME);
+        this._markdownWidget.dispose();
+        this._markdownWidget = this._rendermime.render(bundle) || new Widget();
+        this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
+        (this.layout as PanelLayout).addChild(this._markdownWidget);
       }
       this._prev = text;
-      this._renderedMIME.show();
+      this._markdownWidget.show();
       this.toggleInput(false);
       this.addClass(RENDERED_CLASS);
     } else {
-      this._renderedMIME.hide();
+      this._markdownWidget.hide();
       this.toggleInput(true);
       this.removeClass(RENDERED_CLASS);
     }
@@ -646,7 +646,7 @@ class MarkdownCellWidget extends BaseCellWidget {
   }
 
   private _rendermime: RenderMime<Widget> = null;
-  private _renderedMIME: Widget = null;
+  private _markdownWidget: Widget = null;
   private _rendered = true;
   private _prev = '';
 }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -14,7 +14,7 @@ import {
 } from '../../rendermime';
 
 import {
-  Message, postMessage
+  Message
 } from 'phosphor-messaging';
 
 import {

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -315,8 +315,7 @@ class BaseCellWidget extends Widget {
    * Handle the widget receiving a new model.
    *
    * #### Notes
-   * This method should be implemented by subclasses that need to respond to
-   * the model being replaced.
+   * Subclasses may reimplement this method as needed.
    */
   protected onModelChanged(msg: Message): void {
     this.modelChanged.emit(void 0);
@@ -326,8 +325,7 @@ class BaseCellWidget extends Widget {
    * Handle changes in the model.
    *
    * #### Notes
-   * This method should be implemented by subclasses that need to respond to
-   * the model being replaced.
+   * Subclasses may reimplement this method as needed.
    */
   protected onModelStateChanged(model: ICodeCellModel, args: IChangedArgs<any>): void {
   }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -415,7 +415,7 @@ class CodeCellWidget extends BaseCellWidget {
   }
 
   /**
-   * Handle if the widget receives a new model.
+   * Handle the widget receiving a new model.
    */
   protected onModelChanged(sender: BaseCellWidget, args: IChangedArgs<ICellModel>): void {
     if (args.oldValue) {
@@ -425,12 +425,15 @@ class CodeCellWidget extends BaseCellWidget {
     let factory = this._factory;
     let model = args.newValue as ICodeCellModel;
 
+    if (this._output) {
+      this._output.dispose();
+    }
     this._output = factory.createOutputArea(model.outputs, this._rendermime);
     this._output.trusted = this.trusted;
     (this.layout as PanelLayout).addChild(this._output);
     this._collapsedCursor = model.getMetadata('collapsed');
     this._scrolledCursor = model.getMetadata('scrolled');
-    this.setPrompt(String(model.executionCount));
+    this.setPrompt(`${model.executionCount}`);
     model.stateChanged.connect(this.onModelStateChanged, this);
   }
 
@@ -440,7 +443,7 @@ class CodeCellWidget extends BaseCellWidget {
   protected onModelStateChanged(model: ICodeCellModel, args: IChangedArgs<any>): void {
     switch (args.name) {
     case 'executionCount':
-      this.setPrompt(String(model.executionCount));
+      this.setPrompt(`${model.executionCount}`);
       break;
     default:
       break;
@@ -634,8 +637,8 @@ class RawCellWidget extends BaseCellWidget {
   /**
    * Construct a raw cell widget.
    */
-  constructor(model: ICellModel) {
-    super(model);
+  constructor(options: BaseCellWidget.IOptions) {
+    super(options);
     this.addClass(RAW_CELL_CLASS);
   }
 }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -151,17 +151,14 @@ class BaseCellWidget extends Widget {
       this._model.stateChanged.disconnect(this.onModelStateChanged, this);
       this._model.metadataChanged.disconnect(this.onMetadataChanged, this);
     }
-    let args: IChangedArgs<ICellModel>;
 
     if (!model) {
-      args = { name: 'model', oldValue: this._model, newValue: null };
       this._editor.model = null;
       this._model = null;
-      this.modelChanged.emit(args);
       postMessage(this, new Message('model-changed'));
       return;
     }
-    args = { name: 'model', oldValue: this._model, newValue: model };
+
     this._model = model;
     this._editor.model = this._model;
     // Set the editor mode to be the default MIME type.
@@ -170,7 +167,6 @@ class BaseCellWidget extends Widget {
     this._trustedCursor = this._model.getMetadata('trusted');
     this._trusted = !!this._trustedCursor.getValue();
     this._model.stateChanged.connect(this.onModelStateChanged, this);
-    this.modelChanged.emit(args);
     postMessage(this, new Message('model-changed'));
   }
 
@@ -184,7 +180,7 @@ class BaseCellWidget extends Widget {
   /**
    * A signal emitted when the model of the notebook changes.
    */
-  get modelChanged(): ISignal<BaseCellWidget, IChangedArgs<ICellModel>> {
+  get modelChanged(): ISignal<BaseCellWidget, void> {
     return Private.modelChangedSignal.bind(this);
   }
 
@@ -323,6 +319,7 @@ class BaseCellWidget extends Widget {
    * the model being replaced.
    */
   protected onModelChanged(msg: Message): void {
+    this.modelChanged.emit(void 0);
   }
 
   /**
@@ -738,7 +735,7 @@ namespace Private {
    * A signal emitted when the model changes on a cell widget.
    */
   export
-  const modelChangedSignal = new Signal<BaseCellWidget, IChangedArgs<ICellModel>>();
+  const modelChangedSignal = new Signal<BaseCellWidget, void>();
 
 
   export

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -788,13 +788,13 @@ namespace Private {
   export
   const stateChangedSignal = new Signal<Notebook, IChangedArgs<any>>();
 
- /**
-  * Scroll an element into view if needed.
-  *
-  * @param area - The scroll area element.
-  *
-  * @param elem - The element of interest.
-  */
+  /**
+   * Scroll an element into view if needed.
+   *
+   * @param area - The scroll area element.
+   *
+   * @param elem - The element of interest.
+   */
   export
   function scrollIfNeeded(area: HTMLElement, elem: HTMLElement): void {
     let ar = area.getBoundingClientRect();

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -427,21 +427,27 @@ namespace StaticNotebook {
      * Create a new code cell widget.
      */
     createCodeCell(model: ICodeCellModel, rendermime: RenderMime<Widget>): CodeCellWidget {
-      return new CodeCellWidget(model, rendermime);
+      let widget = new CodeCellWidget({ rendermime });
+      widget.model = model;
+      return widget;
     }
 
     /**
      * Create a new markdown cell widget.
      */
     createMarkdownCell(model: IMarkdownCellModel, rendermime: RenderMime<Widget>): MarkdownCellWidget {
-      return new MarkdownCellWidget(model, rendermime);
+      let widget = new MarkdownCellWidget({ rendermime });
+      widget.model = model;
+      return widget;
     }
 
     /**
      * Create a new raw cell widget.
      */
     createRawCell(model: IRawCellModel): RawCellWidget {
-      return new RawCellWidget(model);
+      let widget = new RawCellWidget();
+      widget.model = model;
+      return widget;
     }
 
     /**
@@ -450,9 +456,7 @@ namespace StaticNotebook {
      * #### Notes
      * The base implementation is a no-op.
      */
-    updateCell(cell: BaseCellWidget): void {
-      // No-op.
-    }
+    updateCell(cell: BaseCellWidget): void { }
 
     /**
      * Get the preferred mimetype for code cells in the notebook.


### PR DESCRIPTION
This PR changes the cell widgets to accept `IOptions` parameters for instantiation and to allow different renderers to be passed in instead of static methods.

This pattern comes with some side-effects, namely that the superclass (`BaseCellWidget`) sets the `model` attribute and emits a `modelChanged` signal, which is heard by `onModelChanged` ... and this all happens *before* the constructor of the subclasses are finished running. That means that *no* attributes that they wanted to attach to `this` will be ready yet. So, for example, the `MarkdownCellWidget` used to have `this._rendermime`, but now it doesn't have the ability to set that before it needs it. To address this issue, the base cell widget is exposing the `options` that were passed into the constructor, and the `MarkdownCellWidget` can then use `options.rendermime`.

I'm not fully sold on this being the best way. I'm open to suggestions.

cc: @blink1073 @jasongrout @sccolbert 