### PR TITLE
Use shell=True when running npm from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ def run(cmd, cwd=None):
 
     >>> run('npm install', cwd='./subdir')
     """
-    check_call(cmd, shell=True, cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
+    # On Windows, shell should be True so that the path is searched for the command.
+    shell = (sys.platform == 'win32')
+    check_call(cmd.split(), shell=shell, cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
 
 from distutils import log
 log.set_verbosity(log.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def run(cmd, cwd=None):
 
     >>> run('npm install', cwd='./subdir')
     """
-    check_call(cmd.split(), cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
+    check_call(cmd, shell=True, cwd=cwd, stdout=sys.stdout, stderr=sys.stderr)
 
 from distutils import log
 log.set_verbosity(log.DEBUG)


### PR DESCRIPTION
On windows, using `shell=True` ensures that the path is set up so we can find npm.

Fixes #102