### PR TITLE
Fixed file browser glitches

### DIFF
--- a/src/filebrowser/theme.css
+++ b/src/filebrowser/theme.css
@@ -34,7 +34,6 @@
 .jp-FileButtons {
   border-top: 1px solid #E0E0E0;
   border-bottom: 1px solid #E0E0E0;
-  padding: 9px 0;
 }
 
 
@@ -47,6 +46,8 @@
   border: none;
   font-size: 16px;
   outline: 0;
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 


### PR DESCRIPTION
Fixes:
- Line alignment with "Files" tab.
<img width="337" alt="screen shot 2016-07-01 at 5 31 22 pm" src="https://cloud.githubusercontent.com/assets/12474166/16537228/3d634482-3fb2-11e6-984d-a6172447e913.png">

- Hover background now spans the entire button.
<img width="336" alt="screen shot 2016-07-01 at 5 31 36 pm" src="https://cloud.githubusercontent.com/assets/12474166/16537230/4895b790-3fb2-11e6-8c90-fd4db3eb2fdc.png">

(Part of the Jupyter Cal Poly team along with @eskirk @rnetro @matt-bowers)