### PR TITLE
Console menu and reordering menus

### DIFF
--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -92,7 +92,7 @@ function activateEditorHandler(app: Application, registry: DocumentRegistry, mai
     submenu: menu
   });
   currentApp = app;
-  mainMenu.addItem(editorMenu);
+  mainMenu.addItem(editorMenu, {rank: 30});
   registry.addWidgetFactory(new EditorWidgetFactory(),
   {
     fileExtensions: ['.*'],

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -190,7 +190,7 @@ function activateNotebookHandler(app: Application, registry: DocumentRegistry, s
   });
 
   let menuOptions = {
-    'rank': 1
+    'rank': 20
   };
   mainMenu.addItem(notebookMenu, menuOptions);
 
@@ -793,7 +793,7 @@ function makeNbMenu() {
 }
 
 /**
- * Handler functions for the notebook MainMenu item 
+ * Handler functions for the notebook MainMenu item
  */
 function clearOutputHandler() {
   currentApp.commands.execute('notebook:clear-outputs');

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -141,7 +141,7 @@ function activateTerminal(app: Application, services: ServiceManager, mainMenu: 
     submenu: menu
   });
 
-  mainMenu.addItem(terminalMenu, {rank: 90});
+  mainMenu.addItem(terminalMenu, {rank: 40});
 
   function increaseFont(): void {
     if (!tracker.isDisposed && options.fontSize < 72) {


### PR DESCRIPTION
Added console menu that allows you to create a new X console depending on what kernels are installed.

Also added ranks to other menu items so that menu order becomes (from L to R): 
File, Notebook, Editor, Terminal, Console, Help