### PR TITLE
Refactor completion widget and update behaviors.

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -36,6 +36,7 @@ import {
 
 import 'jupyterlab/lib/notebook/index.css';
 import 'jupyterlab/lib/notebook/theme.css';
+import 'jupyterlab/lib/notebook/completion/index.css';
 import 'jupyterlab/lib/dialog/index.css';
 import 'jupyterlab/lib/dialog/theme.css';
 

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -49,6 +49,7 @@ import {
 
 import 'jupyterlab/lib/notebook/index.css';
 import 'jupyterlab/lib/notebook/theme.css';
+import 'jupyterlab/lib/notebook/completion/index.css';
 import 'jupyterlab/lib/dialog/index.css';
 import 'jupyterlab/lib/dialog/theme.css';
 

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -209,7 +209,7 @@ class ConsoleWidget extends Widget {
    */
   static createCompletion(): CompletionWidget {
     let model = new CompletionModel();
-    return new CompletionWidget(model);
+    return new CompletionWidget({ model });
   }
 
   /**

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -246,7 +246,7 @@ class ConsoleWidget extends Widget {
 
     // Instantiate tab completion widget.
     this._completion = constructor.createCompletion();
-    this._completion.reference = this;
+    this._completion.anchor = this.node;
     this._completion.attach(document.body);
     this._completionHandler = new CellCompletionHandler(this._completion);
     this._completionHandler.kernel = session.kernel;

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -463,19 +463,20 @@ class ConsoleWidget extends Widget {
    * Show the tooltip.
    */
   protected showTooltip(change: ITextChange, bundle: MimeMap<string>): void {
-    let { top, bottom, left } = change.coords;
-    let tooltip = this._tooltip;
-    let heightAbove = top + 1; // 1px border
-    let heightBelow = window.innerHeight - bottom - 1; // 1px border
-    let widthLeft = left;
-    let widthRight = window.innerWidth - left;
-
     // Add content and measure.
-    tooltip.content = this._rendermime.render(bundle);
-    tooltip.show();
-    let { width, height } = tooltip.node.getBoundingClientRect();
+    this._tooltip.content = this._rendermime.render(bundle);
+    this._tooltip.show();
+
+    let tooltip = this._tooltip.node;
+    let { width, height } = tooltip.getBoundingClientRect();
     let maxWidth: number;
     let maxHeight: number;
+    let { top, bottom, left } = change.coords;
+    let border = parseInt(window.getComputedStyle(tooltip).borderWidth, 10);
+    let heightAbove = top + border;
+    let heightBelow = window.innerHeight - bottom - border;
+    let widthLeft = left;
+    let widthRight = window.innerWidth - left;
 
     // Prefer displaying below.
     if (heightBelow >= height || heightBelow >= heightAbove) {
@@ -489,18 +490,17 @@ class ConsoleWidget extends Widget {
 
     // Prefer displaying on the right.
     if (widthRight >= width || widthRight >= widthLeft) {
-      // Account for 1px border width.
-      left += 1;
+      left += border;
       maxWidth = widthRight;
     } else {
       maxWidth = widthLeft;
       left -= Math.min(width, maxWidth);
     }
 
-    tooltip.node.style.top = `${top}px`;
-    tooltip.node.style.left = `${left}px`;
-    tooltip.node.style.maxHeight = `${maxHeight}px`;
-    tooltip.node.style.maxWidth = `${maxWidth}px`;
+    tooltip.style.top = `${Math.floor(top)}px`;
+    tooltip.style.left = `${Math.floor(left)}px`;
+    tooltip.style.maxHeight = `${Math.floor(maxHeight)}px`;
+    tooltip.style.maxWidth = `${Math.floor(maxWidth)}px`;
   }
 
   /**

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -422,19 +422,7 @@ class ConsoleWidget extends Widget {
    * Handle a text changed signal from an editor.
    */
   protected onTextChange(editor: CellEditorWidget, change: ITextChange): void {
-    let line = change.newValue.split('\n')[change.line];
-    let lastChar = change.ch - 1;
-    let model = this._completion.model;
-    let hasCompletion = !!model.original;
-    // If last character entered is not whitespace, update completion.
-    if (line[lastChar] && line[lastChar].match(/\S/) && hasCompletion) {
-      // Update the current completion state.
-      model.current = change;
-    } else {
-      // If final character is whitespace, reset completion.
-      model.reset();
-    }
-    // Displaying completion widget overrides displaying tooltip.
+    let hasCompletion = !!this._completion.model.original;
     if (hasCompletion) {
       this._tooltip.hide();
     } else if (change.newValue) {

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -549,8 +549,12 @@ class ConsoleWidget extends Widget {
    * Handle a completion selected signal from the completion widget.
    */
   protected onCompletionSelect(widget: CompletionWidget, value: string): void {
-    let prompt = this.prompt;
     let patch = this._completion.model.createPatch(value);
+    if (!patch) {
+      return;
+    }
+
+    let prompt = this.prompt;
     prompt.model.source = patch.text;
     prompt.editor.setCursorPosition(patch.position);
   }

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -432,9 +432,7 @@ class ConsoleWidget extends Widget {
       model.current = change;
     } else {
       // If final character is whitespace, reset completion.
-      model.options = null;
-      model.original = null;
-      model.cursor = null;
+      model.reset();
     }
     // Displaying completion widget overrides displaying tooltip.
     if (hasCompletion) {

--- a/src/index.css
+++ b/src/index.css
@@ -5,4 +5,5 @@
 |----------------------------------------------------------------------------*/
 @import './dialog/index.css';
 @import './filebrowser/index.css';
+@import './notebook/completion/index.css'
 @import './terminal/index.css';

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -137,6 +137,11 @@ interface ITextChange extends IEditorState {
 export
 interface ICompletionRequest extends IEditorState {
   /**
+   * The cursor position of the request, including line breaks.
+   */
+  position: number;
+
+  /**
    * The current value of the editor text.
    */
   currentValue: string;
@@ -328,16 +333,20 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
+    let position = editor.getDoc().indexFromPos({ line, ch })
 
     // A completion request signal should only be emitted if the final
     // character of the current line is not whitespace. Otherwise, the
     // default tab action of creating a tab character should be allowed to
     // propagate.
     if (currentLine.match(/\S$/)) {
-      let data = { line, ch, chHeight, chWidth, coords, currentValue };
+      let data = {
+        line, ch, chHeight, chWidth, coords, position, currentValue
+      };
       this.completionRequested.emit(data as ICompletionRequest);
       event.preventDefault();
       event.stopPropagation();
+      event.stopImmediatePropagation();
     }
   }
 

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -24,6 +24,10 @@ import {
   ICellModel
 } from './model';
 
+import {
+  JSONObject
+} from '../common/json';
+
 
 /**
  * The key code for the up arrow key.
@@ -53,10 +57,36 @@ const CELL_EDITOR_CLASS = 'jp-CellEditor';
 
 
 /**
- * And interface describing the state of the editor in an event.
+ * An interface describing editor state coordinates.
  */
 export
-interface IEditorState {
+interface ICoords extends JSONObject {
+  /**
+   * The left coordinate value.
+   */
+  left: number;
+
+  /**
+   * The right coordinate value.
+   */
+  right: number;
+
+  /**
+   * The top coordinate value.
+   */
+  top: number;
+
+  /**
+   * The bottom coordinate value.
+   */
+  bottom: number;
+}
+
+/**
+ * An interface describing the state of the editor in an event.
+ */
+export
+interface IEditorState extends JSONObject {
   /**
    * The character number of the editor cursor within a line.
    */
@@ -80,7 +110,7 @@ interface IEditorState {
   /**
    * The coordinate position of the cursor.
    */
-  coords: { left: number; right: number; top: number; bottom: number; };
+  coords: ICoords;
 }
 
 
@@ -256,7 +286,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     let ch = cursor.ch;
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
-    let coords = editor.charCoords({ line, ch }, 'page');
+    let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
     this.textChanged.emit({
       line, ch, chHeight, chWidth, coords, oldValue, newValue
     });
@@ -297,7 +327,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     let currentLine = currentValue.split('\n')[line];
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
-    let coords = editor.charCoords({ line, ch }, 'page');
+    let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
 
     // A completion request signal should only be emitted if the final
     // character of the current line is not whitespace. Otherwise, the
@@ -305,7 +335,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     // propagate.
     if (currentLine.match(/\S$/)) {
       let data = { line, ch, chHeight, chWidth, coords, currentValue };
-      this.completionRequested.emit(data);
+      this.completionRequested.emit(data as ICompletionRequest);
       event.preventDefault();
       event.stopPropagation();
     }

--- a/src/notebook/completion/handler.ts
+++ b/src/notebook/completion/handler.ts
@@ -99,7 +99,7 @@ class CellCompletionHandler implements IDisposable {
    * Handle a completion requested signal from an editor.
    */
   private _onCompletionRequested(editor: CellEditorWidget, change: ICompletionRequest): void {
-    if (!this.kernel) {
+    if (!this.kernel || !this._completion.model) {
       return;
     }
     this._completion.model.makeKernelRequest(change, this.kernel);
@@ -113,10 +113,12 @@ class CellCompletionHandler implements IDisposable {
       return;
     }
     let patch = this._completion.model.createPatch(value);
-    let editor = this._activeCell.editor.editor;
-    let doc = editor.getDoc();
-    doc.setValue(patch.text);
-    doc.setCursor(doc.posFromIndex(patch.position));
+    if (!patch) {
+      return;
+    }
+    let cell = this._activeCell;
+    cell.model.source = patch.text;
+    cell.editor.setCursorPosition(patch.position);
   }
 
   private _kernel: IKernel = null;

--- a/src/notebook/completion/handler.ts
+++ b/src/notebook/completion/handler.ts
@@ -92,6 +92,9 @@ class CellCompletionHandler implements IDisposable {
    * Handle a text changed signal from an editor.
    */
   private _onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
+    if (!this._completion.model) {
+      return;
+    }
     this._completion.model.handleTextChange(change);
   }
 
@@ -109,7 +112,7 @@ class CellCompletionHandler implements IDisposable {
    * Handle a completion selected signal from the completion widget.
    */
   private _onCompletionSelected(widget: CompletionWidget, value: string): void {
-    if (!this._activeCell) {
+    if (!this._activeCell || !this._completion.model) {
       return;
     }
     let patch = this._completion.model.createPatch(value);

--- a/src/notebook/completion/handler.ts
+++ b/src/notebook/completion/handler.ts
@@ -97,9 +97,8 @@ class CellCompletionHandler implements IDisposable {
    */
   private _complete(request: ICompletionRequest): void {
     let content: KernelMessage.ICompleteRequest = {
-      // Only send the current line of code for completion.
-      code: request.currentValue.split('\n')[request.line],
-      cursor_pos: request.ch
+      code: request.currentValue,
+      cursor_pos: request.position
     };
     let pending = ++this._pending;
     this._kernel.complete(content).then(msg => {

--- a/src/notebook/completion/index.css
+++ b/src/notebook/completion/index.css
@@ -1,0 +1,8 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+.jp-Completion.jp-mod-outofview {
+  display: none;
+}

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -154,13 +154,6 @@ interface ICompletionModel extends IDisposable {
 export
 class CompletionModel implements ICompletionModel {
   /**
-   * Get whether the model is disposed.
-   */
-  get isDisposed(): boolean {
-    return this._isDisposed;
-  }
-
-  /**
    * A signal emitted when state of the completion menu changes.
    */
   get stateChanged(): ISignal<ICompletionModel, void> {
@@ -267,6 +260,26 @@ class CompletionModel implements ICompletionModel {
   }
 
   /**
+   * Get whether the model is disposed.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Dispose of the resources held by the model.
+   */
+  dispose(): void {
+    // Do nothing if already disposed.
+    if (this.isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    clearSignalData(this);
+    this._reset();
+  }
+
+  /**
    * Make a request using a kernel.
    */
   makeKernelRequest(request: ICompletionRequest, kernel: IKernel): void {
@@ -350,26 +363,10 @@ class CompletionModel implements ICompletionModel {
   }
 
   /**
-   * Dispose of the resources held by the model.
-   */
-  dispose(): void {
-    // Do nothing if already disposed.
-    if (this.isDisposed) {
-      return;
-    }
-    clearSignalData(this);
-    this._isDisposed = true;
-  }
-
-  /**
-   * Reset the state of the model.
+   * Reset the state of the model and emit a state change signal.
    */
   reset() {
-    this._current = null;
-    this._original = null;
-    this._options = null;
-    this.setQuery('');
-    this.setCursor(null);
+    this._reset();
     this.stateChanged.emit(void 0);
   }
 
@@ -409,6 +406,17 @@ class CompletionModel implements ICompletionModel {
     }
     return results.sort((a, b) => { return a.score - b.score; })
       .map(result => ({ text: result.text, raw: result.raw }));
+  }
+
+  /**
+   * Reset the state of the model.
+   */
+  private _reset(): void {
+    this._current = null;
+    this._original = null;
+    this._options = null;
+    this.setQuery('');
+    this.setCursor(null);
   }
 
   private _isDisposed = false;

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -17,6 +17,10 @@ import {
   ICompletionRequest, ITextChange
 } from '../cells/editor';
 
+import {
+  deepEqual, JSONObject
+} from '../common/json';
+
 
 /**
  * A filtered completion menu matching result.
@@ -195,7 +199,10 @@ class CompletionModel implements ICompletionModel {
     return this._options;
   }
   set options(newValue: string[]) {
-    if (newValue) {
+    if (deepEqual(newValue, this._options)) {
+      return;
+    }
+    if (newValue && newValue.length) {
       this._options = [];
       this._options.push(...newValue);
     } else {
@@ -210,8 +217,11 @@ class CompletionModel implements ICompletionModel {
   get original(): ICompletionRequest {
     return this._original;
   }
-  set original(request: ICompletionRequest) {
-    this._original = request;
+  set original(newValue: ICompletionRequest) {
+    if (deepEqual(newValue, this._original)) {
+      return;
+    }
+    this._original = newValue;
     this._current = null;
     this.stateChanged.emit(void 0);
   }
@@ -223,6 +233,9 @@ class CompletionModel implements ICompletionModel {
     return this._current;
   }
   set current(newValue: ITextChange) {
+    if (deepEqual(newValue, this._current)) {
+      return;
+    }
     this._current = newValue;
 
     let original = this._original;
@@ -273,9 +286,7 @@ class CompletionModel implements ICompletionModel {
       // Update the state.
       this.options = value.matches;
       this.cursor = { start: value.cursor_start, end: value.cursor_end };
-    }).then(() => {
-      this.original = request;
-    });
+    }).then(() => { this.original = request; });
   }
 
   /**
@@ -291,10 +302,7 @@ class CompletionModel implements ICompletionModel {
       }
     } else {
       // If final character is whitespace, reset completion.
-      this.options = null;
-      this.original = null;
-      this.cursor = null;
-      return;
+      this.reset();
     }
   }
 

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -258,7 +258,7 @@ class CompletionModel implements ICompletionModel {
       // Clip the back of the current line.
       let ending = originalLine.substring(end);
       query = query.substring(0, query.lastIndexOf(ending));
-      this._query = query;
+      this.setQuery(query);
     }
     this.stateChanged.emit(void 0);
   }
@@ -363,8 +363,8 @@ class CompletionModel implements ICompletionModel {
    */
   reset() {
     this._original = null;
-    this._query = '';
-    this._cursor = null;
+    this.setQuery('');
+    this.setCursor(null);
     this._options = null;
     this.stateChanged.emit(void 0);
   }
@@ -374,6 +374,13 @@ class CompletionModel implements ICompletionModel {
    */
   protected setCursor(cursor: ICursorSpan): void {
     this._cursor = cursor;
+  }
+
+  /**
+   * Set the query value that the model filters against.
+   */
+  protected setQuery(query: string): void {
+    this._query = query;
   }
 
   /**

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -235,7 +235,7 @@ class CompletionModel implements ICompletionModel {
     if (currentLine.length < originalLine.length) {
       this.reset();
     } else {
-      let {start, end} = this._cursor;
+      let { start, end } = this._cursor;
       // Clip the front of the current line.
       let query = currentLine.substring(start);
       // Clip the back of the current line.
@@ -304,11 +304,6 @@ class CompletionModel implements ICompletionModel {
    * @param patch - The patch string to apply to the original value.
    *
    * @returns A patched text change or null if original value did not exist.
-   *
-   * #### Notes
-   * The coords field is set to null because it is calculated by the editor, so
-   * a patched version cannot reliably produce accurate coordinates for the
-   * cursor.
    */
   createPatch(patch: string): ICompletionPatch {
     let original = this._original;
@@ -318,7 +313,7 @@ class CompletionModel implements ICompletionModel {
       return null;
     }
 
-    let {start, end} = cursor;
+    let { start, end } = cursor;
     let lines = original.currentValue.split('\n');
     let line = lines[original.line];
     let prefix = line.substring(0, start);
@@ -329,7 +324,7 @@ class CompletionModel implements ICompletionModel {
 
     // Add current line to position.
     let position = prefix.length + patch.length;
-    // Add all the preceding lines lengths to position.
+    // Add all the preceding lines' lengths to position.
     for (let i = 0; i < original.line; i++) {
       // Add an extra character for the line break.
       position += lines[i].length + 1;

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -218,7 +218,7 @@ class CompletionModel implements ICompletionModel {
     }
 
     // Cursor must always be set before a text change. This happens
-    // automatically in the API response but since `current` is a public
+    // automatically in the completion handler, but since `current` is a public
     // attribute, this defensive check is necessary.
     if (!this._cursor) {
       return;

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -261,9 +261,6 @@ class CompletionModel implements ICompletionModel {
     return this._cursor;
   }
   set cursor(newValue: ICursorSpan) {
-    if (deepEqual(newValue, this._cursor)) {
-      return;
-    }
     // Original request must always be set before a cursor change. If it isn't
     // the model fails silently.
     if (!this.original) {

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -233,7 +233,6 @@ class CompletionModel implements ICompletionModel {
     // If the text change means that the original start point has been preceded,
     // then the completion is no longer valid and should be reset.
     if (currentLine.length < originalLine.length) {
-      console.log('A');
       this.reset();
     } else {
       let {start, end} = this._cursor;
@@ -355,10 +354,11 @@ class CompletionModel implements ICompletionModel {
    * Reset the state of the model.
    */
   reset() {
-    this.original = null;
-    this.options = null;
+    this._original = null;
     this._query = '';
     this._cursor = null;
+    this._options = null;
+    this.stateChanged.emit(void 0);
   }
 
   /**

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -208,6 +208,8 @@ class CompletionModel implements ICompletionModel {
     }
     this._original = newValue;
     this._current = null;
+    this.setQuery('');
+    this.setCursor(null);
     this.stateChanged.emit(void 0);
   }
 
@@ -251,6 +253,7 @@ class CompletionModel implements ICompletionModel {
     // then the completion is no longer valid and should be reset.
     if (currentLine.length < originalLine.length) {
       this.reset();
+      return;
     } else {
       let { start, end } = this._cursor;
       // Clip the front of the current line.
@@ -362,10 +365,11 @@ class CompletionModel implements ICompletionModel {
    * Reset the state of the model.
    */
   reset() {
+    this._current = null;
     this._original = null;
+    this._options = null;
     this.setQuery('');
     this.setCursor(null);
-    this._options = null;
     this.stateChanged.emit(void 0);
   }
 

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -336,21 +336,11 @@ class CompletionModel implements ICompletionModel {
     }
 
     let { start, end } = cursor;
-    let lines = original.currentValue.split('\n');
-    let line = lines[original.line];
-    let prefix = line.substring(0, start);
-    let suffix = line.substring(end);
-
-    lines[original.line] = prefix + patch + suffix;
-    let text = lines.join('\n');
-
-    // Add current line to position.
-    let position = prefix.length + patch.length;
-    // Add all the preceding lines' lengths to position.
-    for (let i = 0; i < original.line; i++) {
-      // Add an extra character for the line break.
-      position += lines[i].length + 1;
-    }
+    let value = original.currentValue;
+    let prefix = value.substring(0, start);
+    let suffix = value.substring(end);
+    let text = prefix + patch + suffix;
+    let position = (prefix + patch).length;
 
     return { position, text };
   }

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -128,6 +128,11 @@ interface ICompletionModel extends IDisposable {
   original: ICompletionRequest;
 
   /**
+   * The query against which items are filtered.
+   */
+  query: string;
+
+  /**
    * Handle a text change.
    */
   handleTextChange(change: ITextChange): void;
@@ -223,7 +228,6 @@ class CompletionModel implements ICompletionModel {
     if (!this._cursor) {
       return;
     }
-
     this._current = newValue;
 
     if (!this.current) {
@@ -248,7 +252,7 @@ class CompletionModel implements ICompletionModel {
       // Clip the back of the current line.
       let ending = originalLine.substring(end);
       query = query.substring(0, query.lastIndexOf(ending));
-      this.setQuery(query);
+      this._query = query;
     }
     this.stateChanged.emit(void 0);
   }
@@ -269,6 +273,15 @@ class CompletionModel implements ICompletionModel {
     this._cursor = newValue;
   }
 
+  /**
+   * The query against which items are filtered.
+   */
+  get query(): string {
+    return this._query;
+  }
+  set query(newValue: string) {
+    this._query = newValue;
+  }
 
   /**
    * Get whether the model is disposed.
@@ -351,13 +364,6 @@ class CompletionModel implements ICompletionModel {
   }
 
   /**
-   * Set the query value that the model filters against.
-   */
-  protected setQuery(query: string): void {
-    this._query = query;
-  }
-
-  /**
    * Apply the query to the complete options list to return the matching subset.
    */
   private _filter(): ICompletionItem[] {
@@ -389,7 +395,7 @@ class CompletionModel implements ICompletionModel {
     this._original = null;
     this._options = null;
     this._cursor = null;
-    this.setQuery('');
+    this._query = '';
   }
 
   private _isDisposed = false;

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -337,7 +337,6 @@ class CompletionWidget extends Widget {
    */
   private _evtScroll(event: MouseEvent) {
     if (!this._reference || this.isHidden) {
-      this.hide();
       return;
     }
 
@@ -349,7 +348,7 @@ class CompletionWidget extends Widget {
       }
       target = target.parentElement;
     }
-    this.hide();
+    this._model.reset();
   }
 
   private _activeIndex = 0;

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -398,12 +398,12 @@ class CompletionWidget extends Widget {
     }
     node.style.maxHeight = `${maxHeight}px`;
 
-    let borderWidth = parseInt(window.getComputedStyle(node).borderWidth, 10);
-    let left = Math.floor(coords.left) + borderWidth;
+    let border = parseInt(window.getComputedStyle(node).borderWidth, 10);
+    let left = coords.left + border
     let rect = node.getBoundingClientRect();
     let top = availableHeight - rect.height;
-    node.style.left = `${left}px`;
-    node.style.top = `${top}px`;
+    node.style.left = `${Math.floor(left)}px`;
+    node.style.top = `${Math.floor(top)}px`;
     node.style.width = 'auto';
 
     // Expand the menu width by the scrollbar size, if present.

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -389,6 +389,9 @@ class CompletionWidget extends Widget {
    */
   private _selectActive(): void {
     let active = this.node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
+    if (!active) {
+      return;
+    }
     this.selected.emit(active.dataset['value']);
     this._reset();
   }

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -329,7 +329,7 @@ class CompletionWidget extends Widget {
       }
       target = target.parentElement;
     }
-    this.hide();
+    this._model.reset();
   }
 
   /**

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -72,7 +72,7 @@ class CompletionWidget extends Widget {
   constructor(options: CompletionWidget.IOptions = {}) {
     super();
     this._renderer = options.renderer || CompletionWidget.defaultRenderer;
-    this._anchor = options.anchor || null;
+    this.anchor = options.anchor || null;
     this.model = options.model || null;
     this.addClass(COMPLETION_CLASS);
   }
@@ -118,7 +118,20 @@ class CompletionWidget extends Widget {
     return this._anchor;
   }
   set anchor(element: HTMLElement) {
+    if (this._anchor === element) {
+      return;
+    }
+    // Clean up scroll listener if anchor is being replaced.
+    if (this._anchor) {
+      this._anchor.removeEventListener('scroll', this, USE_CAPTURE);
+    }
+
     this._anchor = element;
+
+    // Add scroll listener to anchor element.
+    if (this._anchor) {
+      this._anchor.addEventListener('scroll', this, USE_CAPTURE);
+    }
   }
 
   /**
@@ -172,9 +185,6 @@ class CompletionWidget extends Widget {
   protected onAfterAttach(msg: Message): void {
     window.addEventListener('keydown', this, USE_CAPTURE);
     window.addEventListener('mousedown', this, USE_CAPTURE);
-    if (this._anchor) {
-      this._anchor.addEventListener('scroll', this, USE_CAPTURE);
-    }
   }
 
   /**

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -62,9 +62,9 @@ class CompletionWidget extends Widget {
   constructor(options: CompletionWidget.IOptions = {}) {
     super();
     this._renderer = options.renderer || CompletionWidget.defaultRenderer;
+    this._reference = options.reference || null;
     this.model = options.model || null;
     this.addClass(COMPLETION_CLASS);
-    this.update();
   }
 
 
@@ -238,7 +238,9 @@ class CompletionWidget extends Widget {
    * Handle model state changes.
    */
   protected onModelStateChanged(): void {
-    this.update();
+    if (this.isAttached) {
+      this.update();
+    }
   }
 
   /**
@@ -368,6 +370,11 @@ namespace CompletionWidget {
      * The model for the completion widget.
      */
     model?: ICompletionModel;
+
+    /**
+     * The semantic parent of the completion widget, its reference widget.
+     */
+    reference?: Widget;
 
     /**
      * The renderer for the completion widget nodes.

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -192,7 +192,10 @@ class CompletionWidget extends Widget {
     }
 
     for (let item of items) {
-      node.appendChild(this._renderer.createItemNode(item));
+      let li = this._renderer.createItemNode(item);
+      // Set the raw, un-marked up value as a data attribute.
+      li.dataset['value'] = item.raw;
+      node.appendChild(li);
     }
 
     let active = node.querySelectorAll(`.${ITEM_CLASS}`)[this._activeIndex];
@@ -226,6 +229,13 @@ class CompletionWidget extends Widget {
    * Handle model state changes.
    */
   protected onModelStateChanged(): void {
+    let items = this._model.items;
+    // If there is only one item, do not bother rendering.
+    if (items.length === 1) {
+      this.selected.emit(items[0].raw);
+      this._model.reset();
+      return;
+    }
     this.update();
   }
 
@@ -382,9 +392,6 @@ namespace CompletionWidget {
     createItemNode(item: ICompletionItem): HTMLLIElement {
       let li = document.createElement('li');
       let code = document.createElement('code');
-
-      // Set the raw, un-marked up value as a data attribute.
-      li.dataset['value'] = item.raw;
 
       // Use innerHTML because search results include <mark> tags.
       code.innerHTML = item.text;

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -179,17 +179,26 @@ class CompletionWidget extends Widget {
       return;
     }
 
-    let node = this.node;
     let items = model.items;
-    node.textContent = '';
 
-    // All repaints reset the index back to 0.
-    this._activeIndex = 0;
-
+    // If there are no items, hide and bail.
     if (!items || !items.length) {
       this.hide();
       return;
     }
+
+    // If there is only one item, signal and bail.
+    if (items.length === 1) {
+      this.selected.emit(items[0].raw);
+      this._model.reset();
+      return;
+    }
+
+    let node = this.node;
+    node.textContent = '';
+
+    // All repaints reset the index back to 0.
+    this._activeIndex = 0;
 
     for (let item of items) {
       let li = this._renderer.createItemNode(item);
@@ -229,13 +238,6 @@ class CompletionWidget extends Widget {
    * Handle model state changes.
    */
   protected onModelStateChanged(): void {
-    let items = this._model.items;
-    // If there is only one item, do not bother rendering.
-    if (items.length === 1) {
-      this.selected.emit(items[0].raw);
-      this._model.reset();
-      return;
-    }
     this.update();
   }
 

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -287,7 +287,6 @@ class CompletionWidget extends Widget {
       if (target === this._reference.node) {
         switch (event.keyCode) {
         case 13: // Enter key
-        case 9: // Tab key
           event.preventDefault();
           event.stopPropagation();
           event.stopImmediatePropagation();
@@ -301,17 +300,21 @@ class CompletionWidget extends Widget {
           event.stopImmediatePropagation();
           this._model.reset();
           return;
+        case 9: // Tab key
         case 38: // Up arrow key
         case 40: // Down arrow key
           event.preventDefault();
           event.stopPropagation();
           event.stopImmediatePropagation();
           let items = this.node.querySelectorAll(`.${ITEM_CLASS}`);
+          let index = this._activeIndex;
           active = node.querySelector(`.${ACTIVE_CLASS}`) as HTMLElement;
           active.classList.remove(ACTIVE_CLASS);
-          this._activeIndex = event.keyCode === 38 ?
-            Math.max(--this._activeIndex, 0)
-              : Math.min(++this._activeIndex, items.length - 1);
+          if (event.keyCode === 38) { // For up arrow, cycle up.
+            this._activeIndex = index === 0 ? items.length - 1 : index - 1;
+          } else { // For down arrow or tab, cycle down.
+            this._activeIndex = index < items.length - 1 ? index + 1 : 0;
+          }
           active = items[this._activeIndex] as HTMLElement;
           active.classList.add(ACTIVE_CLASS);
           Private.scrollIfNeeded(this.node, active);

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -379,7 +379,7 @@ class CompletionWidget extends Widget {
    * Set the visible dimensions of the widget.
    */
   private _setGeometry(): void {
-    if (!this._model.original) {
+    if (!this.model || !this._model.original) {
       return;
     }
 
@@ -398,8 +398,8 @@ class CompletionWidget extends Widget {
     }
     node.style.maxHeight = `${maxHeight}px`;
 
-    // Account for 1px border width.
-    let left = Math.floor(coords.left) + 1;
+    let borderWidth = parseInt(window.getComputedStyle(node).borderWidth, 10);
+    let left = Math.floor(coords.left) + borderWidth;
     let rect = node.getBoundingClientRect();
     let top = availableHeight - rect.height;
     node.style.left = `${left}px`;

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -99,7 +99,9 @@ class NotebookPanel extends Widget {
     layout.addChild(container);
 
     this._completion = this._renderer.createCompletion();
-    this._completion.reference = this;
+    // The completion widget's anchor node is the node whose scrollTop is
+    // pegged to the completion widget's position.
+    this._completion.anchor = container.node;
     this._completion.attach(document.body);
 
     this._completionHandler = new CellCompletionHandler(this._completion);

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -417,7 +417,7 @@ export namespace NotebookPanel {
      */
     createCompletion(): CompletionWidget {
       let model = new CompletionModel();
-      return new CompletionWidget(model);
+      return new CompletionWidget({ model });
     }
   }
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -14,6 +14,7 @@ import './notebook/cells/editor.spec';
 import './notebook/cells/model.spec';
 import './notebook/cells/widget.spec';
 
+import './notebook/completion/handler.spec';
 import './notebook/completion/model.spec';
 import './notebook/completion/widget.spec';
 

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
+
 import './dialog/dialog.spec';
 
 import './docregistry/default.spec';
@@ -10,8 +11,10 @@ import './renderers/latex.spec';
 import './rendermime/rendermime.spec';
 
 import './notebook/cells/editor.spec';
-import './notebook/cells/widget.spec';
 import './notebook/cells/model.spec';
+import './notebook/cells/widget.spec';
+
+import './notebook/completion/model.spec';
 
 import './notebook/notebook/actions.spec';
 import './notebook/notebook/default-toolbar.spec';

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -15,6 +15,7 @@ import './notebook/cells/model.spec';
 import './notebook/cells/widget.spec';
 
 import './notebook/completion/model.spec';
+import './notebook/completion/widget.spec';
 
 import './notebook/notebook/actions.spec';
 import './notebook/notebook/default-toolbar.spec';

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -62,7 +62,7 @@ class LogBaseCell extends BaseCellWidget {
   }
 
   protected onUpdateRequest(msg: Message): void {
-    super.onAfterAttach(msg);
+    super.onUpdateRequest(msg);
     this.methods.push('onUpdateRequest');
   }
 

--- a/test/src/notebook/completion/handler.spec.ts
+++ b/test/src/notebook/completion/handler.spec.ts
@@ -43,27 +43,29 @@ class TestCompletionHandler extends CellCompletionHandler {
   methods: string[] = [];
 
   makeRequest(request: ICompletionRequest): Promise<void> {
+    let promise = super.makeRequest(request);
     this.methods.push('makeRequest');
-    return super.makeRequest(request);
+    return promise;
   }
 
   onReply(pending: number, request: ICompletionRequest, msg: KernelMessage.ICompleteReplyMsg): void {
     super.onReply(pending, request, msg);
+    this.methods.push('onReply');
   }
 
   onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
-    this.methods.push('onTextChanged');
     super.onTextChanged(editor, change);
+    this.methods.push('onTextChanged');
   }
 
   onCompletionRequested(editor: CellEditorWidget, request: ICompletionRequest): void {
-    this.methods.push('onCompletionRequested');
     super.onCompletionRequested(editor, request);
+    this.methods.push('onCompletionRequested');
   }
 
   onCompletionSelected(widget: CompletionWidget, value: string): void {
-    this.methods.push('onCompletionSelected');
     super.onCompletionSelected(widget, value);
+    this.methods.push('onCompletionSelected');
   }
 }
 

--- a/test/src/notebook/completion/handler.spec.ts
+++ b/test/src/notebook/completion/handler.spec.ts
@@ -16,21 +16,44 @@ import {
 } from '../../../../lib/notebook/cells';
 
 import {
-  ICompletionRequest
+  ICompletionRequest, CellEditorWidget, ITextChange
 } from '../../../../lib/notebook/cells/editor';
 
 import {
-  CompletionWidget, CellCompletionHandler
+  CompletionWidget, CellCompletionHandler, CompletionModel
 } from '../../../../lib/notebook/completion';
 
 
+class TestCompletionModel extends CompletionModel {
+  methods: string[] = [];
+
+  handleTextChange(change: ITextChange): void {
+    this.methods.push('handleTextChange');
+    super.handleTextChange(change);
+  }
+}
+
+
 class TestCompletionHandler extends CellCompletionHandler {
+  methods: string[] = [];
+
   makeRequest(request: ICompletionRequest): Promise<void> {
+    this.methods.push('makeRequest');
     return super.makeRequest(request);
   }
 
   onReply(pending: number, request: ICompletionRequest, msg: KernelMessage.ICompleteReplyMsg): void {
     super.onReply(pending, request, msg);
+  }
+
+  onTextChanged(editor: CellEditorWidget, change: ITextChange): void {
+    this.methods.push('onTextChanged');
+    super.onTextChanged(editor, change);
+  }
+
+  onCompletionRequested(editor: CellEditorWidget, request: ICompletionRequest): void {
+    this.methods.push('onCompletionRequested');
+    super.onCompletionRequested(editor, request);
   }
 }
 
@@ -174,14 +197,183 @@ describe('notebook/completion/handler', () => {
     describe('#onReply()', () => {
 
       it('should do nothing if handler has been disposed', () => {
-        let handler = new TestCompletionHandler(new CompletionWidget());
+        let completion = new CompletionWidget();
+        let handler = new TestCompletionHandler(completion);
+        completion.model = new CompletionModel();
+        completion.model.options = ['foo', 'bar', 'baz'];
         handler.dispose();
         handler.onReply(0, null, null);
+        expect(completion.model).to.be.ok();
       });
 
       it('should do nothing if pending request ID does not match', () => {
+        let completion = new CompletionWidget();
+        let handler = new TestCompletionHandler(completion);
+        completion.model = new CompletionModel();
+        completion.model.options = ['foo', 'bar', 'baz'];
+        handler.onReply(2, null, null);
+        expect(completion.model).to.be.ok();
+      });
+
+      it('should reset model if status is not ok', () => {
+        let completion = new CompletionWidget();
+        let handler = new TestCompletionHandler(completion);
+        let options = ['a', 'b', 'c'];
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'f'
+        };
+        let reply: KernelMessage.ICompleteReplyMsg = {
+          header: null,
+          parent_header: {},
+          metadata: {},
+          buffers: null,
+          channel: 'shell',
+          content: {
+            status: 'error',
+            cursor_start: 0,
+            cursor_end: 0,
+            metadata: {},
+            matches: ['foo']
+          }
+        };
+        completion.model = new CompletionModel();
+        completion.model.options = options;
+        expect(completion.model.options).to.eql(options);
+        handler.onReply(0, request, reply);
+        expect(completion.model.options).to.be(null);
+      });
+
+      it('should update model if status is ok', () => {
+        let completion = new CompletionWidget();
+        let handler = new TestCompletionHandler(completion);
+        let options = ['a', 'b', 'c'];
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'f'
+        };
+        let reply: KernelMessage.ICompleteReplyMsg = {
+          header: null,
+          parent_header: {},
+          metadata: {},
+          buffers: null,
+          channel: 'shell',
+          content: {
+            status: 'ok',
+            cursor_start: 0,
+            cursor_end: 0,
+            metadata: {},
+            matches: ['foo']
+          }
+        };
+        completion.model = new CompletionModel();
+        completion.model.options = options;
+        expect(completion.model.options).to.eql(options);
+        handler.onReply(0, request, reply);
+        expect(completion.model.options).to.eql(reply.content.matches);
+      });
+
+    });
+
+    describe('#onTextChanged()', () => {
+
+      it('should fire when the active editor emits a text change', () => {
         let handler = new TestCompletionHandler(new CompletionWidget());
-        handler.onReply(1, null, null);
+        let change: ITextChange = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          oldValue: 'fo',
+          newValue: 'foo'
+        };
+        let cell = new BaseCellWidget();
+
+        handler.activeCell = cell;
+        expect(handler.methods).to.not.contain('onTextChanged');
+        cell.editor.textChanged.emit(change);
+        expect(handler.methods).to.contain('onTextChanged');
+      });
+
+      it('should call model change handler if model exists', () => {
+        let completion = new CompletionWidget({
+          model: new TestCompletionModel()
+        });
+        let handler = new TestCompletionHandler(completion);
+        let change: ITextChange = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          oldValue: 'fo',
+          newValue: 'foo'
+        };
+        let cell = new BaseCellWidget();
+        let model = completion.model as TestCompletionModel;
+
+        handler.activeCell = cell;
+        expect(model.methods).to.not.contain('handleTextChange');
+        cell.editor.textChanged.emit(change);
+        expect(model.methods).to.contain('handleTextChange');
+      });
+
+    });
+
+    describe('#onCompletionRequested()', () => {
+
+      it('should fire when the active editor emits a request', () => {
+        let handler = new TestCompletionHandler(new CompletionWidget());
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
+        };
+        let cell = new BaseCellWidget();
+
+        handler.activeCell = cell;
+        expect(handler.methods).to.not.contain('onCompletionRequested');
+        cell.editor.completionRequested.emit(request);
+        expect(handler.methods).to.contain('onCompletionRequested');
+      });
+
+      it('should make a kernel request if kernel and model exist', () => {
+        let completion = new CompletionWidget({
+          model: new TestCompletionModel()
+        });
+        let handler = new TestCompletionHandler(completion);
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
+        };
+        let cell = new BaseCellWidget();
+        let model = completion.model as TestCompletionModel;
+
+        handler.kernel = new MockKernel();
+        handler.activeCell = cell;
+        expect(handler.methods).to.not.contain('makeRequest');
+        cell.editor.completionRequested.emit(request);
+        expect(handler.methods).to.contain('makeRequest');
       });
 
     });

--- a/test/src/notebook/completion/handler.spec.ts
+++ b/test/src/notebook/completion/handler.spec.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  KernelMessage
+} from 'jupyter-js-services';
+
+import {
+  MockKernel
+} from 'jupyter-js-services/lib/mockkernel';
+
+import {
+  BaseCellWidget
+} from '../../../../lib/notebook/cells';
+
+import {
+  ICompletionRequest
+} from '../../../../lib/notebook/cells/editor';
+
+import {
+  CompletionWidget, CellCompletionHandler
+} from '../../../../lib/notebook/completion';
+
+
+class TestCompletionHandler extends CellCompletionHandler {
+  makeRequest(request: ICompletionRequest): Promise<void> {
+    return super.makeRequest(request);
+  }
+
+  onReply(pending: number, request: ICompletionRequest, msg: KernelMessage.ICompleteReplyMsg): void {
+    super.onReply(pending, request, msg);
+  }
+}
+
+
+describe('notebook/completion/handler', () => {
+
+  describe('CellCompletionHandler', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a completion handler', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        expect(handler).to.be.a(CellCompletionHandler);
+      });
+
+    });
+
+    describe('#kernel', () => {
+
+      it('should default to null', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        expect(handler.kernel).to.be(null);
+      });
+
+      it('should be settable', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        let kernel = new MockKernel();
+        expect(handler.kernel).to.be(null);
+        handler.kernel = kernel;
+        expect(handler.kernel).to.be.a(MockKernel);
+        expect(handler.kernel).to.be(kernel);
+      });
+
+    });
+
+
+    describe('#activeCell', () => {
+
+      it('should default to null', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        expect(handler.activeCell).to.be(null);
+      });
+
+      it('should be settable', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        let cell = new BaseCellWidget();
+        expect(handler.activeCell).to.be(null);
+        handler.activeCell = cell;
+        expect(handler.activeCell).to.be.a(BaseCellWidget);
+        expect(handler.activeCell).to.be(cell);
+      });
+
+      it('should be resettable', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        let one = new BaseCellWidget();
+        let two = new BaseCellWidget();
+        expect(handler.activeCell).to.be(null);
+        handler.activeCell = one;
+        expect(handler.activeCell).to.be.a(BaseCellWidget);
+        expect(handler.activeCell).to.be(one);
+        handler.activeCell = two;
+        expect(handler.activeCell).to.be.a(BaseCellWidget);
+        expect(handler.activeCell).to.be(two);
+      });
+
+    });
+
+    describe('#isDisposed', () => {
+
+      it('should be true if handler has been disposed', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        expect(handler.isDisposed).to.be(false);
+        handler.dispose();
+        expect(handler.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the handler resources', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        let kernel = new MockKernel();
+        handler.kernel = kernel;
+        expect(handler.isDisposed).to.be(false);
+        expect(handler.kernel).to.be.ok();
+        handler.dispose();
+        expect(handler.isDisposed).to.be(true);
+        expect(handler.kernel).to.not.be.ok();
+      });
+
+      it('should be safe to call multiple times', () => {
+        let handler = new CellCompletionHandler(new CompletionWidget());
+        expect(handler.isDisposed).to.be(false);
+        handler.dispose();
+        handler.dispose();
+        expect(handler.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#makeRequest()', () => {
+
+      it('should reject if handler has no kernel', (done) => {
+        let handler = new TestCompletionHandler(new CompletionWidget());
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
+        };
+        handler.makeRequest(request).catch((reason: Error) => {
+          expect(reason).to.be.an(Error);
+          done();
+        });
+      });
+
+      // TODO: This test needs to be fixed when MockKernel is updated.
+      it('should resolve if handler has a kernel', () => {
+        console.warn('This test needs to be fixed when MockKernel is updated.');
+        let handler = new TestCompletionHandler(new CompletionWidget());
+        let kernel = new MockKernel();
+        let request: ICompletionRequest = {
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
+        };
+        handler.kernel = kernel;
+        expect(handler.makeRequest(request)).to.be.a(Promise);
+      });
+
+    });
+
+    describe('#onReply()', () => {
+
+      it('should do nothing if handler has been disposed', () => {
+        let handler = new TestCompletionHandler(new CompletionWidget());
+        handler.dispose();
+        handler.onReply(0, null, null);
+      });
+
+      it('should do nothing if pending request ID does not match', () => {
+        let handler = new TestCompletionHandler(new CompletionWidget());
+        handler.onReply(1, null, null);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -4,6 +4,10 @@
 import expect = require('expect.js');
 
 import {
+  MockKernel
+} from 'jupyter-js-services/lib/mockkernel';
+
+import {
   CompletionModel, ICursorSpan, ICompletionItem
 } from '../../../../lib/notebook/completion';
 
@@ -13,10 +17,6 @@ import {
 
 
 class TestModel extends CompletionModel {
-  setCursor(cursor: ICursorSpan) {
-    super.setCursor(cursor);
-  }
-
   setQuery(query: string) {
     super.setQuery(query);
   }
@@ -119,7 +119,7 @@ describe('notebook/completion/model', () => {
         expect(called).to.be(0);
         model.original = request;
         expect(called).to.be(1);
-        model.setCursor(cursor);
+        model.cursor = cursor;
         model.current = change;
         expect(called).to.be(2);
         model.current = null;
@@ -145,7 +145,7 @@ describe('notebook/completion/model', () => {
         expect(called).to.be(0);
         model.original = request;
         expect(called).to.be(1);
-        model.setCursor(cursor);
+        model.cursor = cursor;
         model.current = change;
         model.current = change;
         expect(called).to.be(2);
@@ -241,7 +241,7 @@ describe('notebook/completion/model', () => {
         model.current = change;
         expect(model.current).to.be(null);
         model.original = request;
-        model.setCursor(cursor);
+        model.cursor = cursor;
         model.current = change;
         expect(model.current).to.be(change);
       });
@@ -262,7 +262,7 @@ describe('notebook/completion/model', () => {
         model.original = request;
         model.current = change;
         expect(model.current).to.be(null);
-        model.setCursor(cursor);
+        model.cursor = cursor;
         model.current = change;
         expect(model.current).to.be(change);
       });
@@ -281,11 +281,35 @@ describe('notebook/completion/model', () => {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
         };
         model.original = request;
-        model.setCursor(cursor);
+        model.cursor = cursor;
         model.current = change;
         expect(model.current).to.be(null);
         expect(model.original).to.be(null);
         expect(model.options).to.be(null);
+      });
+
+    });
+
+    describe('#cursor', () => {
+
+      it('should default to null', () => {
+        let model = new CompletionModel();
+        expect(model.cursor).to.be(null);
+      });
+
+      it('should not set if original request is nonexistent', () => {
+        let model = new TestModel();
+        let currentValue = 'foo';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        model.cursor = cursor;
+        expect(model.cursor).to.be(null);
+        model.original = request;
+        model.cursor = cursor;
+        expect(model.cursor).to.be(cursor);
       });
 
     });

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -192,6 +192,115 @@ describe('notebook/completion/model', () => {
 
     });
 
+    describe('#options', () => {
+
+      it('should default to null', () => {
+        let model = new CompletionModel();
+        expect(model.options).to.be(null);
+      });
+
+      it('should return model options', () => {
+        let model = new CompletionModel();
+        let options = ['foo'];
+        model.options = options;
+        expect(model.options).to.not.equal(options);
+        expect(model.options).to.eql(options);
+      });
+
+    });
+
+    describe('#original', () => {
+
+      it('should default to null', () => {
+        let model = new CompletionModel();
+        expect(model.original).to.be(null);
+      });
+
+      it('should return the original request', () => {
+        let model = new CompletionModel();
+        let currentValue = 'foo';
+        let coords: ICoords = null;
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        model.original = request;
+        expect(model.original).to.equal(request);
+      });
+
+    });
+
+    describe('#current', () => {
+
+      it('should default to null', () => {
+        let model = new CompletionModel();
+        expect(model.current).to.be(null);
+      });
+
+      it('should not set if original request is nonexistent', () => {
+        let model = new TestModel();
+        let currentValue = 'foo';
+        let oldValue = currentValue;
+        let newValue = 'foob';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let change: ITextChange = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+        };
+        model.current = change;
+        expect(model.current).to.be(null);
+        model.original = request;
+        model.setCursor(cursor);
+        model.current = change;
+        expect(model.current).to.be(change);
+      });
+
+      it('should not set if cursor is nonexistent', () => {
+        let model = new TestModel();
+        let currentValue = 'foo';
+        let oldValue = currentValue;
+        let newValue = 'foob';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let change: ITextChange = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+        };
+        model.original = request;
+        model.current = change;
+        expect(model.current).to.be(null);
+        model.setCursor(cursor);
+        model.current = change;
+        expect(model.current).to.be(change);
+      });
+
+      it('should reset model if change is shorter than original', () => {
+        let model = new TestModel();
+        let currentValue = 'foo';
+        let oldValue = currentValue;
+        let newValue = 'fo';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let change: ITextChange = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+        };
+        model.original = request;
+        model.setCursor(cursor);
+        model.current = change;
+        expect(model.current).to.be(null);
+        expect(model.original).to.be(null);
+        expect(model.options).to.be(null);
+      });
+
+    });
+
   });
 
 });

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -56,10 +56,14 @@ describe('notebook/completion/model', () => {
       it('should signal when original request changes', () => {
         let model = new CompletionModel();
         let called = 0;
-        let currentValue = 'foo';
-        let coords: ICoords = null;
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
         };
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
@@ -73,10 +77,14 @@ describe('notebook/completion/model', () => {
       it('should not signal when original request has not changed', () => {
         let model = new CompletionModel();
         let called = 0;
-        let currentValue = 'foo';
-        let coords: ICoords = null;
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
         };
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
@@ -98,7 +106,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -124,7 +138,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -207,10 +227,14 @@ describe('notebook/completion/model', () => {
 
       it('should return the original request', () => {
         let model = new CompletionModel();
-        let currentValue = 'foo';
-        let coords: ICoords = null;
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
         };
         model.original = request;
         expect(model.original).to.equal(request);
@@ -233,7 +257,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -254,7 +284,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -275,7 +311,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -299,11 +341,15 @@ describe('notebook/completion/model', () => {
 
       it('should not set if original request is nonexistent', () => {
         let model = new CompletionModel();
-        let currentValue = 'foo';
-        let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
         };
         model.cursor = cursor;
         expect(model.cursor).to.be(null);
@@ -357,7 +403,13 @@ describe('notebook/completion/model', () => {
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 4, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -376,7 +428,13 @@ describe('notebook/completion/model', () => {
         let newValue = 'foo ';
         let coords: ICoords = null;
         let request: ICompletionRequest = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: coords,
+          position: 0,
+          currentValue: currentValue
         };
         let change: ITextChange = {
           ch: 4, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
@@ -393,13 +451,17 @@ describe('notebook/completion/model', () => {
 
       it('should return a patch value', () => {
         let model = new CompletionModel();
-        let currentValue = 'foo';
         let patch = 'foobar';
         let want: ICompletionPatch = { text: patch, position: patch.length };
-        let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 3 };
         let request: ICompletionRequest = {
-          ch: 3, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: 'foo'
         };
         model.original = request;
         model.cursor = cursor;
@@ -416,10 +478,15 @@ describe('notebook/completion/model', () => {
         let currentValue = 'foo\nbar';
         let patch = 'barbaz';
         let want: ICompletionPatch = { text: 'foo\nbarbaz', position: 10 };
-        let coords: ICoords = null;
-        let cursor: ICursorSpan = { start: 0, end: 3 };
+        let cursor: ICursorSpan = { start: 4, end: 7 };
         let request: ICompletionRequest = {
-          ch: 3, chHeight: 0, chWidth: 0, line: 1, coords, currentValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          coords: null,
+          position: 0,
+          currentValue: currentValue
         };
         model.original = request;
         model.cursor = cursor;

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -1,0 +1,197 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  CompletionModel, ICursorSpan, ICompletionItem
+} from '../../../../lib/notebook/completion';
+
+import {
+  ICompletionRequest, ICoords, ITextChange
+} from '../../../../lib/notebook/cells/editor'
+
+
+class TestModel extends CompletionModel {
+  setCursor(cursor: ICursorSpan) {
+    super.setCursor(cursor);
+  }
+
+  setQuery(query: string) {
+    super.setQuery(query);
+  }
+}
+
+
+describe('notebook/completion/model', () => {
+
+  describe('CompletionModel', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a completion model', () => {
+        let model = new CompletionModel();
+        expect(model).to.be.a(CompletionModel);
+      });
+
+    });
+
+    describe('#isDisposed', () => {
+
+      it('should be true if model has been disposed', () => {
+        let model = new CompletionModel();
+        expect(model.isDisposed).to.be(false);
+        model.dispose();
+        expect(model.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#stateChanged', () => {
+
+      it('should signal when model options have changed', () => {
+        let model = new CompletionModel();
+        let called = 0;
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.options = ['foo'];
+        expect(called).to.be(1);
+        model.options = null;
+        expect(called).to.be(2);
+      });
+
+      it('should not signal when options have not changed', () => {
+        let model = new CompletionModel();
+        let called = 0;
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.options = ['foo'];
+        model.options = ['foo'];
+        expect(called).to.be(1);
+        model.options = null;
+        model.options = null;
+        expect(called).to.be(2);
+      });
+
+      it('should signal when original request changes', () => {
+        let model = new CompletionModel();
+        let called = 0;
+        let currentValue = 'foo';
+        let coords: ICoords = null;
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.original = request;
+        expect(called).to.be(1);
+        model.original = null;
+        expect(called).to.be(2);
+      });
+
+      it('should not signal when original request has not changed', () => {
+        let model = new CompletionModel();
+        let called = 0;
+        let currentValue = 'foo';
+        let coords: ICoords = null;
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.original = request;
+        model.original = request;
+        expect(called).to.be(1);
+        model.original = null;
+        model.original = null;
+        expect(called).to.be(2);
+      });
+
+      it('should signal when current text changes', () => {
+        let model = new TestModel();
+        let called = 0;
+        let currentValue = 'foo';
+        let oldValue = currentValue;
+        let newValue = 'foob';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let change: ITextChange = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+        };
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.original = request;
+        expect(called).to.be(1);
+        model.setCursor(cursor);
+        model.current = change;
+        expect(called).to.be(2);
+        model.current = null;
+        expect(called).to.be(3);
+      });
+
+      it('should not signal when current text has not change', () => {
+        let model = new TestModel();
+        let called = 0;
+        let currentValue = 'foo';
+        let oldValue = currentValue;
+        let newValue = 'foob';
+        let coords: ICoords = null;
+        let cursor: ICursorSpan = { start: 0, end: 0 };
+        let request: ICompletionRequest = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, currentValue
+        };
+        let change: ITextChange = {
+          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+        };
+        let listener = (sender: any, args: void) => { called++; };
+        model.stateChanged.connect(listener);
+        expect(called).to.be(0);
+        model.original = request;
+        expect(called).to.be(1);
+        model.setCursor(cursor);
+        model.current = change;
+        model.current = change;
+        expect(called).to.be(2);
+        model.current = null;
+        model.current = null;
+        expect(called).to.be(3);
+      });
+
+    });
+
+    describe('#items', () => {
+
+      it('should return an unfiltered list of items if query is blank', () => {
+        let model = new CompletionModel();
+        let want: ICompletionItem[] = [
+          { raw: 'foo', text: 'foo' },
+          { raw: 'bar', text: 'bar' },
+          { raw: 'baz', text: 'baz' }
+        ];
+        model.options = ['foo', 'bar', 'baz'];
+        expect(model.items).to.eql(want);
+      });
+
+      it('should return a filtered list of items if query is set', () => {
+        let model = new TestModel();
+        let want: ICompletionItem[] = [
+          { raw: 'foo', text: '<mark>f</mark>oo' }
+        ];
+        model.options = ['foo', 'bar', 'baz'];
+        model.setQuery('f');
+        expect(model.items).to.eql(want);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -12,13 +12,6 @@ import {
 } from '../../../../lib/notebook/cells/editor'
 
 
-class TestModel extends CompletionModel {
-  setQuery(query: string) {
-    super.setQuery(query);
-  }
-}
-
-
 describe('notebook/completion/model', () => {
 
   describe('CompletionModel', () => {
@@ -97,7 +90,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should signal when current text changes', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let called = 0;
         let currentValue = 'foo';
         let oldValue = currentValue;
@@ -123,7 +116,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should not signal when current text has not change', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let called = 0;
         let currentValue = 'foo';
         let oldValue = currentValue;
@@ -166,23 +159,23 @@ describe('notebook/completion/model', () => {
       });
 
       it('should return a filtered list of items if query is set', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let want: ICompletionItem[] = [
           { raw: 'foo', text: '<mark>f</mark>oo' }
         ];
         model.options = ['foo', 'bar', 'baz'];
-        model.setQuery('f');
+        model.query = 'f';
         expect(model.items).to.eql(want);
       });
 
       it('should order list based on score', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let want: ICompletionItem[] = [
           { raw: 'qux', text: '<mark>qux</mark>' },
           { raw: 'quux', text: '<mark>qu</mark>u<mark>x</mark>' }
         ];
         model.options = ['qux', 'quux'];
-        model.setQuery('qux');
+        model.query = 'qux';
         expect(model.items).to.eql(want);
       });
 
@@ -233,7 +226,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should not set if original request is nonexistent', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let currentValue = 'foo';
         let oldValue = currentValue;
         let newValue = 'foob';
@@ -254,7 +247,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should not set if cursor is nonexistent', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let currentValue = 'foo';
         let oldValue = currentValue;
         let newValue = 'foob';
@@ -275,7 +268,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should reset model if change is shorter than original', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let currentValue = 'foo';
         let oldValue = currentValue;
         let newValue = 'fo';
@@ -305,7 +298,7 @@ describe('notebook/completion/model', () => {
       });
 
       it('should not set if original request is nonexistent', () => {
-        let model = new TestModel();
+        let model = new CompletionModel();
         let currentValue = 'foo';
         let coords: ICoords = null;
         let cursor: ICursorSpan = { start: 0, end: 0 };

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -4,10 +4,6 @@
 import expect = require('expect.js');
 
 import {
-  MockKernel
-} from 'jupyter-js-services/lib/mockkernel';
-
-import {
   CompletionModel, ICursorSpan, ICompletionItem, ICompletionPatch
 } from '../../../../lib/notebook/completion';
 

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -36,17 +36,6 @@ describe('notebook/completion/model', () => {
 
     });
 
-    describe('#isDisposed', () => {
-
-      it('should be true if model has been disposed', () => {
-        let model = new CompletionModel();
-        expect(model.isDisposed).to.be(false);
-        model.dispose();
-        expect(model.isDisposed).to.be(true);
-      });
-
-    });
-
     describe('#stateChanged', () => {
 
       it('should signal when model options have changed', () => {
@@ -297,6 +286,39 @@ describe('notebook/completion/model', () => {
         expect(model.current).to.be(null);
         expect(model.original).to.be(null);
         expect(model.options).to.be(null);
+      });
+
+    });
+
+    describe('#isDisposed', () => {
+
+      it('should be true if model has been disposed', () => {
+        let model = new CompletionModel();
+        expect(model.isDisposed).to.be(false);
+        model.dispose();
+        expect(model.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the model resources', () => {
+        let model = new CompletionModel();
+        model.options = ['foo'];
+        expect(model.isDisposed).to.be(false);
+        expect(model.options).to.be.ok();
+        model.dispose();
+        expect(model.isDisposed).to.be(true);
+        expect(model.options).to.not.be.ok();
+      });
+
+      it('should be safe to call multiple times', () => {
+        let model = new CompletionModel();
+        expect(model.isDisposed).to.be(false);
+        model.dispose();
+        model.dispose();
+        expect(model.isDisposed).to.be(true);
       });
 
     });

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -102,14 +102,15 @@ describe('notebook/completion/widget', () => {
     describe('#selected', () => {
 
       it('should emit a signal when an item is selected', () => {
+        let anchor = new Widget();
         let options: CompletionWidget.IOptions = {
           model: new CompletionModel(),
-          reference: new Widget()
+          anchor: anchor.node
         };
         let value = '';
         let listener = (sender: any, selected: string) => { value = selected; };
         options.model.options = ['foo', 'bar'];
-        options.reference.attach(document.body);
+        anchor.attach(document.body);
 
         let widget = new CompletionWidget(options);
 
@@ -117,10 +118,10 @@ describe('notebook/completion/widget', () => {
         widget.attach(document.body);
         sendMessage(widget, Widget.MsgUpdateRequest);
         expect(value).to.be('');
-        simulate(options.reference.node, 'keydown', { keyCode: 13 }); // Enter
+        simulate(anchor.node, 'keydown', { keyCode: 13 }); // Enter
         expect(value).to.be('foo');
         widget.dispose();
-        options.reference.dispose();
+        anchor.dispose();
       });
 
     });
@@ -157,26 +158,26 @@ describe('notebook/completion/widget', () => {
 
     });
 
-    describe('#reference', () => {
+    describe('#anchor', () => {
 
       it('should default to null', () => {
         let widget = new CompletionWidget();
-        expect(widget.reference).to.be(null);
+        expect(widget.anchor).to.be(null);
       });
 
       it('should be settable', () => {
         let widget = new CompletionWidget();
-        expect(widget.reference).to.be(null);
-        widget.reference = new Widget();
-        expect(widget.reference).to.be.a(Widget);
+        expect(widget.anchor).to.be(null);
+        widget.anchor = new Widget().node;
+        expect(widget.anchor).to.be.a(Node);
       });
 
       it('should be safe to reset', () => {
-        let reference = new Widget();
-        let widget = new CompletionWidget({ reference: new Widget() });
-        expect(widget.reference).not.to.be(reference);
-        widget.reference = reference;
-        expect(widget.reference).to.be(reference);
+        let anchor = new Widget();
+        let widget = new CompletionWidget({ anchor: (new Widget()).node });
+        expect(widget.anchor).not.to.be(anchor.node);
+        widget.anchor = anchor.node;
+        expect(widget.anchor).to.be(anchor.node);
       });
 
     });
@@ -200,10 +201,10 @@ describe('notebook/completion/widget', () => {
 
     describe('#handleEvent()', () => {
 
-      it('should handle window keydown, mousedown, and scroll events', () => {
+      it('should handle window keydown and mousedown events', () => {
         let widget = new LogWidget();
         widget.attach(document.body);
-        ['keydown', 'mousedown', 'scroll'].forEach(type => {
+        ['keydown', 'mousedown'].forEach(type => {
           simulate(window, type);
           expect(widget.events).to.contain(type);
         });
@@ -212,12 +213,14 @@ describe('notebook/completion/widget', () => {
 
       context('keydown', () => {
 
-        it('should reset if keydown is outside reference', () => {
-          let reference = new Widget();
+        it('should reset if keydown is outside anchor', () => {
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           model.options = ['foo', 'bar'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -230,15 +233,17 @@ describe('notebook/completion/widget', () => {
           expect(widget.isHidden).to.be(true);
           expect(model.options).to.not.be.ok();
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should reset on escape key', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           model.options = ['foo', 'bar'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -246,24 +251,26 @@ describe('notebook/completion/widget', () => {
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(false);
           expect(model.options).to.be.ok();
-          simulate(reference.node, 'keydown', { keyCode: 27 }); // Escape
+          simulate(anchor.node, 'keydown', { keyCode: 27 }); // Escape
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(true);
           expect(model.options).to.not.be.ok();
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should trigger a selected signal on enter key', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           let value = '';
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
           model.options = ['foo', 'bar', 'baz'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -271,23 +278,25 @@ describe('notebook/completion/widget', () => {
           widget.attach(document.body);
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(value).to.be('');
-          simulate(reference.node, 'keydown', { keyCode: 13 }); // Enter
+          simulate(anchor.node, 'keydown', { keyCode: 13 }); // Enter
           expect(value).to.be('foo');
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should select the item below and cycle back on down', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           model.options = ['foo', 'bar', 'baz'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
           let target = document.createElement('div');
 
-          reference.node.appendChild(target);
+          anchor.node.appendChild(target);
           widget.attach(document.body);
           sendMessage(widget, Widget.MsgUpdateRequest);
 
@@ -309,15 +318,17 @@ describe('notebook/completion/widget', () => {
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should select the item above and cycle back on up', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           model.options = ['foo', 'bar', 'baz'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -329,20 +340,20 @@ describe('notebook/completion/widget', () => {
           expect(items[0].classList).to.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(reference.node, 'keydown', { keyCode: 38 }); // Up
+          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.contain(ACTIVE_CLASS);
-          simulate(reference.node, 'keydown', { keyCode: 38 }); // Up
+          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(reference.node, 'keydown', { keyCode: 38 }); // Up
+          simulate(anchor.node, 'keydown', { keyCode: 38 }); // Up
           expect(items[0].classList).to.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
       });
@@ -350,16 +361,18 @@ describe('notebook/completion/widget', () => {
       context('mousedown', () => {
 
         it('should trigger a selected signal on mouse down', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           let value = '';
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
           model.options = ['foo', 'bar', 'baz'];
           model.query = 'b';
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -373,19 +386,21 @@ describe('notebook/completion/widget', () => {
           simulate(item, 'mousedown');
           expect(value).to.be('baz');
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should ignore a mouse down that misses an item', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           let value = '';
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
           model.options = ['foo', 'bar'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -396,19 +411,21 @@ describe('notebook/completion/widget', () => {
           simulate(widget.node, 'mousedown');
           expect(value).to.be('');
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
         it('should hide widget if mouse down misses it', () => {
-          let reference = new Widget();
+          let anchor = new Widget();
           let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
+          let options: CompletionWidget.IOptions = {
+            model, anchor: anchor.node
+          };
           let value = '';
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
           model.options = ['foo', 'bar'];
-          reference.attach(document.body);
+          anchor.attach(document.body);
 
           let widget = new CompletionWidget(options);
 
@@ -416,11 +433,11 @@ describe('notebook/completion/widget', () => {
           widget.attach(document.body);
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(false);
-          simulate(options.reference.node, 'mousedown');
+          simulate(anchor.node, 'mousedown');
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(true);
           widget.dispose();
-          reference.dispose();
+          anchor.dispose();
         });
 
       });

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -1,0 +1,179 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  sendMessage
+} from 'phosphor-messaging';
+
+import {
+  Widget
+} from 'phosphor-widget';
+
+import {
+  simulate
+} from 'simulate-event';
+
+import {
+  CompletionWidget, CompletionModel, ICompletionItem
+} from '../../../../lib/notebook/completion';
+
+
+const TEST_ITEM_CLASS = 'jp-TestItem';
+
+const ITEM_CLASS = 'jp-Completion-item';
+
+const DOWN_ARROW = 40;
+
+
+class CustomRenderer extends CompletionWidget.Renderer {
+  createItemNode(item: ICompletionItem): HTMLLIElement {
+    let li = super.createItemNode(item);
+    li.classList.add(TEST_ITEM_CLASS);
+    return li;
+  }
+}
+
+
+describe('notebook/completion/widget', () => {
+
+  describe('CompletionWidget', () => {
+
+    describe('.createNode()', () => {
+
+      it('should create node for a completion widget', () => {
+        let node = CompletionWidget.createNode();
+        expect(node.tagName.toLowerCase()).to.be('ul');
+      });
+
+    });
+
+    describe('#constructor()', () => {
+
+      it('should create a completion widget', () => {
+        let widget = new CompletionWidget();
+        expect(widget).to.be.a(CompletionWidget);
+        expect(widget.node.classList).to.contain('jp-Completion');
+      });
+
+      it('should accept options with a model', () => {
+        let options: CompletionWidget.IOptions = {
+          model: new CompletionModel()
+        };
+        let widget = new CompletionWidget(options);
+        expect(widget).to.be.a(CompletionWidget);
+        expect(widget.model).to.equal(options.model);
+      });
+
+      it('should accept options with a renderer', () => {
+        let options: CompletionWidget.IOptions = {
+          model: new CompletionModel(),
+          renderer: new CustomRenderer()
+        };
+        options.model.options = ['foo', 'bar'];
+
+        let widget = new CompletionWidget(options);
+        expect(widget).to.be.a(CompletionWidget);
+        sendMessage(widget, Widget.MsgUpdateRequest);
+
+        let items = widget.node.querySelectorAll(`.${ITEM_CLASS}`);
+        expect(items).to.have.length(2);
+        expect(items[0].classList).to.contain(TEST_ITEM_CLASS);
+      });
+
+    });
+
+    describe('#selected', () => {
+
+      it('should emit a signal when an item is selected', () => {
+        let options: CompletionWidget.IOptions = {
+          model: new CompletionModel(),
+          reference: new Widget()
+        };
+        let value = '';
+        let listener = (sender: any, selected: string) => { value = selected; };
+        options.model.options = ['foo', 'bar'];
+        options.reference.attach(document.body);
+
+        let widget = new CompletionWidget(options);
+
+        widget.selected.connect(listener);
+        widget.attach(document.body);
+        sendMessage(widget, Widget.MsgUpdateRequest);
+        expect(value).to.be('');
+        simulate(options.reference.node, 'keydown', { keyCode: 13 }); // Enter
+        expect(value).to.be('foo');
+        widget.dispose();
+        options.reference.dispose();
+      });
+
+    });
+
+    describe('#model', () => {
+
+      it('should default to null', () => {
+        let widget = new CompletionWidget();
+        expect(widget.model).to.be(null);
+      });
+
+      it('should be settable', () => {
+        let widget = new CompletionWidget();
+        expect(widget.model).to.be(null);
+        widget.model = new CompletionModel();
+        expect(widget.model).to.be.a(CompletionModel);
+      });
+
+      it('should be safe to set multiple times', () => {
+        let model = new CompletionModel();
+        let widget = new CompletionWidget();
+        widget.model = model;
+        widget.model = model;
+        expect(widget.model).to.be(model);
+      });
+
+      it('should be safe to set multiple times', () => {
+        let model = new CompletionModel();
+        let widget = new CompletionWidget();
+        widget.model = model;
+        widget.model = model;
+        expect(widget.model).to.be(model);
+      });
+
+      it('should be safe to reset', () => {
+        let model = new CompletionModel();
+        let widget = new CompletionWidget({ model: new CompletionModel() });
+        expect(widget.model).not.to.be(model);
+        widget.model = model;
+        expect(widget.model).to.be(model);
+      });
+
+    });
+
+    describe('#reference', () => {
+
+      it('should default to null', () => {
+        let widget = new CompletionWidget();
+        expect(widget.reference).to.be(null);
+      });
+
+      it('should be settable', () => {
+        let widget = new CompletionWidget();
+        expect(widget.reference).to.be(null);
+        widget.reference = new Widget();
+        expect(widget.reference).to.be.a(Widget);
+      });
+
+      it('should be safe to reset', () => {
+        let reference = new Widget();
+        let widget = new CompletionWidget({ reference: new Widget() });
+        expect(widget.reference).not.to.be(reference);
+        widget.reference = reference;
+        expect(widget.reference).to.be(reference);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -418,7 +418,7 @@ describe('notebook/completion/widget', () => {
           reference.dispose();
         });
 
-        it('should hide widget if mouse down misses it', (done) => {
+        it('should hide widget if mouse down misses it', () => {
           let reference = new Widget();
           let model = new CompletionModel();
           let options: CompletionWidget.IOptions = { model, reference };
@@ -436,12 +436,58 @@ describe('notebook/completion/widget', () => {
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(false);
           simulate(options.reference.node, 'mousedown');
-          requestAnimationFrame(() => {
-            expect(widget.isHidden).to.be(true);
-            widget.dispose();
-            reference.dispose();
-            done();
-          });
+          sendMessage(widget, Widget.MsgUpdateRequest);
+          expect(widget.isHidden).to.be(true);
+          widget.dispose();
+          reference.dispose();
+        });
+
+      });
+
+      context('scroll', () => {
+
+        it('should reset if scroll is outside widget', () => {
+          let reference = new Widget();
+          let model = new CompletionModel();
+          let options: CompletionWidget.IOptions = { model, reference };
+          let target = document.createElement('div');
+          model.options = ['foo', 'bar'];
+          reference.attach(document.body);
+          reference.node.appendChild(target);
+
+          let widget = new CompletionWidget(options);
+
+          widget.attach(document.body);
+          sendMessage(widget, Widget.MsgUpdateRequest);
+          expect(widget.isHidden).to.be(false);
+          expect(model.options).to.be.ok();
+          simulate(target, 'scroll');
+          sendMessage(widget, Widget.MsgUpdateRequest);
+          expect(widget.isHidden).to.be(true);
+          expect(model.options).to.not.be.ok();
+          widget.dispose();
+          reference.dispose();
+        });
+
+        it('should allow scrolling inside the widget', () => {
+          let reference = new Widget();
+          let model = new CompletionModel();
+          let options: CompletionWidget.IOptions = { model, reference };
+          model.options = ['foo', 'bar'];
+          reference.attach(document.body);
+
+          let widget = new CompletionWidget(options);
+
+          widget.attach(document.body);
+          sendMessage(widget, Widget.MsgUpdateRequest);
+          expect(widget.isHidden).to.be(false);
+          expect(model.options).to.be.ok();
+          simulate(widget.node, 'scroll');
+          sendMessage(widget, Widget.MsgUpdateRequest);
+          expect(widget.isHidden).to.be(false);
+          expect(model.options).to.be.ok();
+          widget.dispose();
+          reference.dispose();
         });
 
       });

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -51,13 +51,6 @@ class LogWidget extends CompletionWidget {
 }
 
 
-class TestModel extends CompletionModel {
-  setQuery(query: string): void {
-    super.setQuery(query);
-  }
-}
-
-
 describe('notebook/completion/widget', () => {
 
   describe('CompletionWidget', () => {
@@ -263,7 +256,7 @@ describe('notebook/completion/widget', () => {
 
         it('should trigger a selected signal on enter key', () => {
           let reference = new Widget();
-          let model = new TestModel();
+          let model = new CompletionModel();
           let options: CompletionWidget.IOptions = { model, reference };
           let value = '';
           let listener = (sender: any, selected: string) => {
@@ -284,7 +277,7 @@ describe('notebook/completion/widget', () => {
           reference.dispose();
         });
 
-        it('should select the item below and cycle back on down or tab', () => {
+        it('should select the item below and cycle back on down', () => {
           let reference = new Widget();
           let model = new CompletionModel();
           let options: CompletionWidget.IOptions = { model, reference };
@@ -312,18 +305,6 @@ describe('notebook/completion/widget', () => {
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.contain(ACTIVE_CLASS);
           simulate(target, 'keydown', { keyCode: 40 });  // Down
-          expect(items[0].classList).to.contain(ACTIVE_CLASS);
-          expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
-          expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(target, 'keydown', { keyCode: 9 });   // Tab
-          expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
-          expect(items[1].classList).to.contain(ACTIVE_CLASS);
-          expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
-          simulate(target, 'keydown', { keyCode: 9 });   // Tab
-          expect(items[0].classList).to.not.contain(ACTIVE_CLASS);
-          expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
-          expect(items[2].classList).to.contain(ACTIVE_CLASS);
-          simulate(target, 'keydown', { keyCode: 9 });   // Tab
           expect(items[0].classList).to.contain(ACTIVE_CLASS);
           expect(items[1].classList).to.not.contain(ACTIVE_CLASS);
           expect(items[2].classList).to.not.contain(ACTIVE_CLASS);
@@ -370,14 +351,14 @@ describe('notebook/completion/widget', () => {
 
         it('should trigger a selected signal on mouse down', () => {
           let reference = new Widget();
-          let model = new TestModel();
+          let model = new CompletionModel();
           let options: CompletionWidget.IOptions = { model, reference };
           let value = '';
           let listener = (sender: any, selected: string) => {
             value = selected;
           };
           model.options = ['foo', 'bar', 'baz'];
-          model.setQuery('b');
+          model.query = 'b';
           reference.attach(document.body);
 
           let widget = new CompletionWidget(options);
@@ -438,54 +419,6 @@ describe('notebook/completion/widget', () => {
           simulate(options.reference.node, 'mousedown');
           sendMessage(widget, Widget.MsgUpdateRequest);
           expect(widget.isHidden).to.be(true);
-          widget.dispose();
-          reference.dispose();
-        });
-
-      });
-
-      context('scroll', () => {
-
-        it('should reset if scroll is outside widget', () => {
-          let reference = new Widget();
-          let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
-          let target = document.createElement('div');
-          model.options = ['foo', 'bar'];
-          reference.attach(document.body);
-          reference.node.appendChild(target);
-
-          let widget = new CompletionWidget(options);
-
-          widget.attach(document.body);
-          sendMessage(widget, Widget.MsgUpdateRequest);
-          expect(widget.isHidden).to.be(false);
-          expect(model.options).to.be.ok();
-          simulate(target, 'scroll');
-          sendMessage(widget, Widget.MsgUpdateRequest);
-          expect(widget.isHidden).to.be(true);
-          expect(model.options).to.not.be.ok();
-          widget.dispose();
-          reference.dispose();
-        });
-
-        it('should allow scrolling inside the widget', () => {
-          let reference = new Widget();
-          let model = new CompletionModel();
-          let options: CompletionWidget.IOptions = { model, reference };
-          model.options = ['foo', 'bar'];
-          reference.attach(document.body);
-
-          let widget = new CompletionWidget(options);
-
-          widget.attach(document.body);
-          sendMessage(widget, Widget.MsgUpdateRequest);
-          expect(widget.isHidden).to.be(false);
-          expect(model.options).to.be.ok();
-          simulate(widget.node, 'scroll');
-          sendMessage(widget, Widget.MsgUpdateRequest);
-          expect(widget.isHidden).to.be(false);
-          expect(model.options).to.be.ok();
           widget.dispose();
           reference.dispose();
         });

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -36,6 +36,21 @@ class CustomRenderer extends CompletionWidget.Renderer {
 }
 
 
+class LogWidget extends CompletionWidget {
+  events: string[] = [];
+
+  dispose(): void {
+    super.dispose();
+    this.events.length = 0;
+  }
+
+  handleEvent(event: Event): void {
+    super.handleEvent(event);
+    this.events.push(event.type);
+  }
+}
+
+
 describe('notebook/completion/widget', () => {
 
   describe('CompletionWidget', () => {
@@ -132,14 +147,6 @@ describe('notebook/completion/widget', () => {
         expect(widget.model).to.be(model);
       });
 
-      it('should be safe to set multiple times', () => {
-        let model = new CompletionModel();
-        let widget = new CompletionWidget();
-        widget.model = model;
-        widget.model = model;
-        expect(widget.model).to.be(model);
-      });
-
       it('should be safe to reset', () => {
         let model = new CompletionModel();
         let widget = new CompletionWidget({ model: new CompletionModel() });
@@ -170,6 +177,37 @@ describe('notebook/completion/widget', () => {
         expect(widget.reference).not.to.be(reference);
         widget.reference = reference;
         expect(widget.reference).to.be(reference);
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should dispose of the resources held by the widget', () => {
+        let widget = new CompletionWidget();
+        widget.dispose();
+        expect(widget.isDisposed).to.be(true);
+      });
+
+      it('should be safe to call multiple times', () => {
+        let widget = new CompletionWidget();
+        widget.dispose();
+        widget.dispose();
+        expect(widget.isDisposed).to.be(true);
+      });
+
+    });
+
+    describe('#handleEvent()', () => {
+
+      it('should handle window keydown, mousedown, and scroll events', () => {
+        let widget = new LogWidget();
+        widget.attach(document.body);
+        ['keydown', 'mousedown', 'scroll'].forEach(type => {
+          simulate(window, type);
+          expect(widget.events).to.contain(type);
+        });
+        widget.dispose();
       });
 
     });


### PR DESCRIPTION
- [x] When there is only one completion match, instead of rendering a completion widget just automatically fill in the value.
- [x] Refactor the completion widget to use the `IOptions` and `IRenderer` pattern.
- [x] Change the behavior of the up and down arrow keys when a completion widget is open: have them cycle through options instead of stopping at the first and last items. (This is, again, closer to what `IPython` does.)
- [x] Switch console's completion to use the `CompletionHandler` class that the notebook uses to minimize repetition.
- [x] Use `JSONObject` where applicable to use `deepEqual` checks.
- [x] Write unit tests for completion widget, model, and handler.
- [x] "Tab should not pick-up a completion." https://github.com/jupyter/jupyterlab/issues/68 To expand: change the behavior of the tab key when a completion widget is open. When every available option has a common initial substring, the tab key will "fill in" the text up to that common substring. Any other tab `keydown` will select the currently active item.
- [x] Peg completion widget's top position to the scroll position of its semantic parent.
