### PR TITLE
update labwidgets to not include new phosphor css

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -9,7 +9,7 @@
     "es6-promise": "^3.1.2",
     "font-awesome": "^4.6.1",
     "jupyter-js-services": "^0.15.1",
-    "jupyter-js-widgets-labextension": "^0.0.3",
+    "jupyter-js-widgets-labextension": "^0.0.4",
     "jupyterlab": "file:../",
     "phosphide": "^0.10.0"
   },


### PR DESCRIPTION
The new phosphor css was being included in jupyter-js-widgets, which was clobbering changes to the phosphor css loaded on the page. This fixes the issue.