### PR TITLE
Dragging OutputAreaWidget produces new OutputAreaWidget mirroring same model

### DIFF
--- a/src/notebook/cells/model.ts
+++ b/src/notebook/cells/model.ts
@@ -410,6 +410,7 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
       return;
     }
     this._outputs.clear(false);
+    this._outputs.dispose();
     this._outputs = null;
     super.dispose();
   }

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -43,6 +43,14 @@ class OutputAreaModel implements IDisposable {
   }
 
   /**
+   * A signal emitted when the model is disposed.
+   */
+  get disposed(): ISignal<OutputAreaModel, void> {
+    console.log('get model disposed signal')
+    return Private.disposedSignal.bind(this);
+  }
+
+  /**
    * Get the length of the items in the model.
    *
    * #### Notes
@@ -69,6 +77,7 @@ class OutputAreaModel implements IDisposable {
     if (this.isDisposed) {
       return;
     }
+    this.disposed.emit(void 0);
     this._list.clear();
     this._list = null;
     clearSignalData(this);
@@ -199,4 +208,6 @@ namespace Private {
    */
   export
   const changedSignal = new Signal<OutputAreaModel, IListChangedArgs<nbformat.IOutput>>();
+  export
+  const disposedSignal = new Signal<OutputAreaModel, void>();
 }

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -46,7 +46,6 @@ class OutputAreaModel implements IDisposable {
    * A signal emitted when the model is disposed.
    */
   get disposed(): ISignal<OutputAreaModel, void> {
-    console.log('get model disposed signal')
     return Private.disposedSignal.bind(this);
   }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -159,6 +159,13 @@ class OutputAreaWidget extends Widget {
   }
 
   /**
+   * A signal emitted when the widget's model is disposed.
+   */
+  get modelDisposed(): ISignal<OutputAreaWidget, void> {
+     return Private.modelDisposedSignal.bind(this);
+  }
+
+  /**
    * The model for the widget.
    */
   get model(): OutputAreaModel {
@@ -305,8 +312,10 @@ class OutputAreaWidget extends Widget {
     let layout = this.layout as PanelLayout;
     if (oldValue) {
       oldValue.changed.disconnect(this._onModelStateChanged, this);
+      oldValue.disposed.disconnect(this._onModelDisposed, this);
     }
     newValue.changed.connect(this._onModelStateChanged, this);
+    newValue.disposed.connect(this._onModelDisposed, this);
     let start = newValue ? newValue.length : 0;
     // Clear unnecessary child widgets.
     for (let i = start; i < layout.childCount(); i++) {
@@ -323,6 +332,16 @@ class OutputAreaWidget extends Widget {
     for (let i = layout.childCount(); i < newValue.length; i++) {
       this._addChild();
     }
+  }
+
+  /**
+   * Handle a model disposal.
+   */
+  protected onModelDisposed(oldValue: OutputAreaModel, newValue: OutputAreaModel): void { }
+
+  private _onModelDisposed(): void {
+    this.modelDisposed.emit(void 0);
+    this.dispose();
   }
 
   /**
@@ -879,4 +898,6 @@ namespace Private {
    */
   export
   const modelChangedSignal = new Signal<OutputAreaWidget, void>();
+  export
+  const modelDisposedSignal = new Signal<OutputAreaWidget, void>();
 }

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -58,6 +58,11 @@ const FACTORY_MIME = 'application/x-phosphor-widget-factory';
 const OUTPUT_AREA_CLASS = 'jp-OutputArea';
 
 /**
+ * The class name added to a "mirrored" output area widget created by a drag.
+ */
+const MIRRORED_OUTPUT_AREA_CLASS = 'jp-MirroredOutputArea';
+
+/**
  * The class name added to an output widget.
  */
 const OUTPUT_CLASS = 'jp-Output';
@@ -144,10 +149,12 @@ class OutputAreaWidget extends Widget {
 
   get mirror(): OutputAreaWidget {
     let rendermime = this._rendermime;
-    let widget = new OutputAreaWidget({ rendermime });
+    let renderer = this._renderer;
+    let widget = new OutputAreaWidget({ rendermime, renderer });
     widget.model = this._model;
     widget.title.text = 'Mirrored Output';
     widget.title.closable = true;
+    widget.addClass(MIRRORED_OUTPUT_AREA_CLASS);
     return widget;
   }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -152,6 +152,7 @@ class OutputAreaWidget extends Widget {
     let renderer = this._renderer;
     let widget = new OutputAreaWidget({ rendermime, renderer });
     widget.model = this._model;
+    widget.trusted = this._trusted;
     widget.title.text = 'Mirrored Output';
     widget.title.closable = true;
     widget.addClass(MIRRORED_OUTPUT_AREA_CLASS);

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -490,7 +490,7 @@ namespace OutputAreaWidget {
 export
 class OutputGutter extends Widget {
   /**
-   * Handle the DOM events for the output area widget.
+   * Handle the DOM events for the output gutter widget.
    *
    * @param event - The DOM event sent to the widget.
    *
@@ -518,8 +518,7 @@ class OutputGutter extends Widget {
    */
   protected onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
-    let node = this.node;
-    node.addEventListener('mousedown', this);
+    this.node.addEventListener('mousedown', this);
   }
 
   /**
@@ -535,16 +534,11 @@ class OutputGutter extends Widget {
    * Handle the `'mousedown'` event for the widget.
    */
   private _evtMousedown(event: MouseEvent): void {
-
     // Left mouse press for drag start.
     if (event.button === 0) {
       this._dragData = { pressX: event.clientX, pressY: event.clientY };
       document.addEventListener('mouseup', this, true);
       document.addEventListener('mousemove', this, true);
-    }
-
-    if (event.button !== 0) {
-      clearTimeout(this._selectTimer);
     }
   }
 
@@ -603,7 +597,6 @@ class OutputGutter extends Widget {
     // Start the drag and remove the mousemove listener.
     this._drag.start(clientX, clientY).then(action => {
       this._drag = null;
-      clearTimeout(this._selectTimer);
     });
     document.removeEventListener('mousemove', this, true);
   }
@@ -618,13 +611,11 @@ class OutputGutter extends Widget {
     }
     this._dragData = null;
     this._drag = null;
-    this._selectTimer = null;
     super.dispose();
   }
 
   private _drag: Drag = null;
   private _dragData: { pressX: number, pressY: number } = null;
-  private _selectTimer = -1;
 }
 
 


### PR DESCRIPTION
Drag-and-drop any notebook output areas to generate a new stand-alone widget that mirrors that output area.

Thanks for the hand, @sccolbert.


![output_dragdrop](https://cloud.githubusercontent.com/assets/2096628/16956462/1ecfd6da-4d9e-11e6-9f8c-1e815e6e99d1.gif)
