### PR TITLE
Completion widget indentation bug fixes.

### DIFF
--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -330,16 +330,18 @@ class CellEditorWidget extends CodeMirrorWidget {
     let editor = this.editor;
     let currentValue = editor.getDoc().getValue();
     let currentLine = currentValue.split('\n')[line];
+    let currentChar = ch ? currentLine[ch - 1] : null;
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
     let position = editor.getDoc().indexFromPos({ line, ch })
 
-    // A completion request signal should only be emitted if the final
-    // character of the current line is not whitespace. Otherwise, the
-    // default tab action of creating a tab character should be allowed to
-    // propagate.
-    if (currentLine.match(/\S$/)) {
+    // A completion request signal should only be emitted if the current
+    // character is not whitespace.
+    //
+    // Otherwise, the default tab action of creating a tab character should be
+    // allowed to propagate.
+    if (currentChar && currentChar.match(/\S/)) {
       let data = {
         line, ch, chHeight, chWidth, coords, position, currentValue
       };

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -330,18 +330,17 @@ class CellEditorWidget extends CodeMirrorWidget {
     let editor = this.editor;
     let currentValue = editor.getDoc().getValue();
     let currentLine = currentValue.split('\n')[line];
-    let currentChar = ch ? currentLine[ch - 1] : null;
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
     let position = editor.getDoc().indexFromPos({ line, ch })
 
     // A completion request signal should only be emitted if the current
-    // character is not whitespace.
+    // character or a preceding character is not whitespace.
     //
     // Otherwise, the default tab action of creating a tab character should be
     // allowed to propagate.
-    if (currentChar && currentChar.match(/\S/)) {
+    if (currentLine.substring(0, ch).match(/\S/)) {
       let data = {
         line, ch, chHeight, chWidth, coords, position, currentValue
       };

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -86,6 +86,13 @@ class CompletionWidget extends Widget {
   }
 
   /**
+   * A signal emitted when the completion widget's visibility changes.
+   */
+  get visibilityChanged(): ISignal<CompletionWidget, void> {
+    return Private.visibilityChangedSignal.bind(this);
+  }
+
+  /**
    * The model used by the completion widget.
    *
    * #### Notes
@@ -154,6 +161,7 @@ class CompletionWidget extends Widget {
     }
     this._activeIndex = 0;
     this._anchorPoint = 0;
+    this.visibilityChanged.emit(void 0);
   }
 
   /**
@@ -225,9 +233,10 @@ class CompletionWidget extends Widget {
 
     let items = model.items;
 
-    // If there are no items, hide and bail.
+    // If there are no items, reset and bail.
     if (!items || !items.length) {
       this.hide();
+      this.visibilityChanged.emit(void 0);
       return;
     }
 
@@ -253,6 +262,7 @@ class CompletionWidget extends Widget {
 
     if (this.isHidden) {
       this.show();
+      this.visibilityChanged.emit(void 0);
     }
     this._anchorPoint = this._anchor.scrollTop;
     this._setGeometry();
@@ -516,6 +526,12 @@ namespace Private {
    */
   export
   const selectedSignal = new Signal<CompletionWidget, string>();
+
+  /**
+   * A signal emitted when the completion widget's visibility changes.
+   */
+  export
+  const visibilityChangedSignal = new Signal<CompletionWidget, void>();
 
   /**
    * Returns the common subset string that a list of strings shares.

--- a/src/notebook/completion/widget.ts
+++ b/src/notebook/completion/widget.ts
@@ -75,6 +75,9 @@ class CompletionWidget extends Widget {
     this.anchor = options.anchor || null;
     this.model = options.model || null;
     this.addClass(COMPLETION_CLASS);
+
+    // Completion widgets are hidden until they are populated.
+    this.hide();
   }
 
 
@@ -161,6 +164,7 @@ class CompletionWidget extends Widget {
     }
     this._activeIndex = 0;
     this._anchorPoint = 0;
+    this.hide();
     this.visibilityChanged.emit(void 0);
   }
 

--- a/test/src/notebook/completion/widget.spec.ts
+++ b/test/src/notebook/completion/widget.spec.ts
@@ -139,6 +139,32 @@ describe('notebook/completion/widget', () => {
 
     });
 
+    describe('#visibilityChanged', () => {
+
+      it('should emit a signal when completion visibility changes', () => {
+        let anchor = new Widget();
+        let options: CompletionWidget.IOptions = {
+          model: new CompletionModel(),
+          anchor: anchor.node
+        };
+        let called = false;
+        let listener = () => { called = true; };
+        options.model.options = ['foo', 'bar'];
+        anchor.attach(document.body);
+
+        let widget = new CompletionWidget(options);
+
+        widget.visibilityChanged.connect(listener);
+        expect(called).to.be(false);
+        widget.attach(document.body);
+        sendMessage(widget, Widget.MsgUpdateRequest);
+        expect(called).to.be(true);
+        widget.dispose();
+        anchor.dispose();
+      });
+
+    });
+
     describe('#model', () => {
 
       it('should default to null', () => {


### PR DESCRIPTION
- [x] Bug fix: A completion request signal should only be emitted if the current character or a preceding character is not whitespace (https://github.com/jupyter/jupyterlab/issues/466)
- [x] Bug fix: do not show tooltip in console if completion is visible.
- [x] Reorganize order of protected methods.
- [x] Add test for new `visibilityChanged` signal.

cc: @jasongrout 

![completion](https://cloud.githubusercontent.com/assets/159529/16986982/890367ea-4e81-11e6-8c30-d6e6f67d3b4e.gif)
