### PR TITLE
'Take a tour' button

### DIFF
--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -76,6 +76,4 @@ function activateAbout(app: Application): void {
     text: 'About JupyterLab',
     category: 'Help'
   }]);
-
-  app.shell.addToMainArea(widget);
 }

--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -9,6 +9,10 @@ import {
   Widget
 } from 'phosphor-widget';
 
+import {
+  TabPanel
+} from 'phosphor-tabs';
+
 
 /**
  * The about page extension.
@@ -67,7 +71,14 @@ function activateAbout(app: Application): void {
     id: commandId,
     handler: () => {
       if (!widget.isAttached) app.shell.addToMainArea(widget);
-      app.shell.activateMain(widget.id);
+      let stack = widget.parent;
+      if (!stack) {
+        return;
+      }
+      let tabs = stack.parent;
+      if (tabs instanceof TabPanel) {
+        tabs.currentWidget = widget;
+      }
     }
   }]);
 

--- a/src/landing/index.css
+++ b/src/landing/index.css
@@ -103,3 +103,9 @@
   font-size: 12px;
   padding-top: 8px;
 }
+
+.jp-Landing-tour {
+    color: #f37a3c;
+    margin-top: 20px;
+    cursor: pointer;
+}

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -80,6 +80,9 @@ function activateLanding(app: Application, services: ServiceManager): void {
   tour.textContent = 'Take a tour';
   tour.className = 'jp-Landing-tour';
   dialog.appendChild(tour);
+  tour.addEventListener('click', () => {
+    app.commands.execute('about-jupyterlab:show');
+  });
 
   img = body.getElementsByClassName('jp-ImageConsole')[0];
   img.addEventListener('click', () => {

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -28,7 +28,7 @@ const landingExtension = {
 function activateLanding(app: Application, services: ServiceManager): void {
   let widget = new Widget();
   widget.id = 'landing-jupyterlab';
-  widget.title.text = 'JupyterLab';
+  widget.title.text = 'Launcher';
   widget.title.closable = true;
   widget.addClass('jp-Landing');
 

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -76,6 +76,11 @@ function activateLanding(app: Application, services: ServiceManager): void {
     app.commands.execute('file-operations:new-notebook');
   });
 
+  let tour = document.createElement('span')
+  title.textContent = 'Take a tour';
+  title.className = 'jp-Landing-tour';
+  dialog.appendChild(header);
+
   img = body.getElementsByClassName('jp-ImageConsole')[0];
   img.addEventListener('click', () => {
     app.commands.execute(`console:create-${services.kernelspecs.default}`);

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -77,9 +77,9 @@ function activateLanding(app: Application, services: ServiceManager): void {
   });
 
   let tour = document.createElement('span')
-  title.textContent = 'Take a tour';
-  title.className = 'jp-Landing-tour';
-  dialog.appendChild(header);
+  tour.textContent = 'Take a tour';
+  tour.className = 'jp-Landing-tour';
+  dialog.appendChild(tour);
 
   img = body.getElementsByClassName('jp-ImageConsole')[0];
   img.addEventListener('click', () => {


### PR DESCRIPTION
* Added a 'Take a tour' button to landing which open an about page tab
* Opens landing on startup
* Rename 'JupyterLab' to 'Launcher'
* Open about page instead of just opening a new about tab

<img width="464" alt="screen shot 2016-07-12 at 2 56 09 am" src="https://cloud.githubusercontent.com/assets/12474166/16759393/3d8085f6-47dc-11e6-944f-ba77d947d223.png">


@faricacarroll @eskirk @rnetro @matt-bowers 