### PR TITLE
Clean up the terminal widget

### DIFF
--- a/typings/xterm/xterm.d.ts
+++ b/typings/xterm/xterm.d.ts
@@ -3,76 +3,79 @@
 // Definitions by: Steven Silvester <https://github.com/blink1073>
 
 
-
 /**
-   * Typing for a term.js terminal object.
-   */
-  interface Terminal {
-
-    options: ITerminalConfig;
-
-    element: HTMLElement;
-
-    colors: string[];
-
-    rows: number;
-
-    cols: number;
-
-    visualBell: boolean;
-
-    popOnBell: boolean;
-
-    scrollback: number;
-
-    on(event: string, callback: (arg: any) => void): void;
-
-    open(el: HTMLElement): void;
-
-    write(msg: string): void;
-
-    resize(width: number, height: number): void;
-
-    destroy(): void;
-
-    focus(): void;
-  }
-
-  interface TerminalConstructor {
-    new (options?: ITerminalConfig): Terminal;
-    (options?: ITerminalConfig): Terminal;
-    brokenBold: boolean;
-  }
-
-/**
- * A terminal configuration.
+ * Typing for a term.js terminal object.
  */
-interface ITerminalConfig {
-  colors?: string[];
+interface Xterm {
 
-  theme?: string;
+  options: Xterm.IOptions;
 
-  convertEol?: boolean;
+  element: HTMLElement;
 
-  termName?: string;
+  colors: string[];
 
-  geometry?: number[];
+  rows: number;
 
-  cursorBlink?: boolean;
+  cols: number;
 
-  visualBell?: boolean;
+  visualBell: boolean;
 
-  popOnBell?: boolean;
+  popOnBell: boolean;
 
-  scrollback?: number;
+  scrollback: number;
 
-  debug?: boolean;
+  on(event: string, callback: (arg: any) => void): void;
 
-  cancelEvents?: boolean;
+  open(el: HTMLElement): void;
+
+  write(msg: string): void;
+
+  resize(width: number, height: number): void;
+
+  destroy(): void;
+
+  focus(): void;
 }
 
 
-declare var Xterm: TerminalConstructor;
+interface XtermConstructor {
+  new (options?: Xterm.IOptions): Xterm;
+  (options?: Xterm.IOptions): Xterm;
+  brokenBold: boolean;
+}
+
+
+/**
+ * A terminal options.
+ */
+declare module Xterm {
+  interface IOptions {
+    colors?: string[];
+
+    theme?: string;
+
+    convertEol?: boolean;
+
+    termName?: string;
+
+    geometry?: number[];
+
+    cursorBlink?: boolean;
+
+    visualBell?: boolean;
+
+    popOnBell?: boolean;
+
+    scrollback?: number;
+
+    debug?: boolean;
+
+    cancelEvents?: boolean;
+  }
+}
+
+
+declare var Xterm: XtermConstructor;
 
 
 declare module 'xterm' {


### PR DESCRIPTION
Fixes a bug found in #205.

Also updates the widget for the current patterns used in the repo.

cc @charnpreetsingh185

Screenshot with the code from #206 applied to the example:

<img width="788" alt="screen shot 2016-07-01 at 6 29 47 am" src="https://cloud.githubusercontent.com/assets/2096628/16520362/491a9616-3f55-11e6-9b36-8c2596245a74.png">
