### PR TITLE
Avoid tabbar border juxtaposition

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -165,6 +165,7 @@ body {
   max-height: 28px;
   color: #777777;
   font-size: 14px;
+  margin-right: -1px;
 }
 
 
@@ -177,6 +178,7 @@ body {
 .p-TabBar-content {
   min-width: 0;
   max-height: 22px;
+  padding-right: 1px;
 }
 
 


### PR DESCRIPTION
Before (juxtaposition of borders)
<img width="562" alt="screen shot 2016-07-07 at 7 59 34 am" src="https://cloud.githubusercontent.com/assets/2397974/16652463/d2f102c2-4418-11e6-9605-d73cf22426de.png">

After (the world is a better place)
<img width="599" alt="screen shot 2016-07-07 at 7 57 38 am" src="https://cloud.githubusercontent.com/assets/2397974/16652422/8eba26ba-4418-11e6-9e30-93347fda0c6e.png">

The right-padding of the tabBar content div is meant to avoid overflow on the right-hand side when the tabBar is full.

