### PR TITLE
Adding a notebook-like border to active console line

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -386,3 +386,22 @@ body {
 .p-Menu-item.p-type-submenu > .p-Menu-itemSubmenuIcon::before {
   content: '\f0da';
 }
+
+
+.p-Widget.jp-Cell.jp-CodeCell.jp-mod-collapsed {
+  border-color: #ABABAB;
+  border-left-width: 1px;
+  background: linear-gradient(to right, #42A5F5 -40px, #42A5F5 5px, transparent 5px, transparent 100%);
+}
+
+
+.p-Widget.jp-Cell.jp-CodeCell.jp-mod-collapsed.jp-mod-readOnly {
+  padding-left: 5px;
+  padding-right: 5px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: transparent;
+  outline: none;
+  background: transparent;
+  border-color: transparent;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,5 +5,5 @@
 |----------------------------------------------------------------------------*/
 @import './dialog/index.css';
 @import './filebrowser/index.css';
-@import './notebook/completion/index.css'
+@import './notebook/completion/index.css';
 @import './terminal/index.css';


### PR DESCRIPTION
This outline makes it easier for users to understand/use the console.
It shows them what input they are working on (and lets them know they can't edit past inputs) 

![screen shot 2016-07-05 at 2 51 17 pm](https://cloud.githubusercontent.com/assets/18707693/16601300/8d287972-42c0-11e6-962f-614401bbfffb.png)

(Team Callisto: @eskirk @roshancvp @matt-bowers)