### PR TITLE
Fix intermittent broken CI build.

### DIFF
--- a/src/notebook/cells/editor.ts
+++ b/src/notebook/cells/editor.ts
@@ -333,7 +333,7 @@ class CellEditorWidget extends CodeMirrorWidget {
     let chHeight = editor.defaultTextHeight();
     let chWidth = editor.defaultCharWidth();
     let coords = editor.charCoords({ line, ch }, 'page') as ICoords;
-    let position = editor.getDoc().indexFromPos({ line, ch })
+    let position = editor.getDoc().indexFromPos({ line, ch });
 
     // A completion request signal should only be emitted if the current
     // character or a preceding character is not whitespace.


### PR DESCRIPTION
:rage:-fixes: https://github.com/jupyter/jupyterlab/issues/532

> The timing of setTimeout is *not* guaranteed and on overburdened
systems, it can take longer than intended, so each pass must check
the actual time elapsed if timing is an inherent part of its behavior
as it is in this test.

Three builds in a row succeeded on this branch.

cc: @blink1073 