### PR TITLE
Minor refactor of CodeCellWidget.execute()

### DIFF
--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IKernel
+  IKernel, KernelMessage
 } from 'jupyter-js-services';
 
 import {
@@ -436,24 +436,20 @@ class CodeCellWidget extends BaseCellWidget {
   /**
    * Execute the cell given a kernel.
    */
-  execute(kernel: IKernel): Promise<boolean> {
+  execute(kernel: IKernel): Promise<KernelMessage.IExecuteReplyMsg> {
     let model = this.model as ICodeCellModel;
     let code = model.source;
     if (!code.trim()) {
       model.executionCount = null;
-      return Promise.resolve(true);
+      return Promise.resolve(null);
     }
     model.executionCount = null;
     this.setPrompt('*');
     this.trusted = true;
     let outputs = model.outputs;
-    return outputs.execute(code, kernel).then((reply: any) => {
+    return outputs.execute(code, kernel).then(reply => {
       model.executionCount = reply.content.execution_count;
-      if (reply.content.status !== 'ok') {
-        model.executionCount = null;
-        return false;
-      }
-      return true;
+      return reply;
     });
   }
 

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -826,7 +826,12 @@ namespace Private {
       break;
     case 'code':
       if (kernel) {
-        return (widget as CodeCellWidget).execute(kernel);
+        return (widget as CodeCellWidget).execute(kernel).then(reply => {
+          if (reply)
+            return reply.content.status === 'ok';
+          else
+            return true;
+        });
       }
       (widget.model as CodeCellModel).executionCount = null;
       break;

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -827,10 +827,7 @@ namespace Private {
     case 'code':
       if (kernel) {
         return (widget as CodeCellWidget).execute(kernel).then(reply => {
-          if (reply)
-            return reply.content.status === 'ok';
-          else
-            return true;
+          return reply ? reply.content.status === 'ok' : true;
         });
       }
       (widget.model as CodeCellModel).executionCount = null;


### PR DESCRIPTION
JupyterLab is looking great so far! I'm very pleased to see that extensibility is a core design requirement and I've been developing a JupyterLab plugin to prototype an idea I had.

I need to override the cell widget's execute() method so that I can process a custom kernel payload. (I know those are deprecated, but there's no replacement yet.) I've refactored the method signature to make this possible without a copy-paste job.