### PR TITLE
Remove more chrome

### DIFF
--- a/src/default-theme/commandpalette.css
+++ b/src/default-theme/commandpalette.css
@@ -42,7 +42,7 @@
 
 
 .p-CommandPalette-command {
-  padding: 4px 12px 4px 4px;
+  padding: 4px 12px 4px 12px;
   font-size: 14px;
   font-weight: 500;
 }

--- a/src/default-theme/commandpalette.css
+++ b/src/default-theme/commandpalette.css
@@ -4,7 +4,6 @@
 |----------------------------------------------------------------------------*/
 .p-CommandPalette {
   min-width: 300px;
-  padding: 8px;
   padding-bottom: 0px;
   color: #757575;
   background: #FAFAFA;
@@ -18,6 +17,7 @@
 
 .p-CommandPalette-inputWrapper {
   padding: 4px 6px;
+  margin: 4px;
   background: white;
   border: 1px solid #E0E0E0;
   border-radius: 4px;
@@ -33,7 +33,7 @@
 
 .p-CommandPalette-header {
   margin: 4px 0px;
-  padding: 4px 0px;
+  padding: 4px 2px;
   font-size: 11px;
   font-weight: 500;
   text-transform: capitalize;
@@ -42,7 +42,7 @@
 
 
 .p-CommandPalette-command {
-  padding: 4px;
+  padding: 4px 12px 4px 4px;
   font-size: 14px;
   font-weight: 500;
 }

--- a/src/filebrowser/index.css
+++ b/src/filebrowser/index.css
@@ -17,7 +17,6 @@
   flex: 0 0 auto;
   display: flex;
   flex-direction: row;
-  justify-content: center;
 }
 
 

--- a/src/filebrowser/theme.css
+++ b/src/filebrowser/theme.css
@@ -45,8 +45,8 @@
   border: none;
   font-size: 14px;
   outline: 0;
-  padding-top: 12px;
-  padding-bottom: 12px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 


### PR DESCRIPTION
Removing some odd padding in the command palette, unifying its style with the one of the file browser.

Before (the vertical lines don't span the whole width, the scroll bars hover the content of the tab, there is ununsed space on the right)
<img width="341" alt="screen shot 2016-07-07 at 7 36 55 am" src="https://cloud.githubusercontent.com/assets/2397974/16652035/b815ba7c-4415-11e6-9ad2-67b8e514adf6.png">

After (I just made the world a better place)
<img width="345" alt="screen shot 2016-07-07 at 5 34 40 am" src="https://cloud.githubusercontent.com/assets/2397974/16652027/afb5d95c-4415-11e6-8f6d-6eff5c434200.png">

