### PR TITLE
Simplify build step and update documents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ npm install --save jupyterlab
 git clone https://github.com/jupyter/jupyterlab.git
 cd jupyterlab
 npm install
-npm run build
+npm run build:all
 ```
 
 **Rebuild**
 
 ```bash
 npm run clean
-npm run build
+npm run build:all
 ```
 
 ### Build JupyterLab server extension

--- a/git-hooks/post-checkout
+++ b/git-hooks/post-checkout
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "rebuilding extension"
-(npm install && npm run build:serverextension) || echo "fail to rebuild javascript"
+(npm install && npm run build:all) || echo "fail to rebuild javascript"

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "rebuilding extension"
-(npm install && npm run build:serverextension) || echo "fail to rebuild javascript"
+(npm install && npm run build:all) || echo "fail to rebuild javascript"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "scripts": {
     "build": "npm run build:src",
+    "build:all": "npm run build:src && npm run build:serverextension",
     "build:examples": "node scripts/buildexamples.js",
     "build:src": "tsc --project src && node scripts/copyfiles.js",
     "build:test": "tsc --project test/src && webpack --config test/webpack.conf.js",
@@ -80,8 +81,8 @@
     "test:debug": "npm run build:test && karma start --browsers=Chrome --singleRun=false --debug=true test/karma.conf.js",
     "test:firefox": "npm run build:test && karma start --browsers=Firefox test/karma.conf.js",
     "test:ie": "npm run build:test && karma start --browsers=IE test/karma.conf.js",
-    "watch": "watch 'npm run build' src --wait 10",
-    "watch:serverextension": "watch 'npm run build:serverextension' src --wait 10",
+    "watch": "watch 'npm run build:all' src --wait 10",
+    "watch:src": "watch 'npm run build' src --wait 10",
     "watch:test": "watch 'npm run build && npm test' src test/src --wait 10"
   },
   "repository": {

--- a/tutorial/repo.md
+++ b/tutorial/repo.md
@@ -72,21 +72,34 @@ To build and install a development version of the server extension, do:
     jupyter lab
 
 ### Rebuild JavaScript
+To rebuild the javascript for both the JupyterLab source and the server extension, run:
 
-To rebuild the javascript for the server extension, do:
+    npm run build:all
+
+To rebuild JupyterLab source only, run:
+
+    npm run build:src
+
+To have the system rebuild the JupyterLab source automatically after every
+change to the typescript source files, run:
+
+    npm run watch:src
+
+To rebuild the javascript for only the server extension, run:
 
     npm run build:serverextension
 
-To have the system do this automatically after every change to the typescript
-source files, do:
 
-    npm run watch:serverextension
+To have the system do both automatically after every change to the typescript
+source files, run:
+
+    npm run watch
 
 and refresh your browser after each successful update.
 
 ### Build npm package
 
-To build just the `jupyterlab` npm package, do:
+To build just the `jupyterlab` npm package, run:
 
 	npm install
 	npm run build


### PR DESCRIPTION
While trying to resolve this issue: https://github.com/jupyter/jupyterlab/issues/148, it became clear that the first-time developer build instructions in the [README](../blob/master/README.md) were missing a call to `npm run build:serverextension`, so instead, I'm proposing `npm run build:all` that will build the source and the server extension. I am reluctant to add another line for a new developer to run.

I would have preferred to have `npm run build` do this automatically, but building the server extension creates a dependency cycle because it calls `npm install` which runs the `prepublish` script, calling build and creating an infinite loop.

cc: @fperez @blink1073 @jasongrout @willingc 