### PR TITLE
Fix mainmenu and notebook services

### DIFF
--- a/src/mainmenu/plugin.ts
+++ b/src/mainmenu/plugin.ts
@@ -14,43 +14,6 @@ import {
 
 
 /**
- * The main menu extension.
- *
- * #### Notes
- * The main menu extension adds a menu bar to the top area
- * of the application shell.
- *
- */
-export
-const mainMenuExtension = {
-  id: 'jupyter.extensions.mainMenu',
-  activate: activateMainMenu
-};
-
-
-/**
- * A service providing an interface to the main menu.
- */
-export
-const mainMenuProvider = {
-  id: 'jupyter.services.mainMenu',
-  provides: MainMenu,
-  resolve: () => {
-    return Private.mainMenu;
-  }
-};
-
-
-/**
- * Activate the main menu extension.
- */
-function activateMainMenu(app: Application): void {
-  Private.menuBar.id = 'jp-MainMenu';
-  app.shell.addToTopArea(Private.menuBar);
-}
-
-
-/**
  * The main menu class.  It is intended to be used as a singleton.
  */
 export
@@ -87,6 +50,43 @@ namespace MainMenu {
      */
     rank?: number;
   }
+}
+
+
+/**
+ * The main menu extension.
+ *
+ * #### Notes
+ * The main menu extension adds a menu bar to the top area
+ * of the application shell.
+ *
+ */
+export
+const mainMenuExtension = {
+  id: 'jupyter.extensions.mainMenu',
+  activate: activateMainMenu
+};
+
+
+/**
+ * A service providing an interface to the main menu.
+ */
+export
+const mainMenuProvider = {
+  id: 'jupyter.services.mainMenu',
+  provides: MainMenu,
+  resolve: () => {
+    return Private.mainMenu;
+  }
+};
+
+
+/**
+ * Activate the main menu extension.
+ */
+function activateMainMenu(app: Application): void {
+  Private.menuBar.id = 'jp-MainMenu';
+  app.shell.addToTopArea(Private.menuBar);
 }
 
 

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -76,6 +76,13 @@ const cmdIds = {
 
 
 /**
+ * A class that tracks notebook widgets.
+ */
+export
+class NotebookTracker extends WidgetTracker<NotebookPanel> { }
+
+
+/**
  * The notebook file handler extension.
  */
 export
@@ -97,13 +104,6 @@ const notebookTrackerProvider = {
     return Private.notebookTracker;
   }
 };
-
-
-/**
- * A class that tracks notebook widgets.
- */
-export
-class NotebookTracker extends WidgetTracker<NotebookPanel> { }
 
 
 /**


### PR DESCRIPTION
The exported class must be defined before the service object is created, or it will provide `undefined`.