### PR TITLE
File browser interaction cleanup

### DIFF
--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -163,6 +163,11 @@ const RENAME_DURATION = 500;
 const DRAG_THRESHOLD = 5;
 
 /**
+ * A boolean indicating whether the platform is Mac.
+ */
+const IS_MAC = !!navigator.platform.match(/Mac/i);
+
+/**
  * The factory MIME type supported by phosphor dock panels.
  */
 const FACTORY_MIME = 'application/x-phosphor-widget-factory';
@@ -713,7 +718,7 @@ class DirListing extends Widget {
     }
 
     // Check for clearing a context menu.
-    if (this._inContext && event.button === 0) {
+    if (this._inContext && event.button === 0 && event.ctrlKey === false) {
       this._inContext = false;
       return;
     }
@@ -1036,7 +1041,7 @@ class DirListing extends Widget {
     let selected = Object.keys(this._selection);
 
     // Handle toggling.
-    if (event.metaKey || event.ctrlKey) {
+    if ((IS_MAC && event.metaKey) || (!IS_MAC && event.ctrlKey)) {
       if (this._selection[name]) {
         delete this._selection[name];
       } else {

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -747,8 +747,10 @@ class DirListing extends Widget {
    * Handle the `'mouseup'` event for the widget.
    */
   private _evtMouseup(event: MouseEvent): void {
+    // Handle any soft selection from the previous mouse down.
     if (this._softSelection) {
       let altered = event.metaKey || event.shiftKey || event.ctrlKey;
+      // See if we need to clear the other selection.
       if (!altered && event.button === 0) {
         this._selection = Object.create(null);
         this._selection[this._softSelection] = true;
@@ -756,6 +758,7 @@ class DirListing extends Widget {
       }
       this._softSelection = '';
     }
+    // Remove the drag listeners if necessary.
     if (event.button !== 0 || !this._drag) {
       document.removeEventListener('mousemove', this, true);
       document.removeEventListener('mouseup', this, true);
@@ -1066,6 +1069,7 @@ class DirListing extends Widget {
           }
         }, RENAME_DURATION);
       }
+      // Select only the given item.
       this._selection = Object.create(null);
       this._selection[name] = true;
     }

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -718,7 +718,8 @@ class DirListing extends Widget {
     }
 
     // Check for clearing a context menu.
-    if (this._inContext && event.button === 0 && event.ctrlKey === false) {
+    let newContext = (IS_MAC && event.ctrlKey) || (event.button === 2);
+    if (this._inContext && !newContext) {
       this._inContext = false;
       return;
     }

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -713,10 +713,11 @@ class DirListing extends Widget {
     }
 
     // Check for clearing a context menu.
-    if (this._inContext) {
+    if (this._inContext && event.button === 0) {
       this._inContext = false;
       return;
     }
+    this._inContext = false;
 
     let index = utils.hitTestNodes(this._items, event.clientX, event.clientY);
     if (index === -1) {

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -534,6 +534,9 @@ class DirListing extends Widget {
     case 'dblclick':
       this._evtDblClick(event as MouseEvent);
       break;
+    case 'contextmenu':
+      this._evtContextMenu(event as MouseEvent);
+      break;
     case 'scroll':
       this._evtScroll(event as MouseEvent);
       break;
@@ -563,6 +566,7 @@ class DirListing extends Widget {
     node.addEventListener('keydown', this);
     node.addEventListener('click', this);
     node.addEventListener('dblclick', this);
+    node.addEventListener('contextmenu', this);
     content.addEventListener('scroll', this);
     content.addEventListener('p-dragenter', this);
     content.addEventListener('p-dragleave', this);
@@ -581,6 +585,7 @@ class DirListing extends Widget {
     node.removeEventListener('keydown', this);
     node.removeEventListener('click', this);
     node.removeEventListener('dblclick', this);
+    node.removeEventListener('contextmenu', this);
     content.removeEventListener('scroll', this);
     content.removeEventListener('p-dragenter', this);
     content.removeEventListener('p-dragleave', this);
@@ -681,6 +686,13 @@ class DirListing extends Widget {
   }
 
   /**
+   * Handle the `'contextmenu'` event for the widget.
+   */
+  private _evtContextMenu(event: MouseEvent): void {
+    this._inContext = true;
+  }
+
+  /**
    * Handle the `'mousedown'` event for the widget.
    */
   private _evtMousedown(event: MouseEvent): void {
@@ -698,6 +710,12 @@ class DirListing extends Widget {
       } else {
         return;
       }
+    }
+
+    // Check for clearing a context menu.
+    if (this._inContext) {
+      this._inContext = false;
+      return;
     }
 
     let index = utils.hitTestNodes(this._items, event.clientX, event.clientY);
@@ -1010,6 +1028,9 @@ class DirListing extends Widget {
       return;
     }
 
+    // Clear any existing soft selection.
+    this._softSelection = '';
+
     let name = items[index].name;
     let selected = Object.keys(this._selection);
 
@@ -1026,7 +1047,7 @@ class DirListing extends Widget {
       this._handleMultiSelect(selected, index);
 
     // Handle a 'soft' selection
-    } else if (this._selection[name] === true && Object.keys(this._selection).length > 1) {
+    } else if (name in this._selection && selected.length > 1) {
       this._softSelection = name;
 
     // Default to selecting the only the item.
@@ -1224,6 +1245,7 @@ class DirListing extends Widget {
   private _manager: DocumentManager = null;
   private _opener: IWidgetOpener = null;
   private _softSelection = '';
+  private _inContext = false;
   private _selection: { [key: string]: boolean; } = Object.create(null);
   private _renderer: DirListing.IRenderer = null;
 }

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -360,7 +360,7 @@ class DirListing extends Widget {
         names.push(item.name);
       }
     }
-    let message = `Permanantly delete these ${names.length} files?`;
+    let message = `Permanently delete these ${names.length} files?`;
     if (names.length === 1) {
       message = `Permanently delete file "${names[0]}"?`;
     }


### PR DESCRIPTION
Fixes #441.

Context Menus:
- Right clicking on an item selects it before opening the context menu
- Right clicking on an unselected item when a context menu is open selects a new item and opens the context menu
- A left click anywhere when there is a context menu clears the menu but keeps the selection

Soft Selection:
- Unmodified mouse down an item in an existing selection is a "soft selection" for dragging or context menu
- Mouse up on a soft selection clears other selection unless there is an active context menu

Drag-drop:
- Fixes a bug when dragging multiple items - the original node text was being changed
- Uses a file icon for all multi-item drags

There is overall less spurious triggering of file name editing as well.


![fix-file-selection](https://cloud.githubusercontent.com/assets/2096628/16962790/d40b92fe-4db8-11e6-8776-0a18a60ecd93.gif)
