### PR TITLE
Use locale sort as a tie-breaker when completer item match scores are equivalent.

### DIFF
--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -413,8 +413,8 @@ namespace Private {
  * A namespace which holds string searching functionality.
  *
  * #### Notes
- * This functionality comes from phosphor-core and can be removed from this file
- * once the phosphor mono-repo is deployed.
+ * All of this functionality comes from phosphor-core and can be removed from
+ * this file once the phosphor mono-repo is deployed *except* `scoreCmp`.
  */
 namespace StringSearch {
   /**

--- a/src/notebook/completion/model.ts
+++ b/src/notebook/completion/model.ts
@@ -373,7 +373,7 @@ class CompletionModel implements ICompletionModel {
         });
       }
     }
-    return results.sort((a, b) => { return a.score - b.score; })
+    return results.sort(StringSearch.scoreCmp)
       .map(result => ({ text: result.text, raw: result.raw }));
   }
 
@@ -414,8 +414,7 @@ namespace Private {
  *
  * #### Notes
  * This functionality comes from phosphor-core and can be removed from this file
- * once newer versions of phosphor libraries are used throughout
- * jupyter-js-notebook.
+ * once the phosphor mono-repo is deployed.
  */
 namespace StringSearch {
   /**
@@ -474,6 +473,22 @@ namespace StringSearch {
       score += j * j;
     }
     return { score, indices };
+  }
+
+  /**
+   * A sort comparison function for item match scores.
+   *
+   * #### Notes
+   * This orders the items first based on score (lower is better), then
+   * by locale order of the item text.
+   */
+  export
+  function scoreCmp(a: ICompletionMatch, b: ICompletionMatch): number {
+    let delta = a.score - b.score;
+    if (delta !== 0) {
+      return delta;
+    }
+    return a.raw.localeCompare(b.raw);
   }
 
   /**

--- a/test/src/notebook/completion/model.spec.ts
+++ b/test/src/notebook/completion/model.spec.ts
@@ -9,7 +9,7 @@ import {
 
 import {
   ICompletionRequest, ICoords, ITextChange
-} from '../../../../lib/notebook/cells/editor'
+} from '../../../../lib/notebook/cells/editor';
 
 
 describe('notebook/completion/model', () => {
@@ -204,8 +204,19 @@ describe('notebook/completion/model', () => {
           { raw: 'qux', text: '<mark>qux</mark>' },
           { raw: 'quux', text: '<mark>qu</mark>u<mark>x</mark>' }
         ];
-        model.options = ['qux', 'quux'];
+        model.options = ['foo', 'bar', 'baz', 'quux', 'qux'];
         model.query = 'qux';
+        expect(model.items).to.eql(want);
+      });
+
+      it('should break ties in score by locale sort', () => {
+        let model = new CompletionModel();
+        let want: ICompletionItem[] = [
+          { raw: 'quux', text: '<mark>qu</mark>ux' },
+          { raw: 'qux', text: '<mark>qu</mark>x' }
+        ];
+        model.options = ['foo', 'bar', 'baz', 'qux', 'quux'];
+        model.query = 'qu';
         expect(model.items).to.eql(want);
       });
 


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyterlab/issues/529

cf. https://github.com/jupyter/jupyterlab/issues/293

cc: @jasongrout 