### PR TITLE
Sidebar alignment in Safari

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -80,18 +80,18 @@ body {
 
 .p-SideBar-content {
   height: 35px;
+  white-space: nowrap;
+  position: absolute;
   transform-origin: 0 0 0;
 }
 
 
 .p-SideBar.p-mod-left > .p-SideBar-content {
-  flex-direction: row-reverse;
   transform: rotate(-90deg) translateX(-100%);
 }
 
 
 .p-SideBar.p-mod-right > .p-SideBar-content {
-  flex-direction: row;
   transform: rotate(90deg) translateY(-100%);
 }
 


### PR DESCRIPTION
As can be seen in #100 there seems to be an issue with sidebar tabs in Safari.
<img width="1314" alt="058e3804-33c9-11e6-9145-45a6512d041c" src="https://cloud.githubusercontent.com/assets/2674600/16171839/25a05d40-357a-11e6-9cb2-4247119c4223.png">
I think it happens because Safari handles the height of rotated elements a bit differently. This fixes the problem and seems to be working with others.