### PR TITLE
Use `sanitize()` instead of a regex to sanitize latex output

### DIFF
--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -93,13 +93,13 @@ const RESULT_CLASS = 'jp-OutputArea-result';
 /**
  * A list of outputs considered safe.
  */
-const safeOutputs = ['text/plain', 'text/latex', 'image/png', 'image/jpeg',
+const safeOutputs = ['text/plain', 'image/png', 'image/jpeg',
                      'application/vnd.jupyter.console-text'];
 
 /**
  * A list of outputs that are sanitizable.
  */
-const sanitizable = ['text/svg', 'text/html'];
+const sanitizable = ['text/svg', 'text/html', 'text/latex'];
 
 
 /**

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -64,7 +64,6 @@ export
 class LatexWidget extends Widget {
   constructor(text: string) {
     super();
-    text = text.replace(/<br>|\$\$|^\$|\$$|\\\(|\\\)|\\\[|\\\]/g, '');
     this.node.innerHTML = text;
   }
 


### PR DESCRIPTION
Fixes #107.

<img width="485" alt="screen shot 2016-06-18 at 8 56 02 am" src="https://cloud.githubusercontent.com/assets/2096628/16171360/9212dbe4-3532-11e6-963c-14d682bea0e3.png">
