### PR TITLE
Add a main menu plugin

### DIFF
--- a/examples/lab/package.json
+++ b/examples/lab/package.json
@@ -12,7 +12,7 @@
     "es6-promise": "^3.1.2",
     "jupyter-js-services": "^0.11.1",
     "jupyterlab": "file:../../",
-    "phosphide": "^0.9.4"
+    "phosphide": "^0.9.5"
   },
   "devDependencies": {
     "rimraf": "^2.5.2",

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -19,6 +19,7 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/imagewidget/plugin').imageHandlerExtension,
     require('jupyterlab/lib/landing/plugin').landingExtension,
     require('jupyterlab/lib/main/plugin').mainExtension,
+    require('jupyterlab/lib/mainmenu/plugin').mainMenuExtension,
     require('jupyterlab/lib/notebook/plugin').notebookHandlerExtension,
     require('jupyterlab/lib/shortcuts/plugin').shortcutsExtension,
     require('jupyterlab/lib/terminal/plugin').terminalExtension,
@@ -29,6 +30,7 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
     require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
     require('jupyterlab/lib/notebook/plugin').notebookTrackerProvider,
+    require('jupyterlab/lib/mainmenu/plugin').mainMenuProvider,
     require('jupyterlab/lib/rendermime/plugin').renderMimeProvider,
     require('jupyterlab/lib/services/plugin').servicesProvider,
   ]

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -10,7 +10,7 @@
     "font-awesome": "^4.6.1",
     "jupyter-js-services": "^0.11.1",
     "jupyterlab": "file:../",
-    "phosphide": "file:../../../phosphor/phosphide"
+    "phosphide": "^0.9.5"
   },
   "devDependencies": {
     "css-loader": "^0.23.1",

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -10,7 +10,7 @@
     "font-awesome": "^4.6.1",
     "jupyter-js-services": "^0.11.1",
     "jupyterlab": "file:../",
-    "phosphide": "^0.9.4"
+    "phosphide": "file:../../../phosphor/phosphide"
   },
   "devDependencies": {
     "css-loader": "^0.23.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jupyter-js-widgets": "2.0.0-dev.0",
     "marked": "^0.3.5",
     "moment": "^2.11.2",
-    "phosphide": "^0.9.4",
+    "phosphide": "^0.9.5",
     "phosphor-arrays": "^1.0.6",
     "phosphor-codemirror": "^0.0.1",
     "phosphor-di": "^0.9.0",

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -31,6 +31,12 @@ body {
 }
 
 
+#p-top-panel {
+  display: flex;
+  min-height: 24px;
+}
+
+
 .jp-Document {
   min-width: 120px;
   min-height: 120px;
@@ -266,7 +272,6 @@ body {
   color: rgba(0, 0, 0, 0.87);
   border-bottom: 1px solid #DDDDDD;
   font-size: 14px;
-  min-height: 24px;
 }
 
 

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -266,6 +266,7 @@ body {
   color: rgba(0, 0, 0, 0.87);
   border-bottom: 1px solid #DDDDDD;
   font-size: 14px;
+  min-height: 24px;
 }
 
 

--- a/src/mainmenu/plugin.ts
+++ b/src/mainmenu/plugin.ts
@@ -9,7 +9,7 @@ import {
 } from 'phosphide/lib/core/application';
 
 import {
-  MenuItem, Menu, MenuBar
+  MenuItem, MenuBar
 } from 'phosphor-menus';
 
 

--- a/src/mainmenu/plugin.ts
+++ b/src/mainmenu/plugin.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import * as arrays
+  from 'phosphor-arrays';
+
+import {
+  Application
+} from 'phosphide/lib/core/application';
+
+import {
+  MenuItem, Menu, MenuBar
+} from 'phosphor-menus';
+
+
+/**
+ * The main menu extension.
+ *
+ * #### Notes
+ * The main menu extension adds a menu bar to the top area
+ * of the application shell.
+ *
+ */
+export
+const mainMenuExtension = {
+  id: 'jupyter.extensions.mainMenu',
+  activate: activateMainMenu
+};
+
+
+/**
+ * A service providing an interface to the main menu.
+ */
+export
+const mainMenuProvider = {
+  id: 'jupyter.services.mainMenu',
+  provides: MainMenu,
+  resolve: () => {
+    return Private.mainMenu;
+  }
+};
+
+
+/**
+ * Activate the main menu extension.
+ */
+function activateMainMenu(app: Application): void {
+  Private.menuBar.id = 'jp-MainMenu';
+  app.shell.addToTopArea(Private.menuBar);
+}
+
+
+/**
+ * The main menu class.  It is intended to be used as a singleton.
+ */
+export
+class MainMenu {
+  /**
+   * Add a new menu to the main menu.
+   */
+  addMenu(menu: MenuItem, options: MainMenu.IAddMenuOptions = {}): void {
+    let rank = 'rank' in options ? options.rank : 100;
+    let rankItem = { menu, rank };
+    let index = arrays.upperBound(this._items, rankItem, Private.itemCmp);
+    arrays.insert(this._items, index, rankItem);
+    let items = Private.menuBar.items.slice();
+    arrays.insert(items, index, menu);
+    Private.menuBar.items = items;
+  }
+
+  private _items: Private.IRankItem[] = [];
+}
+
+
+/**
+ * A namespace for MainMenu statics.
+ */
+export
+namespace MainMenu {
+  /**
+   * The options used to add a menu to the main menu.
+   */
+  export
+  interface IAddMenuOptions {
+    /**
+     * The rank order of the menu among its siblings.
+     */
+    rank?: number;
+  }
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * The singleton menu bar instance.
+   */
+  export
+  const menuBar = new MenuBar();
+
+  /**
+   * The singleton main menu instance.
+   */
+  export
+  const mainMenu = new MainMenu();
+
+
+  /**
+   * An object which holds a menu and its sort rank.
+   */
+  export
+  interface IRankItem {
+    /**
+     * The menu for the item.
+     */
+    menu: MenuItem;
+
+    /**
+     * The sort rank of the menu.
+     */
+    rank: number;
+  }
+
+  /**
+   * A less-than comparison function for menu rank items.
+   */
+  export
+  function itemCmp(first: IRankItem, second: IRankItem): boolean {
+    return first.rank < second.rank;
+  }
+}

--- a/src/mainmenu/plugin.ts
+++ b/src/mainmenu/plugin.ts
@@ -56,15 +56,15 @@ function activateMainMenu(app: Application): void {
 export
 class MainMenu {
   /**
-   * Add a new menu to the main menu.
+   * Add a new menu item to the main menu.
    */
-  addMenu(menu: MenuItem, options: MainMenu.IAddMenuOptions = {}): void {
+  addItem(item: MenuItem, options: MainMenu.IAddMenuOptions = {}): void {
     let rank = 'rank' in options ? options.rank : 100;
-    let rankItem = { menu, rank };
+    let rankItem = { item, rank };
     let index = arrays.upperBound(this._items, rankItem, Private.itemCmp);
     arrays.insert(this._items, index, rankItem);
     let items = Private.menuBar.items.slice();
-    arrays.insert(items, index, menu);
+    arrays.insert(items, index, item);
     Private.menuBar.items = items;
   }
 
@@ -115,7 +115,7 @@ namespace Private {
     /**
      * The menu for the item.
      */
-    menu: MenuItem;
+    item: MenuItem;
 
     /**
      * The sort rank of the menu.

--- a/src/theme.css
+++ b/src/theme.css
@@ -8,4 +8,3 @@
 @import './filebrowser/theme.css';
 @import './terminal/theme.css';
 @import './editorwidget/theme.css';
-


### PR DESCRIPTION
<img width="415" alt="screen shot 2016-06-30 at 7 34 14 am" src="https://cloud.githubusercontent.com/assets/2096628/16488528/9522b7ba-3e96-11e6-9e70-265c9f910aa5.png">


Intended to be used as:

```typescript
const plugin = {
  id: 'my-plugin',
  requires: [MainMenu],
  activate: (app: Application, menu: MainMenu) => {
    let myItem = new MenuItem({
      text: 'foo'
    });
    menu.addItem(myItem, { rank: 10 });
  }
};
```