### PR TITLE
Added an indicator for executed cells

### DIFF
--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -57,6 +57,11 @@ const CELL_EDITOR_CLASS = 'jp-CellEditor';
 
 
 /**
+ * The class name addded to the cell after it has been executed.
+ */
+const CELL_EXECUTED_CLASS = 'jp-ExecutedCell';
+
+/**
  * An interface describing editor state coordinates.
  */
 export
@@ -292,6 +297,11 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
     let position = editor.getDoc().indexFromPos({ line, ch });
+<<<<<<< HEAD
+=======
+    this.addClass(CELL_NEWLY_EDITED_CLASS);
+    this.removeClass(CELL_EXECUTED_CLASS);
+>>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
     this.textChanged.emit({
       line, ch, chHeight, chWidth, coords, position, oldValue, newValue
     });

--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -62,6 +62,11 @@ const CELL_EDITOR_CLASS = 'jp-CellEditor';
 const CELL_EXECUTED_CLASS = 'jp-ExecutedCell';
 
 /**
+ * The class name given to a newly edited cell.
+ */
+const CELL_NEWLY_EDITED_CLASS = 'jp-NewlyEdited';
+
+/**
  * An interface describing editor state coordinates.
  */
 export
@@ -297,11 +302,8 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
     let position = editor.getDoc().indexFromPos({ line, ch });
-<<<<<<< HEAD
-=======
     this.addClass(CELL_NEWLY_EDITED_CLASS);
     this.removeClass(CELL_EXECUTED_CLASS);
->>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
     this.textChanged.emit({
       line, ch, chHeight, chWidth, coords, position, oldValue, newValue
     });

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -106,6 +106,19 @@ const RAW_CELL_CLASS = 'jp-RawCell';
 const RENDERED_CLASS = 'jp-mod-rendered';
 
 /**
+<<<<<<< HEAD
+=======
+ * The class name addded to the cell after it has been executed.
+ */
+const CELL_EXECUTED_CLASS = 'jp-ExecutedCell';
+
+/**
+ * The class name given to a newly edited cell.
+ */
+const CELL_NEWLY_EDITED_CLASS = 'jp-NewlyEdited';
+
+/**
+>>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
  * The text applied to an empty markdown cell.
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $';
@@ -462,6 +475,11 @@ class CodeCellWidget extends BaseCellWidget {
     model.executionCount = null;
     this.setPrompt('*');
     this.trusted = true;
+<<<<<<< HEAD
+=======
+    this.editor.addClass(CELL_EXECUTED_CLASS);
+    this.editor.removeClass(CELL_NEWLY_EDITED_CLASS);
+>>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
     let outputs = model.outputs;
     return outputs.execute(code, kernel).then(reply => {
       model.executionCount = reply.content.execution_count;

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -106,8 +106,6 @@ const RAW_CELL_CLASS = 'jp-RawCell';
 const RENDERED_CLASS = 'jp-mod-rendered';
 
 /**
-<<<<<<< HEAD
-=======
  * The class name addded to the cell after it has been executed.
  */
 const CELL_EXECUTED_CLASS = 'jp-ExecutedCell';
@@ -118,7 +116,6 @@ const CELL_EXECUTED_CLASS = 'jp-ExecutedCell';
 const CELL_NEWLY_EDITED_CLASS = 'jp-NewlyEdited';
 
 /**
->>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
  * The text applied to an empty markdown cell.
  */
 const DEFAULT_MARKDOWN_TEXT = 'Type Markdown and LaTeX: $ α^2 $';
@@ -475,11 +472,8 @@ class CodeCellWidget extends BaseCellWidget {
     model.executionCount = null;
     this.setPrompt('*');
     this.trusted = true;
-<<<<<<< HEAD
-=======
     this.editor.addClass(CELL_EXECUTED_CLASS);
     this.editor.removeClass(CELL_NEWLY_EDITED_CLASS);
->>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
     let outputs = model.outputs;
     return outputs.execute(code, kernel).then(reply => {
       model.executionCount = reply.content.execution_count;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -37,6 +37,13 @@
   flex-shrink: 1;
 }
 
+<<<<<<< HEAD
+=======
+.jp-ExecutedCell {
+  border-left: 2px solid purple !important;
+}
+
+>>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
 
 .jp-MarkdownCell-content.p-Widget {
   padding: 7px;

--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -37,13 +37,11 @@
   flex-shrink: 1;
 }
 
-<<<<<<< HEAD
-=======
+
 .jp-ExecutedCell {
   border-left: 2px solid purple !important;
 }
 
->>>>>>> 77f5e1a... Added a visaul indicator for cells that have been ran
 
 .jp-MarkdownCell-content.p-Widget {
   padding: 7px;


### PR DESCRIPTION
When a cell gets executed, a small purple indicator is added to the left side. If it is edited after that, the marker will disappear, and return once again when the cell is executed etc. 

Not sure what the general consensus on this is, but I think it is a nice quality of life change.

![screen shot 2016-07-20 at 11 57 16 am](https://cloud.githubusercontent.com/assets/7052378/16999135/5eb0a2ec-4e71-11e6-9c78-1bc215c3583b.png)
