### PR TITLE
Proof of Concept for Third Party Extensions

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -9,8 +9,7 @@ require('es6-promise').polyfill();
 require('font-awesome/css/font-awesome.min.css');
 require('jupyterlab/lib/default-theme/index.css');
 
-var app = new phosphide.Application({
-  extensions: [
+var extensions = [
     require('jupyterlab/lib/about/plugin').aboutExtension,
     require('jupyterlab/lib/console/plugin').consoleExtension,
     require('jupyterlab/lib/editorwidget/plugin').editorHandlerExtension,
@@ -25,17 +24,17 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/terminal/plugin').terminalExtension,
     require('jupyterlab/lib/widgets/plugin').widgetManagerExtension,
     require('phosphide/lib/extensions/commandpalette').commandPaletteExtension,
-  ],
-  providers: [
+];
+var providers = [
     require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
     require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
     require('jupyterlab/lib/notebook/plugin').notebookTrackerProvider,
     require('jupyterlab/lib/mainmenu/plugin').mainMenuProvider,
     require('jupyterlab/lib/rendermime/plugin').renderMimeProvider,
     require('jupyterlab/lib/services/plugin').servicesProvider,
-  ]
-});
+];
 
-window.onload = function() {
-    app.run();
+module.exports = {
+    extensions: extensions,
+    providers: providers
 }

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -28,8 +28,17 @@ Distributed under the terms of the Modified BSD License.
 }</script>
 <script src="{{static_prefix}}/jupyter-js-services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/main.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/app.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script>
+var app = new phosphide.Application({
+  extensions: Window['jupyterlab-app'].extensions
+  providers: Window['jupyterlab-app'].providers
+});
 
+window.onload = function() {
+    app.run();
+}
+</script>
 </body>
-
 </html>

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -26,7 +26,9 @@ Distributed under the terms of the Modified BSD License.
   "wsUrl": "{{ws_url| urlencode}}",
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
-<script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyter-js-services.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/main.bundle.js" type="text/javascript" charset="utf-8"></script>
 
 </body>
 

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -32,8 +32,8 @@ Distributed under the terms of the Modified BSD License.
 <script src="{{static_prefix}}/app.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script>
 var app = new phosphide.Application({
-  extensions: Window['jupyterlab-app'].extensions
-  providers: Window['jupyterlab-app'].providers
+  extensions: jupyter.plugins.extensions
+  providers: jupyter.plugins.providers
 });
 
 window.onload = function() {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -14,7 +14,9 @@
   },
   "devDependencies": {
     "css-loader": "^0.23.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
+    "find-imports": "^0.5.0",
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -1,12 +1,55 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+var webpack = require('webpack');
+var glob = require('glob');
+
 // Support for Node 0.10
 // See https://github.com/webpack/css-loader/issues/144
 require('es6-promise').polyfill();
 
+// The list of known vendor libraries/files.
+var vendorFiles = [
+  'ansi_up',
+  'backbone',
+  'codemirror',
+  'codemirror/addon/mode/multiplex.js',
+  'codemirror/lib/codemirror.css',
+  'codemirror/mode/meta.js',
+  'codemirror/mode/python/python.js',
+  'codemirror/mode/stex/stex.js',
+  'codemirror/mode/gfm/gfm.js',
+  'codemirror/mode/javascript/javascript.js',
+  'codemirror/mode/css/css.js',
+  'codemirror/mode/julia/julia.js',
+  'codemirror/mode/r/r.js',
+  'codemirror/mode/markdown/markdown.js',
+  'codemirror/lib/codemirror.css',
+  'diff-match-patch',
+  'es6-promise',
+  'font-awesome/css/font-awesome.min.css',
+  'jquery-ui/themes/smoothness/jquery-ui.min.css',
+  'jupyter-js-widgets',
+  'jupyter-js-widgets/css/widgets.min.css',
+  'marked',
+  'moment',
+  'sanitizer',
+  'simulate-event',
+  'xterm',
+  'xterm/src/xterm.css'
+]
+// Manually add all phosphor entry points.
+// (This will be replaced with a glob of the condensed phosphor library)
+glob.sync("node_modules/phosphor-*/**/index.js").forEach(function(file) {
+  vendorFiles.push(file.replace('node_modules/', ''));
+});
+
+
 module.exports = {
-  entry: './index.js',
+  entry: {
+    main: './index.js',
+    vendor: vendorFiles
+  },
   output: {
     path: __dirname + "/build",
     filename: "bundle.js",
@@ -23,18 +66,22 @@ module.exports = {
       { test: /\.css$/, loader: 'style-loader!css-loader' },
       { test: /\.json$/, loader: 'json-loader' },
       { test: /\.html$/, loader: 'file'},
+      { test: /\.svg$/, loader: 'file' },
       // jquery-ui loads some images
       { test: /\.(jpg|png|gif)$/, loader: "file" },
       // required to load font-awesome
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/font-woff" },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/font-woff" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=application/octet-stream" },
+      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
       { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&minetype=image/svg+xml" }
+      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
     ]
   },
   externals: {
     jquery: '$',
     'jquery-ui': '$'
-  }
+  },
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js"),
+  ]
 }

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -42,7 +42,7 @@ module.exports = [
   },
   output: {
     path: __dirname + "/build",
-    library: '[name]',
+    library: ['jupyter', 'lab'],
     libraryTarget: 'umd',
     filename: "[name].bundle.js",
     publicPath: "lab/"
@@ -89,7 +89,7 @@ module.exports = [
     output: {
         filename: 'jupyter-js-services.bundle.js',
         path: './build',
-        library: 'jupyter-js-services',
+        library: ['jupyter', 'services'],
         libraryTarget: 'umd',
     },
     module: {
@@ -115,7 +115,7 @@ module.exports = [
    output: {
         filename: 'app.bundle.js',
         path: './build',
-        libary: 'jupyterlab-app',
+        libary: ['jupyter', 'plugins'],
         libraryTarget: 'umd'
    },
    externals: [

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -9,6 +9,21 @@ var findImports = require('find-imports');
 // See https://github.com/webpack/css-loader/issues/144
 require('es6-promise').polyfill();
 
+// Set up the loaders.
+var loaders = [
+  { test: /\.css$/, loader: 'style-loader!css-loader' },
+  { test: /\.json$/, loader: 'json-loader' },
+  { test: /\.html$/, loader: 'file'},
+  // jquery-ui loads some images
+  { test: /\.(jpg|png|gif)$/, loader: "file" },
+  // required to load font-awesome
+  { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+  { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
+  { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
+  { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
+  { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
+]
+
 // Get the list of vendor files.
 console.log('Finding vendored files...')
 var vendorFiles = findImports('../lib/**/*.js', { flatten: true });
@@ -18,9 +33,11 @@ console.log('Vendored files:\n', vendorFiles)
 // Build the bundles.
 console.log('\nBuilding webpack bundles...')
 
-module.exports = [{
+module.exports = [
+// Jupyterlab umd bundle
+{
   entry: {
-    main: './index.js',
+    main: './index.js',  // this will become jupyterlab/lib/api.js
     vendor: vendorFiles
   },
   output: {
@@ -37,29 +54,36 @@ module.exports = [{
   bail: true,
   devtool: 'inline-source-map',
   module: {
-    loaders: [
-      { test: /\.css$/, loader: 'style-loader!css-loader' },
-      { test: /\.json$/, loader: 'json-loader' },
-      { test: /\.html$/, loader: 'file'},
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, loader: "file" },
-      // required to load font-awesome
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/font-woff" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=application/octet-stream" },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: "url?limit=10000&mimetype=image/svg+xml" }
-    ]
+    loaders: loaders
   },
   externals: {
     jquery: '$',
     'jquery-ui': '$',
-    'jupyter-js-services': 'umd jupyter-js-services'
+    'jupyter-js-services': 'umd jupyter-js-services',
+    'codemirror': 'codemirror',
+    'codemirror/lib/codemirror': 'codemirror',
+    '../lib/codemirror': 'codemirror',
+    '../../lib/codemirror': 'codemirror',
+    'phosphide': 'umd phosphide'
   },
   plugins: [
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
   ]
+}, 
+// Codemirror umd bundle
+{
+   entry: 'codemirror',
+   output: {
+      filename: 'codemirror.bundle.js',
+      path: './build',
+      libraryTarget: 'umd',
+      library: 'codemirror'
+   },
+   module: {
+    loaders: loaders
+   }
 },
+// Jupyter-js-services umd bundle
 {
     entry: 'jupyter-js-services',
     output: {
@@ -67,5 +91,46 @@ module.exports = [{
         path: './build',
         library: 'jupyter-js-services',
         libraryTarget: 'umd',
-    }
+    },
+    module: {
+      loaders: loaders
+    },
+},
+// Phosphide umd bundle (this will become phosphor bundle).
+{
+   entry: 'phosphide/lib/core/application',
+   output: {
+        filename: 'phosphide.bundle.js',
+        path: './build',
+        library: 'phosphide',
+        libraryTarget: 'umd'
+   },
+   module: {
+    loaders: loaders
+   },
+},
+// default plugins umd bundle
+{
+   entry: './index.js',
+   output: {
+        filename: 'app.bundle.js',
+        path: './build',
+        libary: 'jupyterlab-app',
+        libraryTarget: 'umd'
+   },
+   externals: [
+      function(context, request, callback) {
+        if (/^jupyterlab\//.test(request)) {
+            return callback(null, "jupyterlab");
+        }
+        // This will become phosphor
+        if (/^phosphide\//.test(request)) {
+            return callback(null, "phosphide")
+        }
+        callback();
+      }
+  ],
+    module: {
+    loaders: loaders
+  },
 }]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "codemirror": "^5.12.0",
     "diff-match-patch": "^1.0.0",
     "es6-promise": "^3.2.1",
-    "file-loader": "^0.8.5",
     "jquery": "^2.2.0",
     "jquery-ui": "^1.10.5",
     "jupyter-js-services": "^0.11.3",


### PR DESCRIPTION
cf #224.

This is also a test of automatically moving vendor files to a vendor bundle.

The public API of JupyterLab would be (available as a script tags in the final app):
- `jupyterlab/lib/api` - available as `jupyter.lab` as a global variable.
- CodeMirror core - to allow external addons/themes
- jupyter-js-services - available as `jupyter.services` as a global variable.
- phosphor - cf https://github.com/phosphorjs/phosphor/pull/105

Implementation/verification steps:
- Switch to phosphor mono repo
- Create `jupyterlab/src/api.ts`
- Replace jupyter-js-widgets plugin with an external bundle
- Make jupyter-js-widgets a true third-party extension
