### PR TITLE
[WIP] markdown-it

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -25,6 +25,7 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/main/plugin').mainExtension,
     require('jupyterlab/lib/mainmenu/plugin').mainMenuExtension,
     require('jupyterlab/lib/markdownwidget/plugin').markdownHandlerExtension,
+    require('jupyterlab/lib/markdownwidget/plugin').markdownItHandlerExtension,
     require('jupyterlab/lib/notebook/plugin').notebookHandlerExtension,
     require('jupyterlab/lib/running/plugin').runningSessionsExtension,
     require('jupyterlab/lib/shortcuts/plugin').shortcutsExtension,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jupyter-js-services": "^0.16.0",
     "leaflet": "^0.7.7",
     "markdown-it": "^7.0.0",
+    "markdown-it-mathjax": "^1.0.3",
     "marked": "^0.3.5",
     "moment": "^2.11.2",
     "phosphide": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jquery-ui": "^1.10.5 <1.12",
     "jupyter-js-services": "^0.16.0",
     "leaflet": "^0.7.7",
+    "markdown-it": "^7.0.0",
     "marked": "^0.3.5",
     "moment": "^2.11.2",
     "phosphide": "^0.10.0",

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -10,7 +10,7 @@ import {
 } from '../docregistry';
 
 import {
-  MarkdownWidgetFactory
+  MarkdownWidgetFactory, MarkdownItWidgetFactory
 } from './widget';
 
 /**
@@ -34,12 +34,33 @@ const markdownHandlerExtension = {
   activate: (app: Application, registry: DocumentRegistry) => {
     let options: IWidgetFactoryOptions = {
       fileExtensions: ['.md'],
-      displayName: 'Rendered Markdown',
+      displayName: 'Rendered Markdown (marked)',
       modelName: 'text',
       preferKernel: false,
       canStartKernel: false
     };
     let factory = new MarkdownWidgetFactory();
+    let icon = `${PORTRAIT_ICON_CLASS} ${TEXTEDITOR_ICON_CLASS}`;
+    factory.widgetCreated.connect((sender, widget) => {
+      widget.title.icon = icon;
+    });
+    registry.addWidgetFactory(factory, options);
+  }
+};
+
+export
+const markdownItHandlerExtension = {
+  id: 'jupyter.extensions.RenderedMarkdownIt',
+  requires: [DocumentRegistry],
+  activate: (app: Application, registry: DocumentRegistry) => {
+    let options: IWidgetFactoryOptions = {
+      fileExtensions: ['.md'],
+      displayName: 'Rendered Markdown (markdown-it)',
+      modelName: 'text',
+      preferKernel: false,
+      canStartKernel: false
+    };
+    let factory = new MarkdownItWidgetFactory();
     let icon = `${PORTRAIT_ICON_CLASS} ${TEXTEDITOR_ICON_CLASS}`;
     factory.widgetCreated.connect((sender, widget) => {
       widget.title.icon = icon;

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -4,6 +4,8 @@
 import * as marked
   from 'marked';
 
+import MarkdownIt = require('markdown-it');
+
 import {
   IRenderer
 } from '../rendermime';

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -4,7 +4,9 @@
 import * as marked
   from 'marked';
 
-import MarkdownIt = require('markdown-it');
+import {
+  MarkdownIt
+} from 'markdown-it';
 
 import {
   IRenderer
@@ -33,7 +35,7 @@ import {
 
 // Support GitHub flavored Markdown, leave sanitizing to external library.
 marked.setOptions({ gfm: true, sanitize: false, breaks: true });
-
+let mdit = MarkdownIt().use(require('markdown-it-mathjax'));
 
 /**
  * A widget for displaying HTML and rendering math.
@@ -213,5 +215,18 @@ class MarkdownRenderer implements IRenderer<Widget> {
     let html = marked(data['text']);
     let sanitized = defaultSanitizer.sanitize(replaceMath(html, data['math']));
     return new HTMLWidget(sanitized);
+  }
+}
+
+/**
+ * A renderer for Jupyter Markdown data based on markdown-it.
+ */
+export
+class MarkdownItRenderer implements IRenderer<Widget> {
+  mimetypes = ['text/markdown'];
+
+  render(mimetype: string, text: string): Widget {
+    let sanitizedhtml = defaultSanitizer.sanitize(mdit.render(text));
+    return new HTMLWidget(sanitizedhtml);
   }
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -9,5 +9,6 @@
 /// <reference path="../typings/require/require.d.ts"/>
 /// <reference path="../typings/xterm/xterm.d.ts"/>
 /// <reference path="../typings/marked/marked.d.ts"/>
+/// <reference path="../typings/markdown-it/markdown-it.d.ts"/>
 /// <reference path="../typings/leaflet/leaflet.d.ts"/>
 /// <reference path="../typings/d3-dsv/d3-dsv.d.ts"/>

--- a/typings/markdown-it/markdown-it.d.ts
+++ b/typings/markdown-it/markdown-it.d.ts
@@ -1,3 +1,8 @@
+// Type definitions for markdown-it
+// Project: https://github.com/rapropos/typed-markdown-it
+// Definitions by: rapropos <https://github.com/rapropos>
+// Definitions: https://github.com/rapropos/typed-markdown-it
+
 declare var MarkdownIt: {
   (preset?: string, options?: MarkdownIt.Options): MarkdownIt.MarkdownIt;
   new (preset?: string, options?: MarkdownIt.Options): MarkdownIt.MarkdownIt;

--- a/typings/markdown-it/markdown-it.d.ts
+++ b/typings/markdown-it/markdown-it.d.ts
@@ -109,4 +109,7 @@ declare namespace MarkdownIt {
   }
 }
 
-export = MarkdownIt;
+declare module "markdown-it" {
+    export = MarkdownIt;
+}
+

--- a/typings/markdown-it/markdown-it.d.ts
+++ b/typings/markdown-it/markdown-it.d.ts
@@ -1,0 +1,107 @@
+declare var MarkdownIt: {
+  (preset?: string, options?: MarkdownIt.Options): MarkdownIt.MarkdownIt;
+  new (preset?: string, options?: MarkdownIt.Options): MarkdownIt.MarkdownIt;
+}
+
+declare namespace MarkdownIt {
+  export interface Token {
+    attrs: string[][];
+    block: boolean;
+    children: Token[];
+    content: string;
+    hidden: boolean;
+    info: string;
+    level: number;
+    map: number[];
+    markup: string;
+    meta: any;
+    nesting: number;
+    tag: string;
+    type: string;
+
+    attrIndex(attrName: string): number;
+    attrJoin(name: string, value: string): void;
+    attrPush(attr: string[]): void;
+    attrSet(name: string, value: string): void;
+  }
+
+  export interface Rule {
+    (state: any): void;
+  }
+
+  export interface Ruler {
+    after(afterName: string, ruleName: string, rule: Rule, options?: any): void;
+    at(name: string, rule: Rule, options?: any): void;
+    before(beforeName: string, ruleName: string, rule: Rule, options?: any): void;
+    disable(rules: string | string[], ignoreInvalid?: boolean): string[];
+    enable(rules: string | string[], ignoreInvalid?: boolean): string[];
+    enableOnly(rule: string, ignoreInvalid?: boolean): void;
+    getRules(chain: string): Rule[];
+    push(ruleName: string, rule: Rule, options?: any): void;
+  }
+
+  export interface RendererRule {
+    (tokens: Token[], ix: number, options: any, env: any, md: MarkdownIt): string;
+  }
+
+  export interface Renderer {
+    render(tokens: Token[], options: any, env: any): string;
+    renderAttrs(token: Token): string;
+    renderInline(tokens: Token[], options: any, env: any): string;
+    renderToken(tokens: Token[], idx: number, options?: any): string;
+    rules: { [tokenType: string]: RendererRule };
+  }
+
+  export interface ParserBlock {
+    parse(src: string, md: MarkdownIt, env: any, outTokens: Token[]): void;
+    ruler: Ruler;
+  }
+
+  export interface Core {
+    process(state: any): void;
+    ruler: Ruler;
+  }
+
+  export interface ParserInline {
+    parse(src: string, md: MarkdownIt, env: any, outTokens: Token[]): void;
+    ruler: Ruler;
+    ruler2: Ruler;
+  }
+
+  export interface Options {
+    html?: boolean;
+    xhtmlOut?: boolean;
+    breaks?: boolean;
+    langPrefix?: string;
+    linkify?: boolean;
+    typographer?: boolean;
+    quotes?: string | string[];
+    highlight?: (str:string, lang:string) => string;
+  }
+
+  export interface MarkdownIt {
+    block: ParserBlock;
+    core: Core;
+    helpers: any;
+    inline: ParserInline;
+    linkify: any;
+    renderer: Renderer;
+    utils: any;
+
+    options: any;
+    normalizeLink: {(url: string): string};
+    normalizeLinkText: {(url: string): string};
+    validateLink: {(url: string): string};
+
+    disable(rules: string | string[], ignoreInvalid?: boolean): MarkdownIt;
+    enable(rules: string | string[], ignoreInvalid?: boolean): MarkdownIt;
+    parse(src: string, env: any): Token[];
+    parseInline(src: string, env: any): Token[];
+    render(src: string, env: any): string;
+    renderInline(src: string, env: any): string;
+    use(plugin: any, ...params: any[]): MarkdownIt;
+    render(src: string): string;
+  }
+}
+
+export = MarkdownIt;


### PR DESCRIPTION
Markdown typings from https://github.com/rapropos/typed-markdown-it

This PR provides an alternative markdown renderer, markdown-it, intended for easy, side-by-side comparisons with marked.