### PR TITLE
Remove keydown listener for console tooltips, slight refactor.

### DIFF
--- a/src/console/tooltip.ts
+++ b/src/console/tooltip.ts
@@ -81,9 +81,6 @@ class ConsoleTooltip extends Widget {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-    case 'keydown':
-      this._evtKeydown(event as KeyboardEvent);
-      break;
     case 'mousedown':
       this._evtMousedown(event as MouseEvent);
       break;
@@ -102,7 +99,6 @@ class ConsoleTooltip extends Widget {
    * Captures document events to dismiss the tooltip widget.
    */
   protected onAfterAttach(msg: Message): void {
-    document.addEventListener('keydown', this, USE_CAPTURE);
     document.addEventListener('mousedown', this, USE_CAPTURE);
     document.addEventListener('scroll', this);
   }
@@ -111,7 +107,6 @@ class ConsoleTooltip extends Widget {
    * Handle `before_detach` messages for the widget.
    */
   protected onBeforeDetach(msg: Message): void {
-    document.removeEventListener('keydown', this, USE_CAPTURE);
     document.removeEventListener('mousedown', this, USE_CAPTURE);
     document.removeEventListener('scroll', this);
   }
@@ -121,37 +116,6 @@ class ConsoleTooltip extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     this.show();
-  }
-
-  /**
-   * Handle keydown events for the widget.
-   *
-   * #### Notes
-   * Hides the tooltip if a keydown happens anywhere on the document outside
-   * of either the tooltip or its parent.
-   */
-  private _evtKeydown(event: KeyboardEvent) {
-    if (this.isHidden) {
-      return;
-    }
-
-    if (!this._reference) {
-      this.hide();
-      return;
-    }
-
-    let target = event.target as HTMLElement;
-    while (target !== document.documentElement) {
-      if (target === this._reference.node) {
-        if (event.keyCode === 27) { // Escape key
-          this.hide();
-        }
-        return;
-      }
-      target = target.parentElement;
-    }
-
-    this.hide();
   }
 
   /**

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -111,6 +111,11 @@ interface IEditorState extends JSONObject {
    * The coordinate position of the cursor.
    */
   coords: ICoords;
+
+  /**
+   * The cursor position of the request, including line breaks.
+   */
+  position: number;
 }
 
 
@@ -136,11 +141,6 @@ interface ITextChange extends IEditorState {
  */
 export
 interface ICompletionRequest extends IEditorState {
-  /**
-   * The cursor position of the request, including line breaks.
-   */
-  position: number;
-
   /**
    * The current value of the editor text.
    */
@@ -292,8 +292,9 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
+    let position = editor.getDoc().indexFromPos({ line, ch })
     this.textChanged.emit({
-      line, ch, chHeight, chWidth, coords, oldValue, newValue
+      line, ch, chHeight, chWidth, coords, position, oldValue, newValue
     });
   }
 

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -292,7 +292,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
-    let position = editor.getDoc().indexFromPos({ line, ch })
+    let position = editor.getDoc().indexFromPos({ line, ch });
     this.textChanged.emit({
       line, ch, chHeight, chWidth, coords, position, oldValue, newValue
     });

--- a/test/src/notebook/completion/handler.spec.ts
+++ b/test/src/notebook/completion/handler.spec.ts
@@ -306,6 +306,7 @@ describe('notebook/completion/handler', () => {
           chHeight: 0,
           chWidth: 0,
           line: 0,
+          position: 0,
           coords: null,
           oldValue: 'fo',
           newValue: 'foo'
@@ -328,6 +329,7 @@ describe('notebook/completion/handler', () => {
           chHeight: 0,
           chWidth: 0,
           line: 0,
+          position: 0,
           coords: null,
           oldValue: 'fo',
           newValue: 'foo'

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -115,7 +115,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
@@ -147,7 +152,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         let listener = (sender: any, args: void) => { called++; };
         model.stateChanged.connect(listener);
@@ -266,7 +276,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         model.current = change;
         expect(model.current).to.be(null);
@@ -293,7 +308,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         model.original = request;
         model.current = change;
@@ -320,7 +340,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 0, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 0,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         model.original = request;
         model.cursor = cursor;
@@ -412,7 +437,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 4, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 4,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 4,
+          coords, oldValue, newValue
         };
         model.original = request;
         model.cursor = cursor;
@@ -437,7 +467,12 @@ describe('notebook/completion/model', () => {
           currentValue: currentValue
         };
         let change: ITextChange = {
-          ch: 4, chHeight: 0, chWidth: 0, line: 0, coords, oldValue, newValue
+          ch: 4,
+          chHeight: 0,
+          chWidth: 0,
+          line: 0,
+          position: 0,
+          coords, oldValue, newValue
         };
         model.original = request;
         expect(model.original).to.be.ok();


### PR DESCRIPTION
- [x] Bug fix: add `reference` to console widget in tooltip.
- [x] Remove `keydown` listenever from tooltip.
- [x] Send full code cell to `inspect` API method.
- [x] Update tests.