### PR TITLE
Add an activity monitor

### DIFF
--- a/src/common/activitymonitor.ts
+++ b/src/common/activitymonitor.ts
@@ -14,7 +14,7 @@ import {
  * A class that monitors activity on a signal.
  */
 export
-class ActivityMonitor<Sender, Args> implements IDisposable {
+class ActivityMonitor implements IDisposable {
   /**
    * Construct a new activity monitor.
    */
@@ -26,7 +26,7 @@ class ActivityMonitor<Sender, Args> implements IDisposable {
   /**
    * A signal emitted when activity has ceased.
    */
-  get activityStopped(): ISignal<Sender, Args> {
+  get activityStopped(): ISignal<ActivityMonitor, void> {
     return Private.activityStoppedSignal.bind(this);
   }
 
@@ -110,5 +110,5 @@ namespace Private {
    * A signal emitted when activity has ceased.
    */
   export
-  const activityStoppedSignal = new Signal<any, any>();
+  const activityStoppedSignal = new Signal<ActivityMonitor, void>();
 }

--- a/src/common/activitymonitor.ts
+++ b/src/common/activitymonitor.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IDisposable
+} from 'phosphor-disposable';
+
+import {
+  ISignal, Signal, clearSignalData
+} from 'phosphor-signaling';
+
+
+/**
+ * A class that monitors activity on a signal.
+ */
+export
+class ActivityMonitor implements IDisposable {
+  /**
+   * Construct a new activity monitor.
+   */
+  constructor(options: ActivityMonitor.IOptions) {
+    options.signal.connect(this._onSignalFired, this);
+    this._timeout = options.timeout || 1000;
+  }
+
+  /**
+   * A signal emitted when activity has ceased.
+   */
+  get activityStopped(): ISignal<ActivityMonitor, void> {
+    return Private.activityStoppedSignal.bind(this);
+  }
+
+  /**
+   * Test whether the monitor has been disposed.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  /**
+   * Dispose of the resources used by the activity monitor.
+   */
+  dispose(): void {
+    if (this._isDisposed) {
+      return;
+    }
+    this._isDisposed = true;
+    clearSignalData(this);
+  }
+
+  /**
+   * A signal handler for the monitored signal.
+   */
+  private _onSignalFired(): void {
+    clearTimeout(this._timer);
+    this._timer = setTimeout(() => {
+      this.activityStopped.emit(void 0);
+    });
+  }
+
+  private _timer = -1;
+  private _timeout = -1;
+  private _isDisposed = false;
+}
+
+
+/**
+ * The namespace for `ActivityMonitor` statics.
+ */
+export
+namespace ActivityMonitor {
+  /**
+   * The options used to construct a new `ActivityMonitor`.
+   */
+  export
+  interface IOptions {
+    /**
+     * The signal to monitor.
+     */
+    signal: ISignal<any, any>;
+
+    /**
+     * The activity timeout in milliseconds.
+     *
+     * The default is 1 second.
+     */
+    timeout?: number;
+  }
+}
+
+
+/**
+ * A namespace for private data.
+ */
+namespace Private {
+  /**
+   * A signal emitted when activity has ceased.
+   */
+  export
+  const activityStoppedSignal = new Signal<ActivityMonitor, void>();
+}

--- a/src/common/activitymonitor.ts
+++ b/src/common/activitymonitor.ts
@@ -14,7 +14,7 @@ import {
  * A class that monitors activity on a signal.
  */
 export
-class ActivityMonitor implements IDisposable {
+class ActivityMonitor<Sender, Args> implements IDisposable {
   /**
    * Construct a new activity monitor.
    */
@@ -26,7 +26,7 @@ class ActivityMonitor implements IDisposable {
   /**
    * A signal emitted when activity has ceased.
    */
-  get activityStopped(): ISignal<ActivityMonitor, void> {
+  get activityStopped(): ISignal<Sender, Args> {
     return Private.activityStoppedSignal.bind(this);
   }
 
@@ -110,5 +110,5 @@ namespace Private {
    * A signal emitted when activity has ceased.
    */
   export
-  const activityStoppedSignal = new Signal<ActivityMonitor, void>();
+  const activityStoppedSignal = new Signal<any, any>();
 }

--- a/src/common/activitymonitor.ts
+++ b/src/common/activitymonitor.ts
@@ -31,6 +31,16 @@ class ActivityMonitor implements IDisposable {
   }
 
   /**
+   * The timeout associated with the monitor, in milliseconds.
+   */
+  get timeout(): number {
+    return this._timeout;
+  }
+  set timeout(value: number) {
+    this._timeout = value;
+  }
+
+  /**
    * Test whether the monitor has been disposed.
    *
    * #### Notes
@@ -58,7 +68,7 @@ class ActivityMonitor implements IDisposable {
     clearTimeout(this._timer);
     this._timer = setTimeout(() => {
       this.activityStopped.emit(void 0);
-    });
+    }, this._timeout);
   }
 
   private _timer = -1;

--- a/test/src/common/activitymonitor.spec.ts
+++ b/test/src/common/activitymonitor.spec.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  Signal
+} from 'phosphor-signaling';
+
+import {
+  ActivityMonitor
+} from '../../../lib/common/activitymonitor';
+
+
+describe('common/activitymonitor', () => {
+
+  describe('ActivityMonitor()', () => {
+
+    describe('#constructor()', () => {
+
+      it('should accept a signal', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        expect(monitor).to.be.an(ActivityMonitor);
+      });
+
+      it('should accept a timeout', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        expect(monitor).to.be.an(ActivityMonitor);
+      });
+
+    });
+
+    describe('#activityStopped', () => {
+
+      it('should be emitted after the signal has fired and a timeout', (done) => {
+        let signal = new Signal<any, void>().bind(window);
+        let called = false;
+        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        monitor.activityStopped.connect((sender, args) => {
+          expect(sender).to.be(monitor);
+          expect(args).to.be(void 0);
+          called = true;
+        });
+        signal.emit(void 0);
+        expect(called).to.be(false);
+        setTimeout(() => {
+          expect(called).to.be(true);
+          done();
+        }, 100);
+      });
+
+      it('should collapse during activity', (done) => {
+        let signal = new Signal<any, void>().bind(window);
+        let called = false;
+        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        monitor.activityStopped.connect((sender, args) => {
+          expect(sender).to.be(monitor);
+          expect(args).to.be(void 0);
+          called = true;
+        });
+        signal.emit(void 0);
+        expect(called).to.be(false);
+        setTimeout(() => {
+          signal.emit(void 0);
+        }, 90);
+        setTimeout(() => {
+          expect(called).to.be(false);
+        }, 100);
+        setTimeout(() => {
+          expect(called).to.be(true);
+          done();
+        }, 200);
+      });
+
+    });
+
+    describe('#timeout', () => {
+
+      it('should default to `1000`', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        expect(monitor.timeout).to.be(1000);
+      });
+
+      it('should be set-able', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        monitor.timeout = 200;
+        expect(monitor.timeout).to.be(200);
+      });
+
+    });
+
+    describe('#isDisposed', () => {
+
+      it('should test whether the monitor is disposed', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        expect(monitor.isDisposed).to.be(false);
+        monitor.dispose();
+        expect(monitor.isDisposed).to.be(true);
+      });
+
+      it('should be read-only', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        expect(() => { monitor.isDisposed = false; }).to.throwError();
+      });
+
+    });
+
+    describe('#dispose()', () => {
+
+      it('should disposed of the resources used by the monitor', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        monitor.dispose();
+        expect(monitor.isDisposed).to.be(true);
+      });
+
+      it('should be a no-op if called more than once', () => {
+        let signal = new Signal<any, any>().bind(window);
+        let monitor = new ActivityMonitor({ signal });
+        monitor.dispose();
+        monitor.dispose();
+        expect(monitor.isDisposed).to.be(true);
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/common/activitymonitor.spec.ts
+++ b/test/src/common/activitymonitor.spec.ts
@@ -19,14 +19,14 @@ describe('common/activitymonitor', () => {
     describe('#constructor()', () => {
 
       it('should accept a signal', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         expect(monitor).to.be.an(ActivityMonitor);
       });
 
       it('should accept a timeout', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal, timeout: 100 });
         expect(monitor).to.be.an(ActivityMonitor);
       });
 
@@ -35,15 +35,16 @@ describe('common/activitymonitor', () => {
     describe('#activityStopped', () => {
 
       it('should be emitted after the signal has fired and a timeout', (done) => {
-        let signal = new Signal<any, void>().bind(window);
+        let signal = new Signal<Window, number>().bind(window);
         let called = false;
         let monitor = new ActivityMonitor({ signal, timeout: 100 });
         monitor.activityStopped.connect((sender, args) => {
           expect(sender).to.be(monitor);
-          expect(args).to.be(void 0);
+          expect(args.sender).to.be(window);
+          expect(args.args).to.be(10);
           called = true;
         });
-        signal.emit(void 0);
+        signal.emit(10);
         expect(called).to.be(false);
         setTimeout(() => {
           expect(called).to.be(true);
@@ -52,18 +53,19 @@ describe('common/activitymonitor', () => {
       });
 
       it('should collapse during activity', (done) => {
-        let signal = new Signal<any, void>().bind(window);
+        let signal = new Signal<Window, number>().bind(window);
         let called = false;
-        let monitor = new ActivityMonitor({ signal, timeout: 100 });
+        let monitor = new ActivityMonitor<Window, number>({ signal, timeout: 100 });
         monitor.activityStopped.connect((sender, args) => {
           expect(sender).to.be(monitor);
-          expect(args).to.be(void 0);
+          expect(args.sender).to.be(window);
+          expect(args.args).to.be(10);
           called = true;
         });
-        signal.emit(void 0);
+        signal.emit(5);
         expect(called).to.be(false);
         setTimeout(() => {
-          signal.emit(void 0);
+          signal.emit(10);
         }, 90);
         setTimeout(() => {
           expect(called).to.be(false);
@@ -79,14 +81,14 @@ describe('common/activitymonitor', () => {
     describe('#timeout', () => {
 
       it('should default to `1000`', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         expect(monitor.timeout).to.be(1000);
       });
 
       it('should be set-able', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         monitor.timeout = 200;
         expect(monitor.timeout).to.be(200);
       });
@@ -96,16 +98,16 @@ describe('common/activitymonitor', () => {
     describe('#isDisposed', () => {
 
       it('should test whether the monitor is disposed', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         expect(monitor.isDisposed).to.be(false);
         monitor.dispose();
         expect(monitor.isDisposed).to.be(true);
       });
 
       it('should be read-only', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         expect(() => { monitor.isDisposed = false; }).to.throwError();
       });
 
@@ -114,15 +116,15 @@ describe('common/activitymonitor', () => {
     describe('#dispose()', () => {
 
       it('should disposed of the resources used by the monitor', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         monitor.dispose();
         expect(monitor.isDisposed).to.be(true);
       });
 
       it('should be a no-op if called more than once', () => {
-        let signal = new Signal<any, any>().bind(window);
-        let monitor = new ActivityMonitor({ signal });
+        let signal = new Signal<Window, number>().bind(window);
+        let monitor = new ActivityMonitor<Window, number>({ signal });
         monitor.dispose();
         monitor.dispose();
         expect(monitor.isDisposed).to.be(true);

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import './common/activitymonitor.spec';
+
 import './dialog/dialog.spec';
 
 import './docregistry/default.spec';


### PR DESCRIPTION
To be used for batch-updates (e.g. do not re-render a markdown preview until the user stops typing).