### PR TITLE
Remove TabBar footer bottom border and set active tab background to white

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -178,10 +178,9 @@ body {
 
 /* increase specificity to override default */
 .p-TabBar > .p-TabBar-footer {
-  flex: 0 0 3px;
-  background: #FAFAFA;
+  flex: 0 0 4px;
+  background: #FFFFFF;
   border-top: 1px solid #BDBDBD;
-  border-bottom: 1px solid #E0E0E0;
 }
 
 
@@ -207,7 +206,7 @@ body {
 .p-TabBar-tab.p-mod-current {
   min-height: 24px;
   max-height: 24px;
-  background: #FAFAFA;
+  background: #FFFFFF;
   border-top: 1px solid #F27624;
 }
 

--- a/src/editorwidget/theme.css
+++ b/src/editorwidget/theme.css
@@ -1,0 +1,7 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+.jp-EditorWidget {
+    border-top: 1px solid #E0E0E0;
+}

--- a/src/landing/index.css
+++ b/src/landing/index.css
@@ -3,7 +3,6 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 .jp-Landing {
-  background: rgba(0,0,0,0.25);
   color: #757575;
   position: absolute;
   z-index: 10000;

--- a/src/notebook/theme.css
+++ b/src/notebook/theme.css
@@ -155,7 +155,7 @@
     display: flex;
     flex-direction: row;
     background-color: #F8F8F8;
-    border-top: none;
+    border-top: 1px solid #E0E0E0;
     border-bottom: 1px solid #E0E0E0;
     height: 24px;
 }

--- a/src/notebook/theme.css
+++ b/src/notebook/theme.css
@@ -154,8 +154,6 @@
 .jp-NBToolbar {
     display: flex;
     flex-direction: row;
-    background-color: #F8F8F8;
-    border-top: 1px solid #E0E0E0;
     border-bottom: 1px solid #E0E0E0;
     height: 24px;
 }
@@ -181,11 +179,12 @@
 
 
 .jp-NBToolbar-item.jp-NBToolbar-cellType {
-    border-left: 1px solid #E0E0E0;
-    border-right: 1px solid #E0E0E0;
     flex-basis: 100px;
 }
 
+.jp-NBToolbar-item.jp-NBToolbar-cellType select {
+    background: #FFFFFF;
+}
 
 .jp-NBToolbar-cellType .jp-NBToolbar-cellTypeDropdown {
     border: none;

--- a/src/theme.css
+++ b/src/theme.css
@@ -7,5 +7,5 @@
 @import './dialog/theme.css';
 @import './filebrowser/theme.css';
 @import './terminal/theme.css';
-
+@import './editorwidget/theme.css';
 


### PR DESCRIPTION
- I removed the bottom border of the TabBar footer so as to remove vertical lines. Besides, the background color of the active tab is now white, which makes is the same color as the content of the tab in most plugins.

I think that this makes it a big closer to material design in that tabs are "material layers" and there is no horizontal line separating the tab from the content

Before:
<img width="240" alt="before" src="https://cloud.githubusercontent.com/assets/2397974/16308855/94bc83b2-3934-11e6-8475-890f1cc25a2c.png">

After:
<img width="240" alt="after" src="https://cloud.githubusercontent.com/assets/2397974/16308915/da46201e-3934-11e6-952c-c09443970602.png">

- Besides, this bottom border served as a top border in the notebook toolbar, I changed the color of the notebook toolbar to match that of the tab, and removed the vertical borders of the celltype toobar item, cf screenshot below.

Before:
<img width="263" alt="before - toolbar" src="https://cloud.githubusercontent.com/assets/2397974/16309915/714f30b0-3938-11e6-9082-9e320809f8b5.png">

After: 
<img width="249" alt="notebook toolbar" src="https://cloud.githubusercontent.com/assets/2397974/16309770/e4db1932-3937-11e6-892a-b723f9f7f4fd.png">

- Finally, there is no reason for the landing background to have a color that is used nowhere else and is not that of a tab, so I removed it. Here is a screencast of the final result.

![after](https://cloud.githubusercontent.com/assets/2397974/16310710/9d88b5ea-393b-11e6-919e-215e06bf52d5.gif)
