### PR TITLE
Made notebook output area transparent

### DIFF
--- a/src/notebook/theme.css
+++ b/src/notebook/theme.css
@@ -67,7 +67,7 @@
 
 
 .jp-OutputArea {
-  background: #FFFFFF;
+  background: none;
 }
 
 


### PR DESCRIPTION
Fixes #300 

<img width="959" alt="screen shot 2016-07-12 at 12 07 31 am" src="https://cloud.githubusercontent.com/assets/7052378/16755664/abbefca4-47c4-11e6-9082-3c7805837843.png">
