### PR TITLE
Make nbformat a JSON object

### DIFF
--- a/examples/console/package.json
+++ b/examples/console/package.json
@@ -23,6 +23,6 @@
     "style-loader": "^0.13.1",
     "typescript": "^1.8.10",
     "watch": "^0.18.0",
-    "webpack": "^1.13.0"
+    "webpack": "^1.13.1"
   }
 }

--- a/src/notebook/notebook/nbformat.ts
+++ b/src/notebook/notebook/nbformat.ts
@@ -5,6 +5,11 @@
 // https://nbformat.readthedocs.org/en/latest/format_description.html
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
+import {
+  JSONObject
+} from '../common/json';
+
+
 /**
  * A namespace for nbformat interfaces.
  */
@@ -26,7 +31,7 @@ namespace nbformat {
    * The kernelspec metadata.
    */
   export
-  interface IKernelspecMetadata {
+  interface IKernelspecMetadata extends JSONObject {
     name: string;
     display_name: string;
   }
@@ -35,9 +40,9 @@ namespace nbformat {
    * The language info metatda
    */
   export
-  interface ILanguageInfoMetadata {
+  interface ILanguageInfoMetadata extends JSONObject {
     name: string;
-    codemirror_mode?: any;
+    codemirror_mode?: string | JSONObject;
     file_extension?: string;
     mimetype?: string;
     pygments_lexer?: string;
@@ -48,7 +53,7 @@ namespace nbformat {
    * The default metadata for the notebook.
    */
   export
-  interface INotebookMetadata {
+  interface INotebookMetadata extends JSONObject {
     kernelspec: IKernelspecMetadata;
     language_info: ILanguageInfoMetadata;
     orig_nbformat: number;
@@ -59,7 +64,7 @@ namespace nbformat {
    * The notebook content.
    */
   export
-  interface INotebookContent {
+  interface INotebookContent extends JSONObject {
     metadata: INotebookMetadata;
     nbformat_minor: number;
     nbformat: number;
@@ -81,7 +86,7 @@ namespace nbformat {
    * A mime-type keyed dictionary of data.
    */
   export
-  interface MimeBundle {
+  interface MimeBundle extends JSONObject {
     [key: string]: multilineString;
     'application/json'?: any;
   }
@@ -98,7 +103,7 @@ namespace nbformat {
    * Cell-level metadata.
    */
   export
-  interface IBaseCellMetadata {
+  interface IBaseCellMetadata extends JSONObject {
     /**
      * Whether the cell is trusted.
      *
@@ -126,7 +131,7 @@ namespace nbformat {
    * The base cell interface.
    */
   export
-  interface IBaseCell {
+  interface IBaseCell extends JSONObject {
     /**
      * String identifying the type of cell.
      */
@@ -280,7 +285,7 @@ namespace nbformat {
    * The base output type.
    */
   export
-  interface IBaseOutput {
+  interface IBaseOutput extends JSONObject {
     /**
      * Type of cell output.
      */
@@ -311,7 +316,7 @@ namespace nbformat {
     /**
      * Cell output metadata.
      */
-    metadata: {};
+    metadata: JSONObject;
   }
 
 
@@ -333,7 +338,7 @@ namespace nbformat {
     /**
      * Cell output metadata.
      */
-    metadata: {};
+    metadata: JSONObject;
   }
 
 

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -12,6 +12,10 @@ import {
 } from 'phosphor-observablelist';
 
 import {
+  deepEqual
+} from '../../../../lib/notebook/common/json';
+
+import {
   OutputAreaModel, executeCode
 } from '../../../../lib/notebook/output-area/model';
 
@@ -93,7 +97,7 @@ describe('notebook/output-area/model', () => {
           expect(args.oldIndex).to.be(-1);
           expect(args.newIndex).to.be(0);
           expect(args.oldValue).to.be(void 0);
-          // TODO: use deepEqual when we update nbformat
+          expect(deepEqual(args.newValue, DEFAULT_OUTPUTS[0]));
           called = true;
         });
         model.add(DEFAULT_OUTPUTS[0]);
@@ -160,7 +164,6 @@ describe('notebook/output-area/model', () => {
         model.add(DEFAULT_OUTPUTS[0]);
         let output = model.get(0);
         expect(output).to.not.be(DEFAULT_OUTPUTS[0]);
-        // TODO: use deepEqual when nbformat is updated.
         expect(output.output_type).to.be(DEFAULT_OUTPUTS[0].output_type);
       });
 


### PR DESCRIPTION
- More strictly defines what types of objects there can be
- Ensures capability with `KernelMessage`, which uses `JSONObject`