### PR TITLE
Update sanitize-html type definitions.

### DIFF
--- a/typings/sanitize-html/sanitize-html.d.ts
+++ b/typings/sanitize-html/sanitize-html.d.ts
@@ -1,22 +1,22 @@
 // Type definitions for sanitize-html 1.12.0
 // Project: https://github.com/punkave/sanitize-html
+// Definitions by: Rogier Schouten <https://github.com/rogierschouten>, Afshin Darian <https://github.com/afshin>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+
 declare function sanitize(dirty: string, options?: sanitize.IOptions): string;
 
 
 declare namespace sanitize {
-  export
   type Attributes = { [attr: string]: string };
 
 
-  export
   type Tag = { tagName: string; attributes: Attributes; };
 
 
-  export
   type Transformer = (tagName: string, attributes: Attributes) => Tag;
 
 
-  export
   interface IDefaults {
     allowedAttributes: { [index: string]: string[] };
     allowedSchemes: string[];
@@ -26,7 +26,6 @@ declare namespace sanitize {
   }
 
 
-  export
   interface IFrame {
     tag: string;
     attributes: { [index: string]: string };
@@ -35,7 +34,6 @@ declare namespace sanitize {
   }
 
 
-  export
   interface IOptions {
     allowedAttributes?: { [index: string]: string[] };
     allowedClasses?: { [index: string]: string[] };
@@ -47,11 +45,9 @@ declare namespace sanitize {
   }
 
 
-  export
   var defaults: IDefaults;
 
 
-  export
   function simpleTransform(tagName: string, attributes: Attributes, merge?: boolean): Transformer;
 }
 


### PR DESCRIPTION
Last week, I wrote type definitions for the `sanitize-html` library that we are now using and I submitted a PR to the DefinitelyTyped project. Before merging it, they gave me some feedback, so I'm updating the JupyterLab version to be up-to-date with the DefinitelyTyped version.