### PR TITLE
Changed menu item active and inactive font colors

### DIFF
--- a/src/mainmenu/index.css
+++ b/src/mainmenu/index.css
@@ -16,3 +16,12 @@
    max-height: 24px;
    position: absolute;
 }
+
+.p-MenuBar-itemText {
+  font-size: 13px;
+  color: #777777;
+}
+
+.p-MenuBar-item.p-mod-active > .p-MenuBar-itemText {
+  color: #2196F3;
+}


### PR DESCRIPTION
Changed the default menu bar font color from black to the default gray (#777777)

<img width="359" alt="screen shot 2016-07-13 at 4 38 53 pm" src="https://cloud.githubusercontent.com/assets/7052378/16820780/74ba0f28-4918-11e6-95fb-fabcd6c7ab90.png">
<img width="312" alt="screen shot 2016-07-13 at 4 38 42 pm" src="https://cloud.githubusercontent.com/assets/7052378/16820781/74bd6f74-4918-11e6-8c0e-7575e63a1292.png">
