### PR TITLE
Support height, width, and alt attributes for images in Markdown images.

### DIFF
--- a/src/sanitizer/index.ts
+++ b/src/sanitizer/index.ts
@@ -29,7 +29,7 @@ class Sanitizer implements ISanitizer {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
       // Allow the "src" attribute for <img> tags.
-      'img': ['src']
+      'img': ['src', 'height', 'width', 'alt']
     },
     transformTags: {
       // Set the "rel" attribute for <a> tags to "nofollow".


### PR DESCRIPTION
FYI @blink1073 

n.b. The `<table>` tags generated will need additional CSS theme styles to match the current notebook.