### PR TITLE
Allow kernel info and spec to be set by the mock context

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "file-loader": "^0.8.5",
     "jquery": "^2.2.0",
     "jquery-ui": "^1.10.5",
-    "jupyter-js-services": "^0.10.4",
+    "jupyter-js-services": "^0.10.5",
     "jupyter-js-utils": "^0.4.0",
     "jupyter-js-widgets": "2.0.0-dev.0",
     "marked": "^0.3.5",

--- a/test/src/docmanager/mockcontext.ts
+++ b/test/src/docmanager/mockcontext.ts
@@ -4,7 +4,8 @@
 import expect = require('expect.js');
 
 import {
-  IKernelId, IKernel, IKernelSpecIds, ISessionId, IContentsModel
+  IKernelId, IKernel, IKernelSpecIds, ISessionId, IContentsModel,
+  IKernelLanguageInfo
 } from 'jupyter-js-services';
 
 import {
@@ -27,6 +28,60 @@ import {
   IDocumentContext, IDocumentModel
 } from '../../../lib/docregistry';
 
+
+
+/**
+ * The default kernel spec ids.
+ */
+const KERNELSPECS: IKernelSpecIds = {
+  default: 'python',
+  kernelspecs: {
+    python: {
+      name: 'python',
+      spec: {
+        language: 'python',
+        argv: [],
+        display_name: 'Python',
+        env: {}
+      },
+      resources: {}
+    },
+    shell: {
+      name: 'shell',
+      spec: {
+        language: 'shell',
+        argv: [],
+        display_name: 'Shell',
+        env: {}
+      },
+      resources: {}
+    }
+  }
+};
+
+/**
+ * The default language infos.
+ */
+const LANGUAGE_INFOS: { [key: string]: IKernelLanguageInfo } = {
+  python: {
+    name: 'python',
+    version: '1',
+    mimetype: 'text/x-python',
+    file_extension: '.py',
+    pygments_lexer: 'python',
+    codemirror_mode: 'python',
+    nbconverter_exporter: ''
+  },
+  shell: {
+    name: 'shell',
+    version: '1',
+    mimetype: 'text/x-sh',
+    file_extension: '.sh',
+    pygments_lexer: 'shell',
+    codemirror_mode: 'shell',
+    nbconverter_exporter: ''
+  }
+};
 
 
 export
@@ -69,31 +124,7 @@ class MockContext implements IDocumentContext {
   }
 
   get kernelspecs(): IKernelSpecIds {
-    return {
-      default: 'python',
-      kernelspecs: {
-        python: {
-          name: 'python',
-          spec: {
-            language: 'python',
-            argv: [],
-            display_name: 'Python',
-            env: {}
-          },
-          resources: {}
-        },
-        shell: {
-          name: 'shell',
-          spec: {
-            language: 'shell',
-            argv: [],
-            display_name: 'Shell',
-            env: {}
-          },
-          resources: {}
-        }
-      }
-    };
+    return KERNELSPECS;
   }
 
   get isDisposed(): boolean {
@@ -107,6 +138,23 @@ class MockContext implements IDocumentContext {
 
   changeKernel(options: IKernelId): Promise<IKernel> {
     this._kernel = new MockKernel(options);
+    if (options.name) {
+      let name = options.name;
+      if (!LANGUAGE_INFOS[name]) {
+        name = KERNELSPECS['default'];
+      }
+      let kernel = this._kernel as MockKernel;
+      kernel.setKernelSpec(KERNELSPECS.kernelspecs[name].spec);
+      kernel.setKernelInfo({
+        protocol_version: '1',
+        implementation: 'foo',
+        implementation_version: '1',
+        language_info: LANGUAGE_INFOS[name],
+        banner: 'Hello',
+        help_links: {}
+      });
+    }
+
     this.kernelChanged.emit(this._kernel);
     return Promise.resolve(this._kernel);
   }


### PR DESCRIPTION
We were previously getting console errors during tests because there was no kernel info or spec capability on the mock kernel.  Uses the augmented mock kernel from https://github.com/jupyter/jupyter-js-services/pull/149 to properly set/get those attributes.