### PR TITLE
Adding material design icons.

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -7,6 +7,7 @@ var phosphide = require('phosphide/lib/core/application');
 require('es6-promise').polyfill();
 
 require('font-awesome/css/font-awesome.min.css');
+require('material-design-icons/iconfont/material-icons.css');
 require('jupyterlab/lib/default-theme/index.css');
 
 var app = new phosphide.Application({

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "es6-promise": "^3.1.2",
     "font-awesome": "^4.6.1",
+    "material-design-icons": "^2.2.3",
     "jupyter-js-services": "^0.15.1",
     "jupyter-js-widgets-labextension": "^0.0.7",
     "jupyterlab": "file:../",


### PR DESCRIPTION
To use:

1. Set `font-family: "Material Icons"
2. Set the content to the material design icon name such as `fast_forward`
3. Change font size
4. Add `.material-icons` class