### PR TITLE
Moved file browser buttons above breadcrumbs

### DIFF
--- a/src/filebrowser/browser.ts
+++ b/src/filebrowser/browser.ts
@@ -112,9 +112,9 @@ class FileBrowserWidget extends Widget {
     this._listing.addClass(LISTING_CLASS);
 
     let layout = new PanelLayout();
+    layout.addChild(this._buttons);
     layout.addChild(this._crumbs);
     layout.addChild(this._listing);
-    layout.addChild(this._buttons);
 
     this.layout = layout;
   }

--- a/src/filebrowser/buttons.ts
+++ b/src/filebrowser/buttons.ts
@@ -201,7 +201,7 @@ class FileButtons extends Widget {
     });
 
     // Popup the menu aligned with the bottom of the create button.
-    dropdown.popup(rect.left, rect.top, false, false);
+    dropdown.popup(rect.left, rect.bottom, false, false);
   };
 
 
@@ -324,7 +324,7 @@ namespace Private {
     createIcon.className = ICON_CLASS + ' fa fa-plus';
     uploadIcon.className = ICON_CLASS + ' fa fa-upload';
     refreshIcon.className = ICON_CLASS + ' fa fa-refresh';
-    dropdownIcon.className = DROPDOWN_CLASS + ' fa fa-caret-up';
+    dropdownIcon.className = DROPDOWN_CLASS + ' fa fa-caret-down';
 
     createContent.appendChild(createIcon);
     createContent.appendChild(dropdownIcon);

--- a/src/filebrowser/theme.css
+++ b/src/filebrowser/theme.css
@@ -33,6 +33,7 @@
 
 .jp-FileButtons {
   border-top: 1px solid #E0E0E0;
+  padding: 8px 0 8px 0;
 }
 
 

--- a/src/filebrowser/theme.css
+++ b/src/filebrowser/theme.css
@@ -11,7 +11,7 @@
 
 
 .jp-BreadCrumbs {
-  margin: 8px;
+  margin: 4px 4px 4px 6px;
 }
 
 
@@ -33,7 +33,8 @@
 
 .jp-FileButtons {
   border-top: 1px solid #E0E0E0;
-  padding: 8px 0 8px 0;
+  border-bottom: 1px solid #E0E0E0;
+  padding: 9px 0 9px 0;
 }
 
 


### PR DESCRIPTION
We came to the conclusion that moving the add, upload, and sync buttons above the file browser would be a good choice, aesthetics-wise.

![screen shot 2016-06-30 at 1 52 06 pm](https://cloud.githubusercontent.com/assets/7052378/16503900/0b139a24-3eca-11e6-86e8-bd61b5e05739.png)
