### PR TITLE
Add promise typings to jupyter-js-widgets typing file.

### DIFF
--- a/typings/jupyter-js-widgets/jupyter-js-widgets.d.ts
+++ b/typings/jupyter-js-widgets/jupyter-js-widgets.d.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+/// <reference path="../es6-promise/es6-promise.d.ts"/>
 /// <reference path="../backbone/backbone-global.d.ts" />
 
 


### PR DESCRIPTION
cc: @jasongrout  @SylvainCorlay 

Just a quick fix.