### PR TITLE
Fix #100 Tab vertical alignment on OSX

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -220,7 +220,8 @@ body {
 .p-TabBar-tabIcon,
 .p-TabBar-tabText,
 .p-TabBar-tabCloseIcon {
-  line-height: 18px;
+  line-height: 24px;
+  vertical-align: middle;
 }
 
 


### PR DESCRIPTION
The line will now take the whole height of the element and the text will therefore will be always in the centre.