### PR TITLE
Fix handling of kernels on notebook startup

### DIFF
--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -26,7 +26,7 @@ import {
 } from 'phosphor-widget';
 
 import {
-  IDocumentContext
+  IDocumentContext, findKernel
 } from '../../docregistry';
 
 import {
@@ -263,9 +263,18 @@ class NotebookPanel extends Widget {
    * Handle a context population.
    */
   protected onPopulated(sender: IDocumentContext<INotebookModel>, args: void): void {
+    let model = sender.model;
     // Clear the undo state of the cells.
-    if (sender.model) {
-      sender.model.cells.clearUndo();
+    if (model) {
+      model.cells.clearUndo();
+    }
+    if (!sender.kernel && model) {
+      let name = findKernel(
+        model.defaultKernelName,
+        model.defaultKernelLanguage,
+        sender.kernelspecs
+      );
+      sender.changeKernel({ name });
     }
   }
 

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -6,7 +6,7 @@ import {
 } from 'jupyter-js-services';
 
 import {
-  ABCWidgetFactory, IDocumentContext, findKernel
+  ABCWidgetFactory, IDocumentContext
 } from '../../docregistry';
 
 import {
@@ -73,12 +73,8 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    */
   createNew(context: IDocumentContext<INotebookModel>, kernel?: IKernel.IModel): NotebookPanel {
     let rendermime = this._rendermime.clone();
-    let model = context.model;
     if (kernel) {
       context.changeKernel(kernel);
-    } else {
-      let name = findKernel(model.defaultKernelName, model.defaultKernelLanguage, context.kernelspecs);
-      context.changeKernel({ name });
     }
     let panel = new NotebookPanel({ rendermime, clipboard: this._clipboard });
     panel.context = context;

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -166,15 +166,6 @@ describe('notebook/notebook/panel', () => {
         expect(called).to.be(true);
       });
 
-      it('should not be emitted when the kernel does not change', () => {
-        let panel = createPanel();
-        let called = false;
-        panel.kernelChanged.connect(() => { called = true; });
-        let context = new MockContext<INotebookModel>(panel.model);
-        panel.context = context;
-        expect(called).to.be(false);
-      });
-
     });
 
     describe('#toolbar', () => {
@@ -209,9 +200,9 @@ describe('notebook/notebook/panel', () => {
 
       it('should be the current kernel used by the panel', () => {
         let panel = createPanel();
-        expect(panel.kernel).to.be(null);
-        panel.context.changeKernel({ name: 'python' });
         expect(panel.kernel.name).to.be('python');
+        panel.context.changeKernel({ name: 'shell' });
+        expect(panel.kernel.name).to.be('shell');
       });
 
       it('should be read-only', () => {


### PR DESCRIPTION
Fixes #266.  This problem was introduced when we got rid of the `DocumentWrapper` and forced the widgets to be created synchronously.  The default kernel was being started because we did not have the metadata when the notebook widget was created.  This defers starting a kernel until the context is populated, unless an explicit kernel is given to the widget factory method.