### PR TITLE
NotebookPanel refactor and tests

### DIFF
--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -144,7 +144,9 @@ function createApp(sessionsManager: NotebookSessionManager, specs: IKernelSpecId
       nbWidget.context.kernel.interrupt();
     }
   };
-  let restartHandler = () => nbWidget.restart();
+  let restartHandler = () => {
+    NotebookActions.restart(nbWidget.kernel, nbWidget.node);
+  }
   let switchHandler = () => {
     selectKernelForContext(nbWidget.context, nbWidget.node);
   };

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -30,7 +30,7 @@ import {
 /**
  * An implementation of a document context.
  */
-class Context implements IDocumentContext {
+class Context implements IDocumentContext<IDocumentModel> {
   /**
    * Construct a new document context.
    */
@@ -42,21 +42,21 @@ class Context implements IDocumentContext {
   /**
    * A signal emitted when the kernel changes.
    */
-  get kernelChanged(): ISignal<IDocumentContext, IKernel> {
+  get kernelChanged(): ISignal<Context, IKernel> {
     return Private.kernelChangedSignal.bind(this);
   }
 
   /**
    * A signal emitted when the path changes.
    */
-  get pathChanged(): ISignal<IDocumentContext, string> {
+  get pathChanged(): ISignal<Context, string> {
     return Private.pathChangedSignal.bind(this);
   }
 
   /**
    * A signal emitted when the model is saved or reverted.
    */
-  get dirtyCleared(): ISignal<IDocumentContext, void> {
+  get dirtyCleared(): ISignal<Context, void> {
     return Private.dirtyClearedSignal.bind(this);
   }
 
@@ -285,7 +285,7 @@ class ContextManager implements IDisposable {
   /**
    * Get a context by id.
    */
-  getContext(id: string): IDocumentContext {
+  getContext(id: string): IDocumentContext<IDocumentModel> {
     return this._contexts[id].context;
   }
 
@@ -531,7 +531,7 @@ namespace Private {
    */
   export
   interface IContextEx {
-    context: IDocumentContext;
+    context: IDocumentContext<IDocumentModel>;
     model: IDocumentModel;
     session: INotebookSession;
     opts: IContentsOpts;
@@ -544,17 +544,17 @@ namespace Private {
    * A signal emitted when the kernel changes.
    */
   export
-  const kernelChangedSignal = new Signal<IDocumentContext, IKernel>();
+  const kernelChangedSignal = new Signal<Context, IKernel>();
 
   /**
    * A signal emitted when the path changes.
    */
   export
-  const pathChangedSignal = new Signal<IDocumentContext, string>();
+  const pathChangedSignal = new Signal<Context, string>();
 
   /**
    * A signal emitted when the model is saved or reverted.
    */
   export
-  const dirtyClearedSignal = new Signal<IDocumentContext, void>();
+  const dirtyClearedSignal = new Signal<Context, void>();
 }

--- a/src/docregistry/default.ts
+++ b/src/docregistry/default.ts
@@ -264,7 +264,7 @@ class Base64ModelFactory extends TextModelFactory {
  * The default implemetation of a widget factory.
  */
 export
-abstract class ABCWidgetFactory implements IWidgetFactory<Widget> {
+abstract class ABCWidgetFactory implements IWidgetFactory<Widget, IDocumentModel> {
   /**
    * Get whether the model factory has been disposed.
    */
@@ -282,7 +282,7 @@ abstract class ABCWidgetFactory implements IWidgetFactory<Widget> {
   /**
    * Create a new widget given a document model and a context.
    */
-  abstract createNew(model: IDocumentModel, context: IDocumentContext, kernel?: IKernelId): Widget;
+  abstract createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernelId): Widget;
 
   /**
    * Take an action on a widget before closing it.
@@ -290,7 +290,7 @@ abstract class ABCWidgetFactory implements IWidgetFactory<Widget> {
    * @returns A promise that resolves to true if the document should close
    *   and false otherwise.
    */
-  beforeClose(model: IDocumentModel, context: IDocumentContext, widget: Widget): Promise<boolean> {
+  beforeClose(widget: Widget, context: IDocumentContext<IDocumentModel>): Promise<boolean> {
     // There is nothing specific to do.
     return Promise.resolve(true);
   }

--- a/src/docregistry/interfaces.ts
+++ b/src/docregistry/interfaces.ts
@@ -104,7 +104,7 @@ interface IDocumentModel extends IDisposable {
 /**
  * The document context object.
  */
-export interface IDocumentContext extends IDisposable {
+export interface IDocumentContext<T extends IDocumentModel> extends IDisposable {
   /**
    * The unique id of the context.
    *
@@ -119,7 +119,7 @@ export interface IDocumentContext extends IDisposable {
    * #### Notes
    * This is a read-only property
    */
-  model: IDocumentModel;
+  model: T;
 
   /**
    * The current kernel associated with the document.
@@ -157,12 +157,12 @@ export interface IDocumentContext extends IDisposable {
   /**
    * A signal emitted when the kernel changes.
    */
-  kernelChanged: ISignal<IDocumentContext, IKernel>;
+  kernelChanged: ISignal<IDocumentContext<T>, IKernel>;
 
   /**
    * A signal emitted when the path changes.
    */
-  pathChanged: ISignal<IDocumentContext, string>;
+  pathChanged: ISignal<IDocumentContext<T>, string>;
 
   /**
    * Change the current kernel associated with the document.
@@ -254,11 +254,11 @@ interface IWidgetFactoryOptions {
  * The interface for a widget factory.
  */
 export
-interface IWidgetFactory<T extends Widget> extends IDisposable {
+interface IWidgetFactory<T extends Widget, U extends IDocumentModel> extends IDisposable {
   /**
    * Create a new widget.
    */
-  createNew(model: IDocumentModel, context: IDocumentContext, kernel?: IKernelId): T;
+  createNew(context: IDocumentContext<U>, kernel?: IKernelId): T;
 
   /**
    * Take an action on a widget before closing it.
@@ -266,7 +266,7 @@ interface IWidgetFactory<T extends Widget> extends IDisposable {
    * @returns A promise that resolves to true if the document should close
    *   and false otherwise.
    */
-  beforeClose(model: IDocumentModel, context: IDocumentContext, widget: Widget): Promise<boolean>;
+  beforeClose(widget: T, context: IDocumentContext<U>): Promise<boolean>;
 }
 
 
@@ -274,11 +274,11 @@ interface IWidgetFactory<T extends Widget> extends IDisposable {
  * An interface for a widget extension.
  */
 export
-interface IWidgetExtension<T extends Widget> {
+interface IWidgetExtension<T extends Widget, U extends IDocumentModel> {
   /**
    * Create a new extension for a given widget.
    */
-   createNew(widget: T, model: IDocumentModel, context: IDocumentContext): IDisposable;
+   createNew(widget: T, context: IDocumentContext<U>): IDisposable;
 }
 
 

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -10,7 +10,7 @@ import {
 } from '../dialog';
 
 import {
-  IDocumentContext
+  IDocumentContext, IDocumentModel
 } from './interfaces';
 
 
@@ -95,7 +95,7 @@ function selectKernel(options: IKernelSelection): Promise<IKernelId> {
  * Change the kernel on a context.
  */
 export
-function selectKernelForContext(context: IDocumentContext, host?: HTMLElement): Promise<void> {
+function selectKernelForContext(context: IDocumentContext<IDocumentModel>, host?: HTMLElement): Promise<void> {
   return context.listSessions().then(sessions => {
     let options = {
       name: context.path.split('/').pop(),

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -14,7 +14,8 @@ import {
 
 import {
   IModelFactory, IWidgetFactory, IWidgetFactoryOptions,
-  IFileType, IKernelPreference, IFileCreator, IWidgetExtension
+  IFileType, IKernelPreference, IFileCreator, IWidgetExtension,
+  IDocumentModel
 } from './interfaces';
 
 
@@ -74,7 +75,7 @@ class DocumentRegistry implements IDisposable {
    * If a factory is already registered as a default for a given extension or
    * as the global default, this factory will override the existing default.
    */
-  addWidgetFactory(factory: IWidgetFactory<Widget>, options: IWidgetFactoryOptions): IDisposable {
+  addWidgetFactory(factory: IWidgetFactory<Widget, IDocumentModel>, options: IWidgetFactoryOptions): IDisposable {
     let name = options.displayName;
     let exOpt = utils.copy(options) as Private.IWidgetFactoryEx;
     exOpt.factory = factory;
@@ -136,7 +137,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns A disposable which will unregister the extension.
    */
-  addWidgetExtension(widgetName: string, extension: IWidgetExtension<Widget>): IDisposable {
+  addExtension(widgetName: string, extension: IWidgetExtension<Widget, IDocumentModel>): IDisposable {
     if (!(widgetName in this._extenders)) {
       this._extenders[widgetName] = [];
     }
@@ -319,7 +320,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns A widget factory instance.
    */
-  getWidgetFactory(widgetName: string): IWidgetFactory<Widget> {
+  getWidgetFactory(widgetName: string): IWidgetFactory<Widget, IDocumentModel> {
     return this._getWidgetFactoryEx(widgetName).factory;
   }
 
@@ -330,7 +331,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns A new array of widget extensions.
    */
-  getWidgetExtensions(widgetName: string): IWidgetExtension<Widget>[] {
+  getWidgetExtensions(widgetName: string): IWidgetExtension<Widget, IDocumentModel>[] {
     if (!(widgetName in this._extenders)) {
       return [];
     }
@@ -356,7 +357,7 @@ class DocumentRegistry implements IDisposable {
   private _defaultWidgetFactories: { [key: string]: string } = Object.create(null);
   private _fileTypes: IFileType[] = [];
   private _creators: IFileCreator[] = [];
-  private _extenders: { [key: string] : IWidgetExtension<Widget>[] } = Object.create(null);
+  private _extenders: { [key: string] : IWidgetExtension<Widget, IDocumentModel>[] } = Object.create(null);
 }
 
 
@@ -369,6 +370,6 @@ namespace Private {
    */
   export
   interface IWidgetFactoryEx extends IWidgetFactoryOptions {
-    factory: IWidgetFactory<Widget>;
+    factory: IWidgetFactory<Widget, IDocumentModel>;
   }
 }

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -137,7 +137,7 @@ class DocumentRegistry implements IDisposable {
    *
    * @returns A disposable which will unregister the extension.
    */
-  addExtension(widgetName: string, extension: IWidgetExtension<Widget, IDocumentModel>): IDisposable {
+  addWidgetExtension(widgetName: string, extension: IWidgetExtension<Widget, IDocumentModel>): IDisposable {
     if (!(widgetName in this._extenders)) {
       this._extenders[widgetName] = [];
     }

--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -42,10 +42,11 @@ class EditorWidget extends CodeMirrorWidget {
   /**
    * Construct a new editor widget.
    */
-  constructor(model: IDocumentModel, context: IDocumentContext) {
+  constructor(context: IDocumentContext<IDocumentModel>) {
     super();
     this.addClass(EDITOR_CLASS);
     let editor = this.editor;
+    let model = context.model;
     editor.setOption('lineNumbers', true);
     let doc = editor.getDoc();
     doc.setValue(model.toString());
@@ -84,14 +85,14 @@ class EditorWidget extends CodeMirrorWidget {
  * A widget factory for editors.
  */
 export
-class EditorWidgetFactory extends ABCWidgetFactory implements IWidgetFactory<EditorWidget> {
+class EditorWidgetFactory extends ABCWidgetFactory implements IWidgetFactory<EditorWidget, IDocumentModel> {
   /**
-   * Create a new widget given a document model and a context.
+   * Create a new widget given a context.
    */
-  createNew(model: IDocumentModel, context: IDocumentContext, kernel?: IKernelId): EditorWidget {
+  createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernelId): EditorWidget {
     if (kernel) {
       context.changeKernel(kernel);
     }
-    return new EditorWidget(model, context);
+    return new EditorWidget(context);
   }
 }

--- a/src/imagewidget/widget.ts
+++ b/src/imagewidget/widget.ts
@@ -33,20 +33,19 @@ class ImageWidget extends Widget {
   /**
    * Construct a new image widget.
    */
-  constructor(model: IDocumentModel, context: IDocumentContext) {
+  constructor(context: IDocumentContext<IDocumentModel>) {
     super();
-    this._model = model;
     this._context = context;
     this.node.tabIndex = -1;
     this.node.style.overflowX = 'auto';
     this.node.style.overflowY = 'auto';
-    if (model.toString()) {
+    if (context.model.toString()) {
       this.update();
     }
     context.pathChanged.connect(() => {
       this.update();
     });
-    model.contentChanged.connect(() => {
+    context.model.contentChanged.connect(() => {
       this.update();
     });
   }
@@ -58,7 +57,6 @@ class ImageWidget extends Widget {
     if (this.isDisposed) {
       return;
     }
-    this._model = null;
     this._context = null;
     super.dispose();
   }
@@ -69,13 +67,12 @@ class ImageWidget extends Widget {
   protected onUpdateRequest(msg: Message): void {
     this.title.text = this._context.path.split('/').pop();
     let node = this.node as HTMLImageElement;
-    let content = this._model.toString();
-    let model = this._context.contentsModel;
-    node.src = `data:${model.mimetype};${model.format},${content}`;
+    let content = this._context.toString();
+    let cm = this._context.contentsModel;
+    node.src = `data:${cm.mimetype};${cm.format},${content}`;
   }
 
-  private _model: IDocumentModel;
-  private _context: IDocumentContext;
+  private _context: IDocumentContext<IDocumentModel>;
 }
 
 
@@ -83,11 +80,11 @@ class ImageWidget extends Widget {
  * A widget factory for images.
  */
 export
-class ImageWidgetFactory extends ABCWidgetFactory implements IWidgetFactory<ImageWidget> {
+class ImageWidgetFactory extends ABCWidgetFactory implements IWidgetFactory<ImageWidget, IDocumentModel> {
   /**
-   * Create a new widget given a document model and a context.
+   * Create a new widget given a context.
    */
-  createNew(model: IDocumentModel, context: IDocumentContext, kernel?: IKernelId): ImageWidget {
-    return new ImageWidget(model, context);
+  createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernelId): ImageWidget {
+    return new ImageWidget(context);
   }
 }

--- a/src/imagewidget/widget.ts
+++ b/src/imagewidget/widget.ts
@@ -67,7 +67,7 @@ class ImageWidget extends Widget {
   protected onUpdateRequest(msg: Message): void {
     this.title.text = this._context.path.split('/').pop();
     let node = this.node as HTMLImageElement;
-    let content = this._context.toString();
+    let content = this._context.model.toString();
     let cm = this._context.contentsModel;
     node.src = `data:${cm.mimetype};${cm.format},${content}`;
   }

--- a/src/notebook/completion/handler.ts
+++ b/src/notebook/completion/handler.ts
@@ -1,0 +1,125 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IKernel
+} from 'jupyter-js-services';
+
+import {
+  IDisposable
+} from 'phosphor-disposable';
+
+import {
+  BaseCellWidget
+} from '../cells/widget';
+
+import {
+  CellEditorWidget, ITextChange, ICompletionRequest
+} from '../cells/editor';
+
+import {
+  CompletionWidget
+} from './widget';
+
+
+/**
+ * A completion handler for cell widgets.
+ */
+export
+class CellCompletionHandler implements IDisposable {
+  /**
+   * Construct a new completion handler for a widget.
+   */
+  constructor(completion: CompletionWidget) {
+    this._completion = completion;
+    this._completion.selected.connect(this._onCompletionSelected, this);
+  }
+
+  /**
+   * Get whether the completion handler is disposed.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  get isDisposed(): boolean {
+    return this._completion === null;
+  }
+
+  /**
+   * Dispose of the resources used by the handler.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._completion = null;
+    this._kernel = null;
+    this._activeCell = null;
+  }
+
+  /**
+   * The kernel used by the completion handler.
+   */
+  get kernel(): IKernel {
+    return this._kernel;
+  }
+  set kernel(value: IKernel) {
+    this._kernel = value;
+  }
+
+  /**
+   * The cell widget used by the completion handler.
+   */
+  get activeCell(): BaseCellWidget {
+    return this._activeCell;
+  }
+  set activeCell(newValue: BaseCellWidget) {
+    let editor: CellEditorWidget;
+    if (this._activeCell && !this._activeCell.isDisposed) {
+      editor = this._activeCell.editor;
+      editor.textChanged.disconnect(this._onTextChanged, this);
+      editor.completionRequested.disconnect(this._onCompletionRequested, this);
+    }
+    this._activeCell = newValue;
+    if (newValue) {
+      editor = newValue.editor;
+      editor.textChanged.connect(this._onTextChanged, this);
+      editor.completionRequested.connect(this._onCompletionRequested, this);
+    }
+  }
+
+  /**
+   * Handle a text changed signal from an editor.
+   */
+  private _onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
+    this._completion.model.handleTextChange(change);
+  }
+
+  /**
+   * Handle a completion requested signal from an editor.
+   */
+  private _onCompletionRequested(editor: CellEditorWidget, change: ICompletionRequest): void {
+    if (!this.kernel) {
+      return;
+    }
+    this._completion.model.makeKernelRequest(change, this.kernel);
+  }
+
+  /**
+   * Handle a completion selected signal from the completion widget.
+   */
+  private _onCompletionSelected(widget: CompletionWidget, value: string): void {
+    if (!this._activeCell) {
+      return;
+    }
+    let patch = this._completion.model.createPatch(value);
+    let editor = this._activeCell.editor.editor;
+    let doc = editor.getDoc();
+    doc.setValue(patch.text);
+    doc.setCursor(doc.posFromIndex(patch.position));
+  }
+
+  private _kernel: IKernel = null;
+  private _activeCell: BaseCellWidget = null;
+  private _completion: CompletionWidget = null;
+}

--- a/src/notebook/completion/index.ts
+++ b/src/notebook/completion/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+export * from './handler';
 export * from './model';
 export * from './widget';

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -2,6 +2,10 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  IKernel
+} from 'jupyter-js-services';
+
+import {
   IDisposable
 } from 'phosphor-disposable';
 
@@ -124,6 +128,11 @@ interface ICompletionModel extends IDisposable {
   original: ICompletionRequest;
 
   /**
+   * Handle a completion request using a kernel.
+   */
+  makeKernelRequest(request: ICompletionRequest, kernel: IKernel): void;
+
+  /**
    * Create a resolved patch between the original state and a patch string.
    */
   createPatch(patch: string): ICompletionPatch;
@@ -234,6 +243,37 @@ class CompletionModel implements ICompletionModel {
   }
 
   /**
+   * Make a request using a kernel.
+   */
+  makeKernelRequest(request: ICompletionRequest, kernel: IKernel): void {
+    let contents = {
+      // Only send the current line of code for completion.
+      code: request.currentValue.split('\n')[request.line],
+      cursor_pos: request.ch
+    };
+    let pendingComplete = ++this._pendingComplete;
+    kernel.complete(contents).then(value => {
+      // If we have been disposed, bail.
+      if (this.isDisposed) {
+        return;
+      }
+      // If a newer completion request has created a pending request, bail.
+      if (pendingComplete !== this._pendingComplete) {
+        return;
+      }
+      // Completion request failures or negative results fail silently.
+      if (value.status !== 'ok') {
+        return;
+      }
+      // Update the state.
+      this.options = value.matches;
+      this.cursor = { start: value.cursor_start, end: value.cursor_end };
+    }).then(() => {
+      this.original = request;
+    });
+  }
+
+  /**
    * Create a resolved patch between the original state and a patch string.
    *
    * @param patch - The patch string to apply to the original value.
@@ -325,6 +365,7 @@ class CompletionModel implements ICompletionModel {
   private _current: ITextChange = null;
   private _query = '';
   private _cursor: { start: number, end: number } = null;
+  private _pendingComplete = 0;
 }
 
 

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -133,6 +133,11 @@ interface ICompletionModel extends IDisposable {
   makeKernelRequest(request: ICompletionRequest, kernel: IKernel): void;
 
   /**
+   * Handle a text change.
+   */
+  handleTextChange(change: ITextChange): void;
+
+  /**
    * Create a resolved patch between the original state and a patch string.
    */
   createPatch(patch: string): ICompletionPatch;
@@ -271,6 +276,26 @@ class CompletionModel implements ICompletionModel {
     }).then(() => {
       this.original = request;
     });
+  }
+
+  /**
+   * Handle a text change.
+   */
+  handleTextChange(change: ITextChange): void {
+    let line = change.newValue.split('\n')[change.line];
+    // If last character entered is not whitespace, update completion.
+    if (line[change.ch - 1] && line[change.ch - 1].match(/\S/)) {
+      // If there is currently a completion
+      if (this.original) {
+        this.current = change;
+      }
+    } else {
+      // If final character is whitespace, reset completion.
+      this.options = null;
+      this.original = null;
+      this.cursor = null;
+      return;
+    }
   }
 
   /**

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -122,7 +122,6 @@ class CompletionWidget extends Widget {
     }
     this._model.dispose();
     this._model = null;
-    clearSignalData(this);
     super.dispose();
   }
 

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -10,6 +10,10 @@ import {
 } from 'phosphor-dragdrop';
 
 import {
+  showDialog
+} from '../../dialog';
+
+import {
   ICellModel, CodeCellModel,
   CodeCellWidget, BaseCellWidget, MarkdownCellWidget
 } from '../cells';
@@ -581,6 +585,27 @@ namespace NotebookActions {
         cell.executionCount = null;
       }
     }
+  }
+
+  /**
+   * Restart a kernel.
+   */
+  export
+  function restart(kernel: IKernel, host?: HTMLElement): Promise<boolean> {
+    if (!kernel) {
+      return Promise.resolve(false);
+    }
+    return showDialog({
+      title: 'Restart Kernel?',
+      body: 'Do you want to restart the current kernel? All variables will be lost.',
+      host
+    }).then(result => {
+      if (result.text === 'OK') {
+        return kernel.restart().then(() => { return true; });
+      } else {
+        return false;
+      }
+    });
   }
 }
 

--- a/src/notebook/notebook/default-toolbar.ts
+++ b/src/notebook/notebook/default-toolbar.ts
@@ -201,7 +201,7 @@ namespace ToolbarItems {
     return new ToolbarButton({
       className: TOOLBAR_RESTART,
       onClick: () => {
-        panel.restart();
+        NotebookActions.restart(panel.kernel, panel.node);
       },
       tooltip: 'Restart the kernel'
     });

--- a/src/notebook/notebook/default-toolbar.ts
+++ b/src/notebook/notebook/default-toolbar.ts
@@ -307,16 +307,17 @@ class CellTypeSwitcher extends Widget {
       select.value = content.model.cells.get(index).type;
     }
 
-    // Follow the type of the current cell.
-    content.stateChanged.connect(() => {
-      if (!content.model) {
-        return;
-      }
+    let update = () => {
+      select = this.node.firstChild as HTMLSelectElement;
       index = content.activeCellIndex;
       this._changeGuard = true;
       select.value = content.model.cells.get(index).type;
       this._changeGuard = false;
-    });
+    };
+
+    // Follow the type of the current cell.
+    content.modelContentChanged.connect(() => { update(); });
+    content.stateChanged.connect(() => { update(); });
   }
 
   private _changeGuard = false;

--- a/src/notebook/notebook/default-toolbar.ts
+++ b/src/notebook/notebook/default-toolbar.ts
@@ -307,17 +307,12 @@ class CellTypeSwitcher extends Widget {
       select.value = content.model.cells.get(index).type;
     }
 
-    let update = () => {
-      select = this.node.firstChild as HTMLSelectElement;
-      index = content.activeCellIndex;
+    // Follow the type of the active cell.
+    content.activeCellChanged.connect((sender, cell) => {
       this._changeGuard = true;
-      select.value = content.model.cells.get(index).type;
+      select.value = cell.model.type;
       this._changeGuard = false;
-    };
-
-    // Follow the type of the current cell.
-    content.modelContentChanged.connect(() => { update(); });
-    content.stateChanged.connect(() => { update(); });
+    });
   }
 
   private _changeGuard = false;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -96,6 +96,7 @@ class NotebookPanel extends Widget {
     this.layout = new PanelLayout();
     let rendermime = this._rendermime;
     this._content = this._renderer.createContent({ rendermime });
+    this._content.stateChanged.connect(this.onContentStateChanged, this);
     this._toolbar = this._renderer.createToolbar();
 
     let container = new Panel();
@@ -111,15 +112,6 @@ class NotebookPanel extends Widget {
     this._completion.reference = this;
     this._completion.attach(document.body);
     this._completion.selected.connect(this.onCompletionSelected, this);
-
-    // Connect signals.
-    this._content.stateChanged.connect(this.onContentStateChanged, this);
-    let cell = this._content.childAt(this._content.activeCellIndex);
-    if (cell) {
-      let editor = cell.editor;
-      editor.textChanged.connect(this.onTextChanged, this);
-      editor.completionRequested.connect(this.onCompletionRequested, this);
-    }
   }
 
   /**
@@ -432,6 +424,13 @@ class NotebookPanel extends Widget {
       this.onKernelChanged(this._context, this._context.kernel);
     }
     this._content.model = newValue.model as INotebookModel;
+
+    let cell = this._content.childAt(this._content.activeCellIndex);
+    if (cell) {
+      let editor = cell.editor;
+      editor.textChanged.connect(this.onTextChanged, this);
+      editor.completionRequested.connect(this.onCompletionRequested, this);
+    }
 
     // Handle the document title.
     this.title.text = context.path.split('/').pop();

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -26,10 +26,6 @@ import {
 } from 'phosphor-widget';
 
 import {
-  showDialog
-} from '../../dialog';
-
-import {
   IDocumentContext
 } from '../../docregistry';
 
@@ -97,14 +93,14 @@ class NotebookPanel extends Widget {
     let rendermime = this._rendermime;
     this._content = this._renderer.createContent({ rendermime });
     this._content.stateChanged.connect(this.onContentStateChanged, this);
-    this._toolbar = this._renderer.createToolbar();
+    let toolbar = this._renderer.createToolbar();
 
     let container = new Panel();
     container.addClass(NB_CONTAINER);
     container.addChild(this._content);
 
     let layout = this.layout as PanelLayout;
-    layout.addChild(this._toolbar);
+    layout.addChild(toolbar);
     layout.addChild(container);
 
     // Instantiate tab completion widget.
@@ -130,9 +126,12 @@ class NotebookPanel extends Widget {
 
   /**
    * Get the toolbar used by the widget.
+   *
+   * #### Notes
+   * This is a read-only property.
    */
   get toolbar(): NotebookToolbar {
-    return this._toolbar;
+    return (this.layout as PanelLayout).childAt(0) as NotebookToolbar;
   }
 
   /**
@@ -189,7 +188,7 @@ class NotebookPanel extends Widget {
    * This is a read-only property.
    */
   get model(): INotebookModel {
-    return this._content.model;
+    return this._content ? this._content.model : null;
   }
 
   /**
@@ -223,9 +222,8 @@ class NotebookPanel extends Widget {
       return;
     }
     this._context = null;
-    this._rendermime = null;
     this._content = null;
-    this._toolbar = null;
+    this._rendermime = null;
     this._clipboard = null;
     this._completion.dispose();
     this._completion = null;
@@ -390,10 +388,9 @@ class NotebookPanel extends Widget {
 
   private _rendermime: RenderMime<Widget> = null;
   private _context: IDocumentContext<INotebookModel> = null;
-  private _content: Notebook = null;
-  private _toolbar: NotebookToolbar = null;
   private _clipboard: IClipboard = null;
   private _completion: CompletionWidget = null;
+  private _content: Notebook = null;
   private _renderer: NotebookPanel.IRenderer = null;
 }
 

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -6,18 +6,6 @@ import {
 } from 'jupyter-js-services';
 
 import {
-  showDialog
-} from '../../dialog';
-
-import {
-  IDocumentContext
-} from '../../docregistry';
-
-import {
-  RenderMime
-} from '../../rendermime';
-
-import {
   MimeData as IClipboard
 } from 'phosphor-dragdrop';
 
@@ -30,8 +18,24 @@ import {
 } from 'phosphor-properties';
 
 import {
+  ISignal, Signal
+} from 'phosphor-signaling';
+
+import {
   Widget
 } from 'phosphor-widget';
+
+import {
+  showDialog
+} from '../../dialog';
+
+import {
+  IDocumentContext
+} from '../../docregistry';
+
+import {
+  RenderMime
+} from '../../rendermime';
 
 import {
   CellEditorWidget, ITextChange, ICompletionRequest
@@ -80,51 +84,19 @@ const DIRTY_CLASS = 'jp-mod-dirty';
 export
 class NotebookPanel extends Widget {
   /**
-   * Create a new content area for the notebook.
-   */
-  static createContent(model: INotebookModel, rendermime: RenderMime<Widget>): Notebook {
-    let widget = new Notebook({ rendermime });
-    widget.model = model;
-    return widget;
-  }
-
-  /**
-   * Create a new toolbar for the notebook.
-   */
-  static createToolbar(): NotebookToolbar {
-    return new NotebookToolbar();
-  }
-
-  /**
-   * Create a new completion widget.
-   */
-  static createCompletion(): CompletionWidget {
-    let model = new CompletionModel();
-    return new CompletionWidget(model);
-  }
-
-  /**
    * Construct a new notebook panel.
    */
-  constructor(model: INotebookModel, rendermime: RenderMime<Widget>, context: IDocumentContext, clipboard: IClipboard) {
+  constructor(options: NotebookPanel.IOptions) {
     super();
     this.addClass(NB_PANEL);
-    this._model = model;
-    this._rendermime = rendermime;
-    this._context = context;
-    this._clipboard = clipboard;
-
-    context.kernelChanged.connect(() => {
-      this.handleKernelChange(context.kernel);
-    });
-    if (context.kernel) {
-      this.handleKernelChange(context.kernel);
-    }
+    this._rendermime = options.rendermime;
+    this._clipboard = options.clipboard;
+    this._renderer = options.renderer || NotebookPanel.defaultRenderer;
 
     this.layout = new PanelLayout();
-    let ctor = this.constructor as typeof NotebookPanel;
-    this._content = ctor.createContent(model, rendermime);
-    this._toolbar = ctor.createToolbar();
+    let rendermime = this._rendermime;
+    this._content = this._renderer.createContent({ rendermime });
+    this._toolbar = this._renderer.createToolbar();
 
     let container = new Panel();
     container.addClass(NB_CONTAINER);
@@ -135,36 +107,26 @@ class NotebookPanel extends Widget {
     layout.addChild(container);
 
     // Instantiate tab completion widget.
-    this._completion = ctor.createCompletion();
+    this._completion = this._renderer.createCompletion();
     this._completion.reference = this;
     this._completion.attach(document.body);
-    this._completion.selected.connect(this.onCompletionSelect, this);
+    this._completion.selected.connect(this.onCompletionSelected, this);
 
     // Connect signals.
-    this._content.stateChanged.connect(this.onContentChanged, this);
+    this._content.stateChanged.connect(this.onContentStateChanged, this);
     let cell = this._content.childAt(this._content.activeCellIndex);
     if (cell) {
       let editor = cell.editor;
-      editor.textChanged.connect(this.onTextChange, this);
-      editor.completionRequested.connect(this.onCompletionRequest, this);
+      editor.textChanged.connect(this.onTextChanged, this);
+      editor.completionRequested.connect(this.onCompletionRequested, this);
     }
+  }
 
-    // Handle the document title.
-    this.title.text = context.path.split('/').pop();
-    context.pathChanged.connect((c, path) => {
-      this.title.text = path.split('/').pop();
-    });
-
-    // Handle changes to dirty state.
-    model.stateChanged.connect((m, args) => {
-      if (args.name === 'dirty') {
-        if (args.newValue) {
-          this.title.className += ` ${DIRTY_CLASS}`;
-        } else {
-          this.title.className = this.title.className.replace(DIRTY_CLASS, '');
-        }
-      }
-    });
+  /**
+   * A signal emitted when the panel context changes.
+   */
+  get contextChanged(): ISignal<NotebookPanel, void> {
+    return Private.contextChangedSignal.bind(this);
   }
 
   /**
@@ -195,6 +157,13 @@ class NotebookPanel extends Widget {
   }
 
   /**
+   * Get the renderer used by the widget.
+   */
+  get renderer(): NotebookPanel.IRenderer {
+    return this._renderer;
+  }
+
+  /**
    * Get the clipboard instance used by the widget.
    *
    * #### Notes
@@ -208,20 +177,34 @@ class NotebookPanel extends Widget {
    * Get the model used by the widget.
    *
    * #### Notes
-   * This is a read-only property.
+   * This is a read-only property.  Changing the model on the `content`
+   * directly would result in undefined behavior.
    */
   get model(): INotebookModel {
-    return this._model;
+    return this._content.model;
   }
 
   /**
-   * Get the document context for the widget.
+   * The document context for the widget.
    *
    * #### Notes
-   * This is a read-only property.
+   * Changing the context also changes the model on the
+   * `content`.
    */
   get context(): IDocumentContext {
     return this._context;
+  }
+  set context(newValue: IDocumentContext) {
+    newValue = newValue || null;
+    if (newValue === this._context) {
+      return;
+    }
+    let oldValue = this._context;
+    this._context = newValue;
+    // Trigger private, protected, and public changes.
+    this._onContextChanged(oldValue, newValue);
+    this.onContextChanged(oldValue, newValue);
+    this.contextChanged.emit(void 0);
   }
 
   /**
@@ -238,6 +221,7 @@ class NotebookPanel extends Widget {
     this._clipboard = null;
     this._completion.dispose();
     this._completion = null;
+    this._renderer = null;
     super.dispose();
   }
 
@@ -245,6 +229,9 @@ class NotebookPanel extends Widget {
    * Restart the kernel on the panel.
    */
   restart(): Promise<boolean> {
+    if (!this.context) {
+      return;
+    }
     let kernel = this.context.kernel;
     if (!kernel) {
       return Promise.resolve(false);
@@ -262,10 +249,19 @@ class NotebookPanel extends Widget {
     });
   }
 
+
+  /**
+   * Handle a change to the document context.
+   *
+   * #### Notes
+   * The default implementation is a no-op.
+   */
+  protected onContextChanged(oldValue: IDocumentContext, newValue: IDocumentContext): void { }
+
   /**
    * Handle a change in the kernel by updating the document metadata.
    */
-  protected handleKernelChange(kernel: IKernel): void {
+  protected onKernelChanged(context: IDocumentContext, kernel: IKernel): void {
     if (!this.model) {
       return;
     }
@@ -284,20 +280,40 @@ class NotebookPanel extends Widget {
   }
 
   /**
-   * Handle a change in the content area.
+   * Handle a change in the model state.
    */
-  protected onContentChanged(sender: Notebook, args: IChangedArgs<any>): void {
+  protected onModelStateChanged(sender: INotebookModel, args: IChangedArgs<any>): void {
+    if (args.name === 'dirty') {
+      if (args.newValue) {
+        this.title.className += ` ${DIRTY_CLASS}`;
+      } else {
+        this.title.className = this.title.className.replace(DIRTY_CLASS, '');
+      }
+    }
+  }
+
+  /**
+   * Handle a change to the document path.
+   */
+  protected onPathChanged(sender: IDocumentContext, path: string): void {
+    this.title.text = path.split('/').pop();
+  }
+
+  /**
+   * Handle a state change in the content area.
+   */
+  protected onContentStateChanged(sender: Notebook, args: IChangedArgs<any>): void {
     switch (args.name) {
     case 'activeCellIndex':
       let cell = this._content.childAt(args.oldValue);
       let editor = cell.editor;
-      editor.textChanged.disconnect(this.onTextChange, this);
-      editor.completionRequested.disconnect(this.onCompletionRequest, this);
+      editor.textChanged.disconnect(this.onTextChanged, this);
+      editor.completionRequested.disconnect(this.onCompletionRequested, this);
 
       cell = this._content.childAt(args.newValue);
       editor = cell.editor;
-      editor.textChanged.connect(this.onTextChange, this);
-      editor.completionRequested.connect(this.onCompletionRequest, this);
+      editor.textChanged.connect(this.onTextChanged, this);
+      editor.completionRequested.connect(this.onCompletionRequested, this);
       break;
     default:
       break;
@@ -307,7 +323,7 @@ class NotebookPanel extends Widget {
   /**
    * Handle a text changed signal from an editor.
    */
-  protected onTextChange(editor: CellEditorWidget, change: ITextChange): void {
+  protected onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
     if (!this.model) {
       return;
     }
@@ -331,8 +347,8 @@ class NotebookPanel extends Widget {
   /**
    * Handle a completion requested signal from an editor.
    */
-  protected onCompletionRequest(editor: CellEditorWidget, change: ICompletionRequest): void {
-    if (!this.model) {
+  protected onCompletionRequested(editor: CellEditorWidget, change: ICompletionRequest): void {
+    if (!this.model || !this.context) {
       return;
     }
     let kernel = this.context.kernel;
@@ -370,7 +386,7 @@ class NotebookPanel extends Widget {
   /**
    * Handle a completion selected signal from the completion widget.
    */
-  protected onCompletionSelect(widget: CompletionWidget, value: string): void {
+  protected onCompletionSelected(widget: CompletionWidget, value: string): void {
     if (!this.model) {
       return;
     }
@@ -382,12 +398,134 @@ class NotebookPanel extends Widget {
     doc.setCursor(doc.posFromIndex(patch.position));
   }
 
+  /**
+   * Handle a change in the context.
+   */
+  private _onContextChanged(oldValue: IDocumentContext, newValue: IDocumentContext): void {
+    if (oldValue) {
+      oldValue.kernelChanged.disconnect(this.onKernelChanged, this);
+      oldValue.pathChanged.disconnect(this.onPathChanged, this);
+      if (oldValue.model) {
+        oldValue.model.stateChanged.disconnect(this.onModelStateChanged, this);
+      }
+    }
+    let context = newValue;
+    context.kernelChanged.connect(this.onKernelChanged, this);
+    if (context.kernel) {
+      this.onKernelChanged(this._context, this._context.kernel);
+    }
+    this._content.model = newValue.model as INotebookModel;
+
+    // Handle the document title.
+    this.title.text = context.path.split('/').pop();
+    context.pathChanged.connect(this.onPathChanged, this);
+
+    // Handle changes to dirty state.
+    context.model.stateChanged.connect(this.onModelStateChanged, this);
+  }
+
   private _rendermime: RenderMime<Widget> = null;
   private _context: IDocumentContext = null;
-  private _model: INotebookModel = null;
   private _content: Notebook = null;
   private _toolbar: NotebookToolbar = null;
   private _clipboard: IClipboard = null;
   private _completion: CompletionWidget = null;
   private _pendingComplete = 0;
+  private _renderer: NotebookPanel.IRenderer = null;
+}
+
+
+/**
+ * A namespace for `NotebookPanel` statics.
+ */
+export namespace NotebookPanel {
+  /**
+   * An options interface for NotebookPanels.
+   */
+  export
+  interface IOptions {
+    /**
+     * The rendermime instance used by the panel.
+     */
+    rendermime: RenderMime<Widget>;
+
+    /**
+     * The application clipboard.
+     */
+    clipboard: IClipboard;
+
+    /**
+     * The content renderer for the panel.
+     *
+     * The default is a shared `IRenderer` instance.
+     */
+    renderer?: IRenderer;
+  }
+
+  /**
+   * A renderer interface for NotebookPanels.
+   */
+  export
+  interface IRenderer {
+    /**
+     * Create a new content area for the panel.
+     */
+    createContent(options: Notebook.IOptions): Notebook;
+
+    /**
+     * Create a new toolbar for the panel.
+     */
+    createToolbar(): NotebookToolbar;
+
+    /**
+     * Create a new completion widget for the panel.
+     */
+    createCompletion(): CompletionWidget;
+  }
+
+  /**
+   * The default implementation of an `IRenderer`.
+   */
+  export
+  class Renderer {
+    /**
+     * Create a new content area for the panel.
+     */
+    createContent(options: Notebook.IOptions): Notebook {
+      return new Notebook(options);
+    }
+
+    /**
+     * Create a new toolbar for the panel.
+     */
+    createToolbar(): NotebookToolbar {
+      return new NotebookToolbar();
+    }
+
+    /**
+     * Create a new completion widget.
+     */
+    createCompletion(): CompletionWidget {
+      let model = new CompletionModel();
+      return new CompletionWidget(model);
+    }
+  }
+
+  /**
+   * The shared default instance of a `Renderer`.
+   */
+   export
+   const defaultRenderer = new Renderer();
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * A signal emitted when the panel context changes.
+   */
+  export
+  const contextChangedSignal = new Signal<NotebookPanel, void>();
 }

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -382,7 +382,7 @@ export namespace NotebookPanel {
    * The default implementation of an `IRenderer`.
    */
   export
-  class Renderer {
+  class Renderer implements IRenderer {
     /**
      * Create a new content area for the panel.
      */

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -130,6 +130,13 @@ class StaticNotebook extends Widget {
   }
 
   /**
+   * A signal emitted when the widget has changed.
+   */
+  get changed(): ISignal<StaticNotebook, void> {
+    return Private.changedSignal.bind(this);
+  }
+
+  /**
    * The model for the widget.
    */
   get model(): INotebookModel {
@@ -146,6 +153,7 @@ class StaticNotebook extends Widget {
     this._onModelChanged(oldValue, newValue);
     this.onModelChanged(oldValue, newValue);
     this.modelChanged.emit(void 0);
+    this.changed.emit(void 0);
   }
 
   /**
@@ -228,6 +236,7 @@ class StaticNotebook extends Widget {
     case 'language_info':
       this._mimetype = this._renderer.getCodeMimetype(model);
       this._updateChildren();
+      this.changed.emit(void 0);
       break;
     default:
       break;
@@ -347,6 +356,7 @@ class StaticNotebook extends Widget {
     default:
       return;
     }
+    this.changed.emit(void 0);
   }
 
   private _mimetype = 'text/plain';
@@ -816,6 +826,12 @@ namespace Private {
    */
   export
   const stateChangedSignal = new Signal<Notebook, IChangedArgs<any>>();
+
+  /**
+   * A signal emitted when the widget has changed.
+   */
+  export
+  const changedSignal = new Signal<StaticNotebook, void>();
 
   /**
    * Scroll an element into view if needed.

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -532,10 +532,13 @@ class Notebook extends StaticNotebook {
    * The index will be clamped to the bounds of the notebook cells.
    */
   get activeCellIndex(): number {
+    if (!this.model) {
+      return -1;
+    }
     return this.model.cells.length ? this._activeCellIndex : -1;
   }
   set activeCellIndex(newValue: number) {
-    if (!this.model.cells.length) {
+    if (!this.model || !this.model.cells.length) {
       return;
     }
     newValue = Math.max(newValue, 0);
@@ -730,7 +733,7 @@ class Notebook extends StaticNotebook {
    */
   private _evtClick(event: MouseEvent): void {
     let model = this.model;
-    if (model.readOnly) {
+    if (!model || model.readOnly) {
       return;
     }
     let i = this._findCell(event.target as HTMLElement);
@@ -745,7 +748,7 @@ class Notebook extends StaticNotebook {
    */
   private _evtDblClick(event: MouseEvent): void {
     let model = this.model;
-    if (model.readOnly) {
+    if (!model || model.readOnly) {
       return;
     }
     let i = this._findCell(event.target as HTMLElement);

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -600,12 +600,12 @@ class Notebook extends StaticNotebook {
   set activeCellIndex(newValue: number) {
     let oldValue = this._activeCellIndex;
     if (!this.model || !this.model.cells.length) {
-      this._activeCellIndex = -1;
+      newValue = -1;
     } else {
       newValue = Math.max(newValue, 0);
       newValue = Math.min(newValue, this.model.cells.length - 1);
-      this._activeCellIndex = newValue;
     }
+    this._activeCellIndex = newValue;
     let cell = this.childAt(newValue);
     if (cell !== this._activeCell) {
       this._activeCell = cell;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -598,26 +598,22 @@ class Notebook extends StaticNotebook {
     return this.model.cells.length ? this._activeCellIndex : -1;
   }
   set activeCellIndex(newValue: number) {
+    let oldValue = this._activeCellIndex;
     if (!this.model || !this.model.cells.length) {
       this._activeCellIndex = -1;
-      if (this._activeCell) {
-        this._activeCell = null;
-        this.activeCellChanged.emit(null);
-      }
-      return;
+    } else {
+      newValue = Math.max(newValue, 0);
+      newValue = Math.min(newValue, this.model.cells.length - 1);
+      this._activeCellIndex = newValue;
     }
-    newValue = Math.max(newValue, 0);
-    newValue = Math.min(newValue, this.model.cells.length - 1);
     let cell = this.childAt(newValue);
     if (cell !== this._activeCell) {
       this._activeCell = cell;
       this.activeCellChanged.emit(cell);
     }
-    if (newValue === this._activeCellIndex) {
+    if (newValue === oldValue) {
       return;
     }
-    let oldValue = this._activeCellIndex;
-    this._activeCellIndex = newValue;
     this.stateChanged.emit({ name: 'activeCellIndex', oldValue, newValue });
     this.update();
   }

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -261,7 +261,7 @@ class StaticNotebook extends Widget {
   }
 
   /**
-   * Create a child widget and insert into to the notebook.
+   * Create a child widget and insert into the notebook.
    */
   private _insertChild(index: number, cell: ICellModel): void {
     let widget: BaseCellWidget;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -890,9 +890,14 @@ class Notebook extends StaticNotebook {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: FocusEvent): void {
-    if (event.target === this.node) {
-      this.mode = 'command';
-    } else {
+    this.mode = 'command';
+    let i = this._findCell(event.target as HTMLElement);
+    if (i === -1) {
+      return;
+    }
+    this.activeCellIndex = i;
+    let widget = this.childAt(i);
+    if (widget.editor.node.contains(event.target as HTMLElement)) {
       this.mode = 'edit';
     }
   }

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -599,6 +599,7 @@ class Notebook extends StaticNotebook {
   }
   set activeCellIndex(newValue: number) {
     if (!this.model || !this.model.cells.length) {
+      this._activeCellIndex = -1;
       if (this._activeCell) {
         this._activeCell = null;
         this.activeCellChanged.emit(null);

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -796,6 +796,8 @@ class Notebook extends StaticNotebook {
    * Handle a new model.
    */
   protected onModelChanged(oldValue: INotebookModel, newValue: INotebookModel): void {
+    // Try to set the active cell index to 0.
+    // It will be set to `-1` if there is no new model or the model is empty.
     this.activeCellIndex = 0;
   }
 

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -767,6 +767,31 @@ class Notebook extends StaticNotebook {
 
 
 /**
+ * The namespace for the `Notebook` class statics.
+ */
+export
+namespace Notebook {
+  /**
+   * An options object for initializing a notebook.
+   */
+  export
+  interface IOptions extends StaticNotebook.IOptions { }
+
+  /**
+   * The default implementation of an `IRenderer`.
+   */
+  export
+  class Renderer extends StaticNotebook.Renderer { }
+
+  /**
+   * The default `IRenderer` instance.
+   */
+  export
+  const defaultRenderer = new Renderer();
+}
+
+
+/**
  * A namespace for private data.
  */
 namespace Private {

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -38,7 +38,7 @@ import {
  * A widget factory for notebook panels.
  */
 export
-class NotebookWidgetFactory implements IWidgetFactory<NotebookPanel> {
+class NotebookWidgetFactory implements IWidgetFactory<NotebookPanel, INotebookModel> {
   /**
    * Construct a new notebook widget factory.
    *
@@ -76,8 +76,9 @@ class NotebookWidgetFactory implements IWidgetFactory<NotebookPanel> {
    * The factory will start the appropriate kernel and populate
    * the default toolbar items using `ToolbarItems.populateDefaults`.
    */
-  createNew(model: INotebookModel, context: IDocumentContext, kernel?: IKernelId): NotebookPanel {
+  createNew(context: IDocumentContext<INotebookModel>, kernel?: IKernelId): NotebookPanel {
     let rendermime = this._rendermime.clone();
+    let model = context.model;
     if (kernel) {
       context.changeKernel(kernel);
     } else {
@@ -98,7 +99,7 @@ class NotebookWidgetFactory implements IWidgetFactory<NotebookPanel> {
    *
    * ### The default implementation is a no-op.
    */
-  beforeClose(model: INotebookModel, context: IDocumentContext, widget: NotebookPanel): Promise<boolean> {
+  beforeClose(widget: NotebookPanel, context: IDocumentContext<INotebookModel>): Promise<boolean> {
     // No special action required.
     return Promise.resolve(true);
   }

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -84,7 +84,8 @@ class NotebookWidgetFactory implements IWidgetFactory<NotebookPanel> {
       let name = findKernel(model.defaultKernelName, model.defaultKernelLanguage, context.kernelspecs);
       context.changeKernel({ name });
     }
-    let panel = new NotebookPanel(model, rendermime, context, this._clipboard);
+    let panel = new NotebookPanel({ rendermime, clipboard: this._clipboard });
+    panel.context = context;
     ToolbarItems.populateDefaults(panel);
     return panel;
   }

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -261,7 +261,7 @@ function activateNotebookHandler(app: Application, registry: DocumentRegistry, s
     handler: () => {
       if (tracker.activeNotebook) {
         let nbWidget = tracker.activeNotebook;
-        nbWidget.restart();
+        NotebookActions.restart(nbWidget.kernel, nbWidget.node);
       }
     }
   },
@@ -270,7 +270,8 @@ function activateNotebookHandler(app: Application, registry: DocumentRegistry, s
     handler: () => {
       if (tracker.activeNotebook) {
         let nbWidget = tracker.activeNotebook;
-        nbWidget.restart().then(result => {
+        let promise = NotebookActions.restart(nbWidget.kernel, nbWidget.node);
+        promise.then(result => {
           if (result) {
             NotebookActions.clearAllOutputs(nbWidget.content);
           }
@@ -283,7 +284,8 @@ function activateNotebookHandler(app: Application, registry: DocumentRegistry, s
     handler: () => {
       if (tracker.activeNotebook) {
         let nbWidget = tracker.activeNotebook;
-        nbWidget.restart().then(result => {
+        let promise = NotebookActions.restart(nbWidget.kernel, nbWidget.node);
+        promise.then(result => {
           NotebookActions.runAll(nbWidget.content, nbWidget.context.kernel);
         });
       }

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -173,8 +173,8 @@ class TrackingNotebookWidgetFactory extends NotebookWidgetFactory {
   /**
    * Create a new widget.
    */
-  createNew(model: INotebookModel, context: IDocumentContext, kernel?: IKernelId): NotebookPanel {
-    let widget = super.createNew(model, context, kernel);
+  createNew(context: IDocumentContext<INotebookModel>, kernel?: IKernelId): NotebookPanel {
+    let widget = super.createNew(context, kernel);
     Private.notebookTracker.activeNotebook = widget;
     return widget;
   }

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -28,7 +28,7 @@ import {
 } from '../rendermime';
 
 import {
-  IDocumentContext
+  IDocumentContext, IDocumentModel
 } from '../docregistry';
 
 import 'jquery-ui/themes/smoothness/jquery-ui.min.css';
@@ -69,8 +69,8 @@ class BackboneViewWrapper extends Widget {
  */
 export
 class WidgetManager extends ManagerBase<Widget> implements IDisposable {
-  constructor(context: IDocumentContext) {
-    super()
+  constructor(context: IDocumentContext<IDocumentModel>) {
+    super();
     this._context = context;
 
     let newKernel = (kernel: IKernel) => {
@@ -79,12 +79,12 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
         }
         this._commRegistration = kernel.registerCommTarget(this.comm_target_name,
         (comm, msg) => {this.handle_comm_open(comm, msg)});
-    }
+    };
 
     context.kernelChanged.connect((sender, kernel) => {
       this.validateVersion();
       newKernel(kernel);
-    })
+    });
 
     if (context.kernel) {
       this.validateVersion();
@@ -150,7 +150,7 @@ class WidgetManager extends ManagerBase<Widget> implements IDisposable {
     this._context = null;
   }
 
-  _context: IDocumentContext;
+  _context: IDocumentContext<IDocumentModel>;
   _commRegistration: IDisposable;
 }
 

--- a/src/widgets/plugin.ts
+++ b/src/widgets/plugin.ts
@@ -14,6 +14,10 @@ import {
 } from 'phosphor-widget';
 
 import {
+  INotebookModel
+} from '../notebook/notebook/model';
+
+import {
   NotebookPanel
 } from '../notebook/notebook/panel';
 
@@ -43,21 +47,20 @@ const widgetManagerExtension = {
 };
 
 export
-class IPyWidgetExtension implements IWidgetExtension<NotebookPanel>{
+class IPyWidgetExtension implements IWidgetExtension<NotebookPanel, INotebookModel> {
   /**
    * Create a new extension object.
    */
-  createNew(nb: NotebookPanel, model: IDocumentModel,
-            context: IDocumentContext): IDisposable {
+  createNew(nb: NotebookPanel, context: IDocumentContext<INotebookModel>): IDisposable {
     let wManager = new WidgetManager(context);
     let wRenderer = new WidgetRenderer(wManager);
 
-    nb.content.rendermime.addRenderer(WIDGET_MIMETYPE, wRenderer, 0)
+    nb.content.rendermime.addRenderer(WIDGET_MIMETYPE, wRenderer, 0);
     return new DisposableDelegate(() => {
       nb.content.rendermime.removeRenderer(WIDGET_MIMETYPE);
       wRenderer.dispose();
       wManager.dispose();
-    })
+    });
   }
 }
 

--- a/test/src/docmanager/mockcontext.ts
+++ b/test/src/docmanager/mockcontext.ts
@@ -85,21 +85,21 @@ const LANGUAGE_INFOS: { [key: string]: IKernelLanguageInfo } = {
 
 
 export
-class MockContext implements IDocumentContext {
+class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
 
-  constructor(model: IDocumentModel) {
+  constructor(model: T) {
     this._model = model;
   }
 
-  get kernelChanged(): ISignal<MockContext, IKernel> {
+  get kernelChanged(): ISignal<IDocumentContext<IDocumentModel>, IKernel> {
     return Private.kernelChangedSignal.bind(this);
   }
 
-  get pathChanged(): ISignal<MockContext, string> {
+  get pathChanged(): ISignal<IDocumentContext<IDocumentModel>, string> {
     return Private.pathChangedSignal.bind(this);
   }
 
-  get dirtyCleared(): ISignal<MockContext, void> {
+  get dirtyCleared(): ISignal<IDocumentContext<IDocumentModel>, void> {
     return Private.dirtyClearedSignal.bind(this);
   }
 
@@ -107,7 +107,7 @@ class MockContext implements IDocumentContext {
     return '';
   }
 
-  get model(): IDocumentModel {
+  get model(): T {
     return this._model;
   }
 
@@ -179,7 +179,7 @@ class MockContext implements IDocumentContext {
     return void 0;
   }
 
-  private _model: IDocumentModel = null;
+  private _model: T = null;
   private _kernel: IKernel = null;
 }
 
@@ -194,17 +194,17 @@ namespace Private {
    * A signal emitted when the kernel changes.
    */
   export
-  const kernelChangedSignal = new Signal<MockContext, IKernel>();
+  const kernelChangedSignal = new Signal<IDocumentContext<IDocumentModel>, IKernel>();
 
   /**
    * A signal emitted when the path changes.
    */
   export
-  const pathChangedSignal = new Signal<MockContext, string>();
+  const pathChangedSignal = new Signal<IDocumentContext<IDocumentModel>, string>();
 
   /**
    * A signal emitted when the model is saved or reverted.
    */
   export
-  const dirtyClearedSignal = new Signal<MockContext, void>();
+  const dirtyClearedSignal = new Signal<IDocumentContext<IDocumentModel>, void>();
 }

--- a/test/src/docmanager/mockcontext.ts
+++ b/test/src/docmanager/mockcontext.ts
@@ -116,7 +116,7 @@ class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
   }
 
   get path(): string {
-    return '';
+    return this._path;
   }
 
   get contentsModel(): IContentsModel {
@@ -164,6 +164,8 @@ class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
   }
 
   saveAs(path: string): Promise<void> {
+    this._path = path;
+    this.pathChanged.emit(path);
     return Promise.resolve(void 0);
   }
 
@@ -180,6 +182,7 @@ class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
   }
 
   private _model: T = null;
+  private _path = '';
   private _kernel: IKernel = null;
 }
 

--- a/test/src/docregistry/default.spec.ts
+++ b/test/src/docregistry/default.spec.ts
@@ -23,7 +23,7 @@ import {
 
 class WidgetFactory extends ABCWidgetFactory {
 
-  createNew(model: IDocumentModel, context: IDocumentContext, kernel?: IKernelId): Widget {
+  createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernelId): Widget {
     return new Widget();
   }
 }
@@ -72,7 +72,7 @@ describe('docmanager/default', () => {
         let factory = new WidgetFactory();
         let model = new DocumentModel();
         let context = new MockContext(model);
-        let widget = factory.createNew(model, context);
+        let widget = factory.createNew(context);
         expect(widget).to.be.a(Widget);
       });
 
@@ -84,8 +84,8 @@ describe('docmanager/default', () => {
         let factory = new WidgetFactory();
         let model = new DocumentModel();
         let context = new MockContext(model);
-        let widget = factory.createNew(model, context);
-        factory.beforeClose(model, context, widget).then(() => {
+        let widget = factory.createNew(context);
+        factory.beforeClose(widget, context).then(() => {
           done();
         });
       });

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -12,6 +12,7 @@ import './notebook/cells/model.spec';
 import './notebook/notebook/nbformat.spec';
 import './notebook/notebook/model.spec';
 import './notebook/notebook/modelfactory.spec';
+import './notebook/notebook/panel.spec';
 import './notebook/notebook/toolbar.spec';
 import './notebook/notebook/widget.spec';
 import './notebook/notebook/widgetfactory.spec';

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -20,6 +20,46 @@ import {
 } from '../../rendermime/rendermime.spec';
 
 
+class LogNotebookPanel extends NotebookPanel {
+
+  methods: string[] = [];
+
+  protected onContextChanged(oldValue: IDocumentContext<INotebookModel>, newValue: IDocumentContext<INotebookModel>): void {
+    super.onContextChanged(oldValue, newValue);
+    this.methods.push('onContextChanged');
+  }
+
+  protected onModelStateChanged(sender: INotebookModel, args: IChangedArgs<any>): void {
+    super.onModelStateChanged(sender, args);
+    this.methods.push('onModelStateChanged');
+  }
+
+  protected onPathChanged(sender: IDocumentContext<INotebookModel>, path: string): void {
+    super.onPathChanged(sender, args);
+    this.methods.push('onPathChanged');
+  }
+
+  protected onContentStateChanged(sender: Notebook, args: IChangedArgs<any>): void {
+    super.onContentStateChanged(sender, args);
+    this.methods.push('onContentStateChanged');
+  }
+
+  protected onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
+    super.onTextChanged(editor, change);
+    this.methods.push('onTextChanged');
+  }
+
+  protected onCompletionRequested(editor: CellEditorWidget, change: ICompletionRequest): void {
+    super.onCompletionRequested(editor, change);
+    this.methods.push('onCompletionRequested');
+  }
+
+  protected onCompletionSelected(widget: CompletionWidget, value: string): void {
+    super.onCompletionSelected(widget, value);
+    this.methods.push('onCompletionSelected');
+  }
+}
+
 
 describe('notebook/notebook/panel', () => {
 
@@ -35,6 +75,82 @@ describe('notebook/notebook/panel', () => {
       it('should accept an optional render', () => {
 
       });
+
+    });
+
+    describe('#contextChanged', () => {
+
+    });
+
+    describe('#kernelChanged', () => {
+
+    });
+
+    describe('#toolbar', () => {
+
+    });
+
+    describe('#content', () => {
+
+    });
+
+    describe('#kernel', () => {
+
+    });
+
+    describe('#rendermime', () => {
+
+    });
+
+    describe('#renderer', () => {
+
+    });
+
+    describe('#clipboard', () => {
+
+    });
+
+    describe('#model', () => {
+
+    });
+
+    describe('#context', () => {
+
+    });
+
+    describe('#dispose()', () => {
+
+    });
+
+    describe('#onContextChanged()', () => {
+
+    });
+
+    describe('#onKernelChanged()', () => {
+
+    });
+
+    describe('#onModelStateChanged()', () => {
+
+    });
+
+    describe('#onPathChanged()', () => {
+
+    });
+
+    describe('#onContentStateChanged()', () => {
+
+    });
+
+    describe('#onTextChanged()', () => {
+
+    });
+
+    describe('#onCompletionRequested()', () => {
+
+    });
+
+    describe('#onCompletionSelected()', () => {
 
     });
 

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -4,20 +4,59 @@
 import expect = require('expect.js');
 
 import {
+  MockKernel
+} from 'jupyter-js-services/lib/mockkernel';
+
+import {
+  MimeData
+} from 'phosphor-dragdrop';
+
+import {
+  IChangedArgs
+} from 'phosphor-properties';
+
+import {
+  IDocumentContext
+} from '../../../../lib/docregistry';
+
+import {
+  CellEditorWidget, ITextChange, ICompletionRequest
+} from '../../../../lib/notebook/cells/editor';
+
+import {
+  CompletionWidget
+} from '../../../../lib/notebook/completion';
+
+import {
   INotebookModel, NotebookModel
 } from '../../../../lib/notebook/notebook/model';
 
 import {
-  Notebook, StaticNotebook
+  NotebookPanel
+} from '../../../../lib/notebook/notebook/panel';
+
+import {
+  NotebookToolbar
+} from '../../../../lib/notebook/notebook/toolbar';
+
+import {
+  Notebook
 } from '../../../../lib/notebook/notebook/widget';
 
 import {
-  nbformat
-} from '../../../../lib/notebook/notebook/nbformat';
+  MockContext
+} from '../../docmanager/mockcontext';
 
 import {
   defaultRenderMime
 } from '../../rendermime/rendermime.spec';
+
+
+/**
+ * Default rendermime and clipboard instances.
+ */
+const rendermime = defaultRenderMime();
+const clipboard = new MimeData();
 
 
 class LogNotebookPanel extends NotebookPanel {
@@ -35,7 +74,7 @@ class LogNotebookPanel extends NotebookPanel {
   }
 
   protected onPathChanged(sender: IDocumentContext<INotebookModel>, path: string): void {
-    super.onPathChanged(sender, args);
+    super.onPathChanged(sender, path);
     this.methods.push('onPathChanged');
   }
 
@@ -61,6 +100,15 @@ class LogNotebookPanel extends NotebookPanel {
 }
 
 
+function createPanel(): LogNotebookPanel {
+  let panel = new LogNotebookPanel({ rendermime, clipboard });
+  let model = new NotebookModel();
+  let context = new MockContext<NotebookModel>(model);
+  panel.context = context;
+  return panel;
+}
+
+
 describe('notebook/notebook/panel', () => {
 
   describe('NotebookPanel', () => {
@@ -68,89 +116,304 @@ describe('notebook/notebook/panel', () => {
     describe('#constructor()', () => {
 
       it('should create a notebook panel', () => {
-
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel).to.be.a(NotebookPanel);
       });
 
 
       it('should accept an optional render', () => {
-
+        let renderer = new NotebookPanel.Renderer();
+        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        expect(panel.renderer).to.be(renderer);
       });
 
     });
 
     describe('#contextChanged', () => {
 
+      it('should be emitted when the context on the panel changes', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        let called = false;
+        let model = new NotebookModel();
+        let context = new MockContext<INotebookModel>(model);
+        panel.contextChanged.connect((sender, args) => {
+          expect(sender).to.be(panel);
+          expect(args).to.be(void 0);
+          called = true;
+        });
+        panel.context = context;
+        expect(called).to.be(true);
+      });
+
+      it('should not be emitted if the context does not change', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        let called = false;
+        let model = new NotebookModel();
+        let context = new MockContext<INotebookModel>(model);
+        panel.context = context;
+        panel.contextChanged.connect(() => { called = true; });
+        panel.context = context;
+        expect(called).to.be(false);
+      });
+
     });
 
     describe('#kernelChanged', () => {
+
+      it('should be emitted when the kernel on the panel changes', () => {
+        let panel = createPanel();
+        let called = false;
+        panel.kernelChanged.connect((sender, args) => {
+          expect(sender).to.be(panel);
+          expect(args).to.be.a(MockKernel);
+          called = true;
+        });
+        panel.context.changeKernel({ name: 'python' });
+        expect(called).to.be(true);
+      });
+
+      it('should not be emitted when the kernel does not change', () => {
+        let panel = createPanel();
+        let called = false;
+        panel.kernelChanged.connect(() => { called = true; });
+        let context = new MockContext<INotebookModel>(panel.model);
+        panel.context = context;
+        expect(called).to.be(false);
+      });
 
     });
 
     describe('#toolbar', () => {
 
+      it('should be the toolbar used by the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.toolbar).to.be.a(NotebookToolbar);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.toolbar = null; }).to.throwError();
+      });
+
     });
 
     describe('#content', () => {
+
+      it('should be the content area used by the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.content).to.be.a(Notebook);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.content = null; }).to.throwError();
+      });
 
     });
 
     describe('#kernel', () => {
 
+      it('should be the current kernel used by the panel', () => {
+        let panel = createPanel();
+        expect(panel.kernel).to.be(null);
+        panel.context.changeKernel({ name: 'python' });
+        expect(panel.kernel.name).to.be('python');
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.kernel = null; }).to.throwError();
+      });
+
     });
 
     describe('#rendermime', () => {
+
+      it('should be the rendermime instance used by the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.rendermime).to.be(rendermime);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.rendermime = null; }).to.throwError();
+      });
 
     });
 
     describe('#renderer', () => {
 
+      it('should be the renderer used by the widget', () => {
+        let renderer = new NotebookPanel.Renderer();
+        let panel = new NotebookPanel({ rendermime, clipboard, renderer });
+        expect(panel.renderer).to.be(renderer);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.renderer = null; });
+      });
+
     });
 
     describe('#clipboard', () => {
+
+      it('should be the clipboard instance used by the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.clipboard).to.be(clipboard);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.clipboard = null; }).to.throwError();
+      });
 
     });
 
     describe('#model', () => {
 
+      it('should be the model for the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.model).to.be(null);
+        let model = new NotebookModel();
+        let context = new MockContext<NotebookModel>(model);
+        panel.context = context;
+        expect(panel.model).to.be(model);
+        expect(panel.content.model).to.be(model);
+      });
+
+      it('should be read-only', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(() => { panel.model = null; }).to.throwError();
+      });
+
     });
 
     describe('#context', () => {
+
+      it('should get the document context for the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        expect(panel.context).to.be(null);
+      });
+
+      it('should set the document context for the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        let model = new NotebookModel();
+        let context = new MockContext<NotebookModel>(model);
+        panel.context = context;
+        expect(panel.context).to.be(context);
+      });
+
+      it('should emit the `contextChanged` signal', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        let called = false;
+        let model = new NotebookModel();
+        let context = new MockContext<NotebookModel>(model);
+        panel.contextChanged.connect(() => { called = true; });
+        panel.context = context;
+        expect(called).to.be(true);
+      });
 
     });
 
     describe('#dispose()', () => {
 
+      it('should dispose of the resources used by the widget', () => {
+        let panel = new NotebookPanel({ rendermime, clipboard });
+        let model = new NotebookModel();
+        let context = new MockContext<NotebookModel>(model);
+        panel.context = context;
+        panel.dispose();
+        expect(panel.isDisposed).to.be(true);
+      });
+
+      // it('should be safe to call more than once', () => {
+      //   let panel = new NotebookPanel({ rendermime, clipboard });
+      //   panel.dispose();
+      //   panel.dispose();
+      //   expect(panel.isDisposed).to.be(true);
+      // });
+
     });
 
     describe('#onContextChanged()', () => {
+
+      it('should be called when the context changes', () => {
+        //let panel = createPanel();
+
+      });
 
     });
 
     describe('#onKernelChanged()', () => {
 
+      it('should be called when the kernel changes', () => {
+
+      });
+
     });
 
     describe('#onModelStateChanged()', () => {
+
+      it('should be called when the model state changes', () => {
+
+      });
 
     });
 
     describe('#onPathChanged()', () => {
 
+      it('should be called when the path changes', () => {
+
+      });
+
     });
 
     describe('#onContentStateChanged()', () => {
+
+      it('should be called when the content state changes', () => {
+
+      });
 
     });
 
     describe('#onTextChanged()', () => {
 
+      it('should be called on a text changed signal from the current editor', () => {
+
+      });
+
     });
 
     describe('#onCompletionRequested()', () => {
 
+      it('should be called on a `completionRequested` signal from the current editor', () => {
+
+      });
+
     });
 
     describe('#onCompletionSelected()', () => {
+
+      it('should be called on a `completionSelected` signal from the completion widget', () => {
+
+      });
+
+    });
+
+    describe('.Renderer', () => {
+
+      describe('#createContent()', () => {
+
+      });
+
+      describe('#createToolbar()', () => {
+
+      });
+
+      describe('#createCompletion()', () => {
+
+      });
 
     });
 

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -391,7 +391,8 @@ describe('notebook/notebook/panel', () => {
       describe('#createContent()', () => {
 
         it('should create a notebook widget', () => {
-
+          let renderer = new NotebookPanel.Renderer();
+          expect(renderer.createContent({ rendermime })).to.be.a(Notebook);
         });
 
       });
@@ -399,7 +400,8 @@ describe('notebook/notebook/panel', () => {
       describe('#createToolbar()', () => {
 
         it('should create a notebook toolbar', () => {
-
+          let renderer = new NotebookPanel.Renderer();
+          expect(renderer.createToolbar()).to.be.a(NotebookToolbar);
         });
 
       });
@@ -407,9 +409,18 @@ describe('notebook/notebook/panel', () => {
       describe('#createCompletion()', () => {
 
         it('should create a completion widget', () => {
-
+          let renderer = new NotebookPanel.Renderer();
+          expect(renderer.createCompletion()).to.be.a(CompletionWidget);
         });
 
+      });
+
+    });
+
+    describe('.defaultRenderer', () => {
+
+      it('should be an instance of a `Renderer`', () => {
+        expect(NotebookPanel.defaultRenderer).to.be.a(NotebookPanel.Renderer);
       });
 
     });

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  INotebookModel, NotebookModel
+} from '../../../../lib/notebook/notebook/model';
+
+import {
+  Notebook, StaticNotebook
+} from '../../../../lib/notebook/notebook/widget';
+
+import {
+  nbformat
+} from '../../../../lib/notebook/notebook/nbformat';
+
+import {
+  defaultRenderMime
+} from '../../rendermime/rendermime.spec';
+
+
+
+describe('notebook/notebook/panel', () => {
+
+  describe('NotebookPanel', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a notebook panel', () => {
+
+      });
+
+
+      it('should accept an optional render', () => {
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -390,13 +390,25 @@ describe('notebook/notebook/panel', () => {
 
       describe('#createContent()', () => {
 
+        it('should create a notebook widget', () => {
+
+        });
+
       });
 
       describe('#createToolbar()', () => {
 
+        it('should create a notebook toolbar', () => {
+
+        });
+
       });
 
       describe('#createCompletion()', () => {
+
+        it('should create a completion widget', () => {
+
+        });
 
       });
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -847,6 +847,17 @@ describe('notebook/notebook/widget', () => {
           expect(widget.activeCellIndex).to.be(0);
         });
 
+        it('should preserve "command" mode if in a markdown cell', () => {
+          let cell = widget.model.factory.createMarkdownCell();
+          widget.model.cells.add(cell);
+          let count = widget.childCount();
+          let child = widget.childAt(count - 1) as MarkdownCellWidget;
+          expect(child.rendered).to.be(true);
+          simulate(child.node, 'click');
+          expect(child.rendered).to.be(true);
+          expect(widget.activeCell).to.be(child);
+        });
+
       });
 
       context('dblclick', () => {

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -162,6 +162,30 @@ describe('notebook/notebook/widget', () => {
 
     });
 
+    describe('#modelContentChanged', () => {
+
+      it('should be emitted when a cell is added', () => {
+        let widget = new StaticNotebook({ rendermime: defaultRenderMime() });
+        widget.model = new NotebookModel();
+        let called = false;
+        widget.modelContentChanged.connect(() => { called = true; });
+        let cell = widget.model.factory.createCodeCell();
+        widget.model.cells.add(cell);
+        expect(called).to.be(true);
+      });
+
+      it('should be emitted when metadata is set', () => {
+        let widget = new StaticNotebook({ rendermime: defaultRenderMime() });
+        widget.model = new NotebookModel();
+        let called = false;
+        widget.modelContentChanged.connect(() => { called = true; });
+        let cursor = widget.model.getMetadata('foo');
+        cursor.setValue(1);
+        expect(called).to.be(true);
+      });
+
+    });
+
     describe('#model', () => {
 
       it('should get the model for the widget', () => {

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -518,6 +518,18 @@ describe('notebook/notebook/widget', () => {
 
     });
 
+    describe('#activeCellChanged', () => {
+
+      it('should be emitted when the active cell changes', () => {
+
+      });
+
+      it('should not be emitted when the active cell does not change', () => {
+
+      });
+
+    });
+
     describe('#mode', () => {
 
       it('should get the interactivity mode of the notebook', () => {
@@ -643,6 +655,22 @@ describe('notebook/notebook/widget', () => {
           done();
         });
         widget.activeCellIndex = 1;
+      });
+
+      it('should update the active cell if necessary', () => {
+
+      });
+
+    });
+
+    describe('#activeCell', () => {
+
+      it('should get the active cell widget', () => {
+
+      });
+
+      it('should be read-only', () => {
+
       });
 
     });
@@ -954,6 +982,10 @@ describe('notebook/notebook/widget', () => {
         });
       });
 
+      it('should update the active cell if necessary', () => {
+
+      });
+
       context('`edgeRequested` signal', () => {
 
         it('should activate the previous cell if top is requested', () => {
@@ -988,6 +1020,10 @@ describe('notebook/notebook/widget', () => {
           expect(widget.methods).to.contain('onUpdateRequest');
           done();
         });
+      });
+
+      it('should update the active cell if necessary', () => {
+
       });
 
     });

--- a/test/src/notebook/notebook/widgetfactory.spec.ts
+++ b/test/src/notebook/notebook/widgetfactory.spec.ts
@@ -82,33 +82,33 @@ describe('notebook/notebook/widgetfactory', () => {
 
       it('should create a new `NotebookPanel` widget', () => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
+        let panel = factory.createNew(context);
         expect(panel).to.be.a(NotebookPanel);
       });
 
       it('should create a clone of the rendermime', () => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
+        let panel = factory.createNew(context);
         expect(panel.rendermime).to.not.be(rendermime);
       });
 
       it('should start a kernel if one is given', () => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context, { name: 'shell' });
+        let panel = factory.createNew(context, { name: 'shell' });
         expect(panel.context.kernel.name).to.be('shell');
       });
 
       it('should start a kernel given the default kernel language', () => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
+        let panel = factory.createNew(context);
         expect(panel.context.kernel.name).to.be('python');
       });
 
@@ -116,17 +116,17 @@ describe('notebook/notebook/widgetfactory', () => {
         let model = new NotebookModel();
         let cursor = model.getMetadata('language_info');
         cursor.setValue({ name: 'shell' });
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
+        let panel = factory.createNew(context);
         expect(panel.context.kernel.name).to.be('shell');
       });
 
       it('should populate the default toolbar items', () => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
+        let panel = factory.createNew(context);
         let items = panel.toolbar.list();
         expect(items).to.contain('save');
         expect(items).to.contain('restart');
@@ -139,10 +139,10 @@ describe('notebook/notebook/widgetfactory', () => {
 
       it('should be a no-op', (done) => {
         let model = new NotebookModel();
-        let context = new MockContext(model);
+        let context = new MockContext<NotebookModel>(model);
         let factory = new NotebookWidgetFactory(rendermime, clipboard);
-        let panel = factory.createNew(model, context);
-        factory.beforeClose(model, context, panel).then(() => {
+        let panel = factory.createNew(context);
+        factory.beforeClose(panel, context).then(() => {
           done();
         });
       });

--- a/tutorial/notebook.md
+++ b/tutorial/notebook.md
@@ -113,29 +113,39 @@ We'll walk through two notebook extensions:
 Create a `src/mybutton/plugin.ts` file with the following contents.
 
 ```typescript
-import {
-  IWidgetExtension, IDocumentContext, IDocumentModel, DocumentRegistry
-} from '../docregistry';
-
-import {
-  IDisposable, DisposableDelegate
-} from 'phosphor-disposable';
-
-import {
-  NotebookPanel
-} from '../notebook/notebook/panel';
 
 import {
   Application
 } from 'phosphide/lib/core/application';
 
 import {
-  ToolbarButton
-} from '../notebook/notebook/toolbar';
+  IDisposable, DisposableDelegate
+} from 'phosphor-disposable';
 
 import {
   NotebookActions
 } from '../notebook/notebook/actions';
+
+import {
+  NotebookPanel
+} from '../notebook/notebook/panel';
+
+import {
+  INotebookModel
+} from '../notebook/notebook/model';
+
+import {
+  ToolbarButton
+} from '../notebook/notebook/toolbar';
+
+import {
+<<<<<<< HEAD
+  NotebookActions
+} from '../notebook/notebook/actions';
+=======
+  IWidgetExtension, IDocumentContext, IDocumentModel, DocumentRegistry
+} from '../docregistry';
+>>>>>>> 803d561... Clean up the notebook plugin example
 
 /**
  * The plugin registration information.
@@ -148,12 +158,11 @@ const widgetExtension = {
 };
 
 export
-class ButtonExtension implements IWidgetExtension<NotebookPanel>{
+class ButtonExtension implements IWidgetExtension<NotebookPanel, INotebookModel> {
   /**
    * Create a new extension object.
    */
-  createNew(nb: NotebookPanel, model: IDocumentModel,
-            context: IDocumentContext): IDisposable {
+  createNew(nb: NotebookPanel, context: IDocumentContext<INotebookModel>): IDisposable {
     let callback = () => {
       NotebookActions.runAll(nb.content, context.kernel);
     };
@@ -164,10 +173,10 @@ class ButtonExtension implements IWidgetExtension<NotebookPanel>{
     });
 
     let i = document.createElement('i');
-    i.classList.add('fa', 'fa-fast-forward')
+    i.classList.add('fa', 'fa-fast-forward');
     button.node.appendChild(i);
 
-    nb.toolbar.add('mybutton', button, 'run')
+    nb.toolbar.add('mybutton', button, 'run');
     return new DisposableDelegate(() => {
       button.dispose();
     });

--- a/tutorial/notebook.md
+++ b/tutorial/notebook.md
@@ -139,13 +139,8 @@ import {
 } from '../notebook/notebook/toolbar';
 
 import {
-<<<<<<< HEAD
-  NotebookActions
-} from '../notebook/notebook/actions';
-=======
   IWidgetExtension, IDocumentContext, IDocumentModel, DocumentRegistry
 } from '../docregistry';
->>>>>>> 803d561... Clean up the notebook plugin example
 
 /**
  * The plugin registration information.


### PR DESCRIPTION
- Allows the `context` on the notebook panel to change and updates the API to match other classes.
- Changes the `IDocumentContext` to take a type argument and makes resulting changes
- Fixes active cell tracking on the notebook widget.
- Provides convenience signals on the notebook and the notebook panel to make it easier to follow the
current kernel and model.
- Factored some completion behavior out of the notebook panel.
- Updated the example in `tuturial/notebook.md`

- Note: I could not use `onChildAdded` or `onChildRemoved` because they are triggered *before* the child widget is added to the layout.