### PR TITLE
Reenable widgets.

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -30,6 +30,7 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/shortcuts/plugin').shortcutsExtension,
     require('jupyterlab/lib/terminal/plugin').terminalExtension,
     require('phosphide/lib/extensions/commandpalette').commandPaletteExtension,
+    require('jupyter-js-widgets-labextension/lib/plugin').widgetManagerExtension,
   ],
   providers: [
     require('jupyterlab/lib/clipboard/plugin').clipboardProvider,

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -10,7 +10,7 @@
     "font-awesome": "^4.6.1",
     "material-design-icons": "^2.2.3",
     "jupyter-js-services": "^0.15.1",
-    "jupyter-js-widgets-labextension": "0.0.9",
+    "jupyter-js-widgets-labextension": "^0.1.0",
     "jupyterlab": "file:../",
     "phosphide": "^0.10.0"
   },


### PR DESCRIPTION
This should fix the problems with the version numbers and widgets.

c.f. https://github.com/jupyter/jupyterlab/pull/410