### PR TITLE
RenderMime updates and Markdown code highlighting

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from 'jupyter-js-services';
 
 import {
-  RenderMime, IRenderer, MimeMap
+  RenderMime
 } from 'jupyterlab/lib/rendermime';
 
 import {
@@ -74,7 +74,7 @@ function startApp(session: ISession) {
     new LatexRenderer(),
     new TextRenderer()
   ];
-  let renderers: MimeMap<IRenderer<Widget>> = {};
+  let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
   let order: string[] = [];
   for (let t of transformers) {
     for (let m of t.mimetypes) {
@@ -82,7 +82,7 @@ function startApp(session: ISession) {
       order.push(m);
     }
   }
-  let rendermime = new RenderMime<Widget>(renderers, order);
+  let rendermime = new RenderMime<Widget>({ renderers, order });
 
   let consolePanel = new ConsolePanel({ session, rendermime });
   consolePanel.title.text = TITLE;

--- a/examples/filebrowser/src/index.ts
+++ b/examples/filebrowser/src/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  ContentsManager, SessionManager, IServiceManager, createServiceManager
+  IServiceManager, createServiceManager
 } from 'jupyter-js-services';
 
 import {
@@ -20,7 +20,6 @@ import {
 import {
   EditorWidgetFactory
 } from 'jupyterlab/lib/editorwidget/widget';
-
 
 import {
   showDialog, okButton

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from 'jupyterlab/lib/docregistry';
 
 import {
-  RenderMime, IRenderer, MimeMap
+  RenderMime
 } from 'jupyterlab/lib/rendermime';
 
 import {
@@ -83,7 +83,7 @@ function createApp(manager: IServiceManager): void {
     new LatexRenderer(),
     new TextRenderer()
   ];
-  let renderers: MimeMap<IRenderer<Widget>> = {};
+  let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
   let order: string[] = [];
   for (let t of transformers) {
     for (let m of t.mimetypes) {
@@ -91,7 +91,7 @@ function createApp(manager: IServiceManager): void {
       order.push(m);
     }
   }
-  let rendermime = new RenderMime<Widget>(renderers, order);
+  let rendermime = new RenderMime<Widget>({ renderers, order });
 
   let opener = {
     open: (widget: Widget) => {

--- a/src/codemirror/index.ts
+++ b/src/codemirror/index.ts
@@ -33,13 +33,36 @@ function loadModeByMIME(editor: CodeMirror.Editor, mimetype: string): void {
 }
 
 
-
 /**
  * Load a codemirror mode by mode name.
  */
 export
 function loadModeByName(editor: CodeMirror.Editor, mode: string): void {
   loadInfo(editor, CodeMirror.findModeByName(mode));
+}
+
+
+/**
+ * Require a codemirror mode by name.
+ */
+export
+function requireMode(mode: string): Promise<CodeMirror.modespec> {
+  if (CodeMirror.modes.hasOwnProperty(mode)) {
+    let spec = CodeMirror.findModeByName(mode);
+    if (spec) {
+      spec.name = spec.mode;
+    }
+    return Promise.resolve(spec);
+  }
+  return new Promise<CodeMirror.modespec>((resolve, reject) => {
+    require([`codemirror/mode/${mode}/${mode}`], () => {
+      let spec = CodeMirror.findModeByName(mode);
+      if (spec) {
+        spec.name = spec.mode;
+      }
+      return Promise.resolve(spec);
+    });
+  });
 }
 
 
@@ -51,11 +74,7 @@ function loadInfo(editor: CodeMirror.Editor, info: CodeMirror.modespec): void {
     editor.setOption('mode', 'null');
     return;
   }
-  if (CodeMirror.modes.hasOwnProperty(info.mode)) {
+  requireMode(info.mode).then(() => {
     editor.setOption('mode', info.mime);
-  } else {
-    require([`codemirror/mode/${info.mode}/${info.mode}`], () => {
-      editor.setOption('mode', info.mime);
-    });
-  }
+  });
 }

--- a/src/default-theme/codemirror.css
+++ b/src/default-theme/codemirror.css
@@ -1,0 +1,4 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -11,6 +11,7 @@
 @import url('~jupyterlab/lib/running/theme.css');
 
 @import './about.css';
+@import './codemirror.css';
 @import './commandpalette.css';
 @import './completion.css';
 @import './console.css';

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -19,6 +19,7 @@
 @import './images.css';
 @import './inspector.css';
 @import './markdownwidget.css';
+@import './rendermime.css';
 
 @import '../landing/index.css';
 

--- a/src/default-theme/rendermime.css
+++ b/src/default-theme/rendermime.css
@@ -1,0 +1,5 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+

--- a/src/default-theme/rendermime.css
+++ b/src/default-theme/rendermime.css
@@ -3,3 +3,229 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
+.jp-Rendered-html {
+  color: #000;
+  /* any extras will just be numbers: */
+}
+
+.jp-Rendered-html em {
+  font-style: italic;
+}
+
+.jp-Rendered-html strong {
+  font-weight: bold;
+}
+
+.jp-Rendered-html u {
+  text-decoration: underline;
+}
+
+.jp-Rendered-html :link {
+  text-decoration: underline;
+}
+
+.jp-Rendered-html :visited {
+  text-decoration: underline;
+}
+
+.jp-Rendered-html h1 {
+  font-size: 185.7%;
+  margin: 1.08em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+
+.jp-Rendered-html h2 {
+  font-size: 157.1%;
+  margin: 1.27em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+
+.jp-Rendered-html h3 {
+  font-size: 128.6%;
+  margin: 1.55em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+
+.jp-Rendered-html h4 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+}
+
+.jp-Rendered-html h5 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+
+.jp-Rendered-html h6 {
+  font-size: 100%;
+  margin: 2em 0 0 0;
+  font-weight: bold;
+  line-height: 1.0;
+  font-style: italic;
+}
+
+.jp-Rendered-html h1:first-child {
+  margin-top: 0.538em;
+}
+
+.jp-Rendered-html h2:first-child {
+  margin-top: 0.636em;
+}
+
+.jp-Rendered-html h3:first-child {
+  margin-top: 0.777em;
+}
+
+.jp-Rendered-html h4:first-child {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html h5:first-child {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html h6:first-child {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html ul:not(.list-inline),
+.jp-Rendered-html ol:not(.list-inline) {
+  padding-left: 2em;
+}
+
+.jp-Rendered-html ul {
+  list-style: disc;
+}
+
+.jp-Rendered-html ul ul {
+  list-style: square;
+}
+
+.jp-Rendered-html ul ul ul {
+  list-style: circle;
+}
+
+.jp-Rendered-html ol {
+  list-style: decimal;
+}
+
+.jp-Rendered-html ol ol {
+  list-style: upper-alpha;
+}
+
+.jp-Rendered-html ol ol ol {
+  list-style: lower-alpha;
+}
+
+.jp-Rendered-html ol ol ol ol {
+  list-style: lower-roman;
+}
+
+.jp-Rendered-html ol ol ol ol ol {
+  list-style: decimal;
+}
+
+.jp-Rendered-html * + ul {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html * + ol {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html hr {
+  color: black;
+  background-color: black;
+}
+
+.jp-Rendered-html pre {
+  margin: 1em 2em;
+}
+
+.jp-Rendered-html pre,
+.jp-Rendered-html code {
+  border: 0;
+  background-color: #fff;
+  color: #000;
+  font-size: 100%;
+  padding: 0px;
+}
+
+.jp-Rendered-html blockquote {
+  margin: 1em 2em;
+}
+
+.jp-Rendered-html table {
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid black;
+  border-collapse: collapse;
+}
+
+.jp-Rendered-html tr,
+.jp-Rendered-html th,
+.jp-Rendered-html td {
+  border: 1px solid black;
+  border-collapse: collapse;
+  margin: 1em 2em;
+}
+
+.jp-Rendered-html td,
+.jp-Rendered-html th {
+  text-align: left;
+  vertical-align: middle;
+  padding: 4px;
+}
+
+.jp-Rendered-html th {
+  font-weight: bold;
+}
+
+.jp-Rendered-html * + table {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html p {
+  text-align: left;
+}
+
+.jp-Rendered-html * + p {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.jp-Rendered-html * + img {
+  margin-top: 1em;
+}
+
+.jp-Rendered-html img,
+.jp-Rendered-html svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.jp-Rendered-html img.unconfined,
+.jp-Rendered-html svg.unconfined {
+  max-width: none;
+}
+
+.jp-Rendered-html .alert {
+  margin-bottom: initial;
+}
+
+.jp-Rendered-html * + .alert {
+  margin-top: 1em;
+}

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -26,13 +26,17 @@ import {
 } from '../notebook/cells/editor';
 
 import {
-  RenderMime, MimeMap
+  RenderMime
 } from '../rendermime';
 
 import {
   Inspector
 } from './';
 
+
+/**
+ * An object that handles code inspection.
+ */
 export
 class InspectionHandler implements IDisposable, Inspector.IInspectable {
   /**
@@ -139,9 +143,11 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
 
     let details = content.payload.filter(i => (i as any).source === 'page')[0];
     if (details) {
-      let bundle = (details as any).data as MimeMap<string>;
-      update.content = this._rendermime.render(bundle);
-      this.inspected.emit(update);
+      let bundle = (details as any).data as RenderMime.MimeMap<string>;
+      this._rendermime.render(bundle, true).then(widget => {
+        update.content = widget;
+        this.inspected.emit(update);
+      });
       return;
     }
 
@@ -194,9 +200,11 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
         return;
       }
 
-      let bundle = value.data as MimeMap<string>;
-      update.content = this._rendermime.render(bundle);
-      this.inspected.emit(update);
+      let bundle = value.data as RenderMime.MimeMap<string>;
+      this._rendermime.render(bundle, true).then(widget => {
+        update.content = widget;
+        this.inspected.emit(update);
+      });
     });
   }
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -10,7 +10,7 @@ import {
 } from '../../codemirror';
 
 import {
-  RenderMime, MimeMap
+  RenderMime
 } from '../../rendermime';
 
 import {
@@ -662,14 +662,17 @@ class MarkdownCellWidget extends BaseCellWidget {
       let text = model && model.source || DEFAULT_MARKDOWN_TEXT;
       // Do not re-render if the text has not changed.
       if (text !== this._prev) {
-        let bundle: MimeMap<string> = { 'text/markdown': text };
+        let bundle: RenderMime.MimeMap<string> = { 'text/markdown': text };
         this._markdownWidget.dispose();
-        this._markdownWidget = this._rendermime.render(bundle) || new Widget();
-        this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
-        (this.layout as PanelLayout).addChild(this._markdownWidget);
+        this._rendermime.render(bundle, this.trusted).then(widget => {
+          this._markdownWidget = widget || new Widget();
+          this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
+          (this.layout as PanelLayout).addChild(this._markdownWidget);
+        });
+      } else {
+        this._markdownWidget.show();
       }
       this._prev = text;
-      this._markdownWidget.show();
       this.toggleInput(false);
       this.addClass(RENDERED_CLASS);
     } else {

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -34,6 +34,16 @@ import {
 } from './latex';
 
 
+/**
+ * The class name added to rendered widgets.
+ */
+const RENDERED_CLASS = 'jp-Rendered';
+
+/**
+ * The class name added to rendered html widgets.
+ */
+const RENDERED_HTML = 'jp-Rendered-html';
+
 
 // Support GitHub flavored Markdown, leave sanitizing to external library.
 marked.setOptions({
@@ -83,6 +93,8 @@ class HTMLWidget extends Widget {
    */
   constructor(html: string) {
     super();
+    this.addClass(RENDERED_HTML);
+    this.addClass(RENDERED_CLASS);
     try {
       let range = document.createRange();
       this.node.appendChild(range.createContextualFragment(html));
@@ -181,6 +193,7 @@ class ImageRenderer implements RenderMime.IRenderer<Widget> {
     let img = document.createElement('img');
     img.src = `data:${mimetype};base64,${data}`;
     w.node.appendChild(img);
+    w.addClass(RENDERED_CLASS);
     return w;
   }
 }
@@ -224,6 +237,7 @@ class TextRenderer implements RenderMime.IRenderer<Widget> {
   render(mimetype: string, data: string): Widget {
     let w = new Widget();
     w.node.innerHTML = data;
+    w.addClass(RENDERED_CLASS);
     return w;
   }
 }
@@ -269,6 +283,7 @@ class JavascriptRenderer implements RenderMime.IRenderer<Widget> {
     s.type = mimetype;
     s.textContent = data;
     w.node.appendChild(s);
+    w.addClass(RENDERED_CLASS);
     return w;
   }
 }
@@ -315,6 +330,7 @@ class SVGRenderer implements RenderMime.IRenderer<Widget> {
     if (!svgElement) {
       throw new Error('SVGRender: Error: Failed to create <svg> element');
     }
+    w.addClass(RENDERED_CLASS);
     return w;
   }
 }
@@ -361,6 +377,7 @@ class PDFRenderer implements RenderMime.IRenderer<Widget> {
     a.textContent = 'View PDF';
     a.href = 'data:application/pdf;base64,' + data;
     w.node.appendChild(a);
+    w.addClass(RENDERED_CLASS);
     return w;
   }
 }

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -10,7 +10,7 @@ import * as marked
   from 'marked';
 
 import {
-  ansi_to_html
+  ansi_to_html, escape_for_html
 } from 'ansi_up';
 
 import {
@@ -200,20 +200,21 @@ class TextRenderer implements RenderMime.IRenderer<Widget> {
    * Whether the input can safely sanitized for a given mimetype.
    */
   sanitizable(mimetype: string): boolean {
-    return true;
+    return false;
   }
 
   /**
    * Whether the input is safe without sanitization.
    */
   isSafe(mimetype: string): boolean {
-    return false;
+    return true;
   }
 
   /**
    * Transform the input bundle.
    */
   transform(mimetype: string, data: string): string {
+    data = escape_for_html(data);
     return `<pre>${ansi_to_html(data)}</pre>`;
   }
 
@@ -369,11 +370,39 @@ class PDFRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for LateX data.
  */
 export
-class LatexRenderer extends HTMLRenderer {
+class LatexRenderer implements RenderMime.IRenderer<Widget>  {
   /**
    * The mimetypes this renderer accepts.
    */
   mimetypes = ['text/latex'];
+
+  /**
+   * Whether the input can safely sanitized for a given mimetype.
+   */
+  sanitizable(mimetype: string): boolean {
+    return false;
+  }
+
+  /**
+   * Whether the input is safe without sanitization.
+   */
+  isSafe(mimetype: string): boolean {
+    return false;
+  }
+
+  /**
+   * Transform the input bundle.
+   */
+  transform(mimetype: string, data: string): string {
+    return data;
+  }
+
+  /**
+   * Render the transformed mime bundle.
+   */
+  render(mimetype: string, data: string): Widget {
+    return new HTMLWidget(data);
+  }
 }
 
 

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -77,7 +77,6 @@ marked.setOptions({
 /**
  * A widget for displaying HTML and rendering math.
  */
-export
 class HTMLWidget extends Widget {
   /**
    * Construct a new html widget.
@@ -215,7 +214,7 @@ class TextRenderer implements RenderMime.IRenderer<Widget> {
    * Transform the input bundle.
    */
   transform(mimetype: string, data: string): string {
-    return ansi_to_html(data);
+    return `<pre>${ansi_to_html(data)}</pre>`;
   }
 
   /**
@@ -223,9 +222,7 @@ class TextRenderer implements RenderMime.IRenderer<Widget> {
    */
   render(mimetype: string, data: string): Widget {
     let w = new Widget();
-    let el = document.createElement('pre');
-    el.innerHTML = data;
-    w.node.appendChild(el);
+    w.node.innerHTML = data;
     return w;
   }
 }

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -115,6 +115,28 @@ class HTMLWidget extends Widget {
 
 
 /**
+ * A widget for displaying LaTeX output.
+ */
+class LatexWidget extends Widget {
+  /**
+   * Construct a new latex widget.
+   */
+  constructor(text: string) {
+    super();
+    this.node.textContent = text;
+    this.addClass(RENDERED_CLASS);
+  }
+
+  /**
+   * A message handler invoked on an `'after-attach'` message.
+   */
+  onAfterAttach(msg: Message): void {
+    typeset(this.node);
+  }
+}
+
+
+/**
  * A renderer for raw html.
  */
 export
@@ -404,7 +426,7 @@ class LatexRenderer implements RenderMime.IRenderer<Widget>  {
    * Whether the input is safe without sanitization.
    */
   isSafe(mimetype: string): boolean {
-    return false;
+    return true;
   }
 
   /**
@@ -418,7 +440,7 @@ class LatexRenderer implements RenderMime.IRenderer<Widget>  {
    * Render the transformed mime bundle.
    */
   render(mimetype: string, data: string): Widget {
-    return new HTMLWidget(data);
+    return new LatexWidget(data);
   }
 }
 

--- a/src/renderers/latex.ts
+++ b/src/renderers/latex.ts
@@ -203,7 +203,7 @@ function processMath(i: number, j: number, preProcess: (input: string) => string
     j--;
   }
   blocks[i] = '@@' + math.length + '@@'; // replace the current block text with a unique tag to find later
-  if (preProcess){
+  if (preProcess) {
     block = preProcess(block);
   }
   math.push(block);

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  RenderMime, MimeMap, IRenderer
+  RenderMime
 } from './index';
 
 import {
@@ -32,7 +32,7 @@ const renderMimeProvider = {
       new LatexRenderer(),
       new TextRenderer()
     ];
-    let renderers: MimeMap<IRenderer<Widget>> = {};
+    let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
     let order: string[] = [];
     for (let t of transformers) {
       for (let m of t.mimetypes) {
@@ -40,6 +40,6 @@ const renderMimeProvider = {
         order.push(m);
       }
     }
-    return new RenderMime<Widget>(renderers, order);
+    return new RenderMime<Widget>({ renderers, order });
   }
 };

--- a/src/sanitizer/index.ts
+++ b/src/sanitizer/index.ts
@@ -24,7 +24,7 @@ class Sanitizer implements ISanitizer {
   }
 
   private _options: sanitize.IOptions = {
-    allowedTags: sanitize.defaults.allowedTags.concat('h1', 'h2', 'img', 'span'),
+    allowedTags: sanitize.defaults.allowedTags.concat('svg', 'h1', 'h2', 'img', 'span'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),

--- a/src/sanitizer/index.ts
+++ b/src/sanitizer/index.ts
@@ -24,12 +24,16 @@ class Sanitizer implements ISanitizer {
   }
 
   private _options: sanitize.IOptions = {
-    allowedTags: sanitize.defaults.allowedTags.concat('h1', 'h2', 'img'),
+    allowedTags: sanitize.defaults.allowedTags.concat('h1', 'h2', 'img', 'span'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),
       // Allow the "src" attribute for <img> tags.
-      'img': ['src', 'height', 'width', 'alt']
+      'img': ['src', 'height', 'width', 'alt'],
+      // Allow "class" attribute for <code> tags.
+      'code': ['class'],
+      // Allow "class" attribute for <span> tags.
+      'span': ['class']
     },
     transformTags: {
       // Set the "rel" attribute for <a> tags to "nofollow".

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -102,9 +102,9 @@ describe('renderers', () => {
 
     describe('#isSafe()', () => {
 
-      it('should be `false`', () => {
+      it('should be `true`', () => {
         let t = new LatexRenderer();
-        expect(t.isSafe('text/latex')).to.be(false);
+        expect(t.isSafe('text/latex')).to.be(true);
       });
 
     });
@@ -122,12 +122,13 @@ describe('renderers', () => {
 
     describe('#render()', () => {
 
-      it('should set the inner html of the widget', () => {
-        let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
+      it('should set the textContent of the widget', () => {
+        let mathJaxScript = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
         let t = new LatexRenderer();
         let widget = t.render('text/latex', mathJaxScript);
-        expect(widget.node.innerHTML).to.be(mathJaxScript);
+        expect(widget.node.textContent).to.be(mathJaxScript);
       });
+
     });
 
   });

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -13,181 +13,472 @@ describe('renderers', () => {
 
   describe('TextRenderer', () => {
 
-    it('should have the text/plain and jupyter/console-text mimetype', () => {
-      let mimetypes = ['text/plain', 'application/vnd.jupyter.console-text'];
-      let t = new TextRenderer();
-      expect(t.mimetypes).to.eql(mimetypes);
+    describe('#mimetypes', () => {
+
+      it('should have the text/plain and jupyter/console-text mimetype', () => {
+        let mimetypes = ['text/plain', 'application/vnd.jupyter.console-text'];
+        let t = new TextRenderer();
+        expect(t.mimetypes).to.eql(mimetypes);
+      });
+
     });
 
-    it('should output the correct HTML', () => {
-      let consoleText = 'x = 2 ** a';
-      let t = new TextRenderer();
-      let w = t.render('application/vnd.jupyter.console-text', consoleText);
-      let el = w.node;
-      expect(el.innerHTML).to.be('<pre>x = 2 ** a</pre>');
-      expect(el.textContent).to.be(consoleText);
+    describe('#sanitizable()', () => {
+
+      it('should be `true`', () => {
+        let t = new TextRenderer();
+        expect(t.sanitizable('text/plain')).to.be(true);
+        expect(t.sanitizable('application/vnd.jupyter.console-text')).to.be(true);
+      });
+
     });
 
-    it('should output the correct HTML with ansi colors', () => {
-      let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
-      let plainText = 'There is no text but text.\nWoo.';
-      let innerHTML = '<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>';
-      let t = new TextRenderer();
-      text = t.transform('application/vnd.jupyter.console-text', text);
-      let w = t.render('application/vnd.jupyter.console-text', text);
-      let el = w.node;
-      expect(el.innerHTML).to.be(innerHTML);
-      expect(el.textContent).to.be(plainText);
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new TextRenderer();
+        expect(t.isSafe('text/plain')).to.be(false);
+        expect(t.isSafe('application/vnd.jupyter.console-text')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should output the correct HTML', () => {
+        let t = new TextRenderer();
+        let text = t.transform('text/plain', 'x = 2 ** a');
+        expect(text).to.be('<pre>x = 2 ** a</pre>');
+      });
+
+      it('should output the correct HTML with ansi colors', () => {
+        let t = new TextRenderer();
+        let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+        text = t.transform('application/vnd.jupyter.console-text', text);
+        expect(text).to.be('<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should set the inner html of the widget', () => {
+        let t = new TextRenderer();
+        let html = '<pre>Hello</pre>';
+        let widget = t.render('text/plain', html);
+        expect(widget.node.innerHTML).to.be(html);
+      });
+
     });
 
   });
 
-
   describe('LatexRenderer', () => {
 
-    it('should have the text/latex mimetype', () => {
-      let t = new LatexRenderer();
-      expect(t.mimetypes).to.eql(['text/latex']);
+    describe('#mimetypes', () => {
+
+      it('should have the text/latex mimetype', () => {
+        let t = new LatexRenderer();
+        expect(t.mimetypes).to.eql(['text/latex']);
+      });
+
     });
 
-    it('should output the correct MathJax script', () => {
-      let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
-      let t = new LatexRenderer();
-      let w = t.render('text/latex', mathJaxScript);
-      expect(w.node.innerHTML).to.be(mathJaxScript);
+    describe('#sanitizable()', () => {
+
+      it('should be `true`', () => {
+        let t = new LatexRenderer();
+        expect(t.sanitizable('text/latex')).to.be(true);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new LatexRenderer();
+        expect(t.isSafe('text/latex')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
+        let t = new LatexRenderer();
+        let text = t.transform('text/latex', mathJaxScript);
+        expect(text).to.be(mathJaxScript);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should set the inner html of the widget', () => {
+        let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
+        let t = new LatexRenderer();
+        let widget = t.render('text/latex', mathJaxScript);
+        expect(widget.node.innerHTML).to.be(mathJaxScript);
+      });
     });
 
   });
 
   describe('PDFRenderer', () => {
 
-    it('should have the application/pdf mimetype', () => {
-      let t = new PDFRenderer();
-      expect(t.mimetypes).to.eql(['application/pdf']);
+    describe('#mimetypes', () => {
+
+      it('should have the application/pdf mimetype', () => {
+        let t = new PDFRenderer();
+        expect(t.mimetypes).to.eql(['application/pdf']);
+      });
+
     });
 
-    it('should output the correct HTML', () => {
-      let base64PDF = "I don't have a b64'd PDF";
-      let t = new PDFRenderer();
-      let w = t.render('application/pdf', base64PDF);
-      expect(w.node.innerHTML.indexOf('data:application/pdf')).to.not.be(-1);
+    describe('#sanitizable()', () => {
+
+      it('should be `false`', () => {
+        let t = new PDFRenderer();
+        expect(t.sanitizable('application/pdf')).to.be(false);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new PDFRenderer();
+        expect(t.isSafe('application/pdf')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        let base64PDF = "I don't have a b64'd PDF";
+        let t = new PDFRenderer();
+        let text = t.transform('application/pdf', base64PDF);
+        expect(text).to.be(base64PDF);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should render the correct HTML', () => {
+        let base64PDF = "I don't have a b64'd PDF";
+        let t = new PDFRenderer();
+        let w = t.render('application/pdf', base64PDF);
+        expect(w.node.innerHTML.indexOf('data:application/pdf')).to.not.be(-1);
+      });
+
     });
 
   });
 
   describe('JavascriptRenderer', () => {
 
-    it('should have the text/javascript mimetype', () => {
-      let mimetypes = ['text/javascript', 'application/javascript'];
-      let t = new JavascriptRenderer();
-      expect(t.mimetypes).to.eql(mimetypes);
+    describe('#mimetypes', () => {
+
+      it('should have the text/javascript mimetype', () => {
+        let mimetypes = ['text/javascript', 'application/javascript'];
+        let t = new JavascriptRenderer();
+        expect(t.mimetypes).to.eql(mimetypes);
+      });
+
     });
 
-    it('should create a script tag', () => {
-      let t = new JavascriptRenderer();
-      let w = t.render('text/javascript', 'window.x = 1');
-      let el = w.node.firstChild as HTMLElement;
-      expect(el.localName).to.be('script');
-      expect(el.textContent).to.be('window.x = 1');
+    describe('#sanitizable()', () => {
 
-      // Ensure script has not been run yet
-      expect((window as any).x).to.be(void 0);
-      // Put it on the DOM
-      w.attach(document.body);
-      // Should be evaluated now
-      expect((window as any).x).to.be(1);
-      w.dispose();
+      it('should be `false`', () => {
+        let t = new JavascriptRenderer();
+        expect(t.sanitizable('text/javascript')).to.be(false);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new JavascriptRenderer();
+        expect(t.isSafe('text/javascript')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        let t = new PDFRenderer();
+        let text = t.transform('text/javascript', 'window.x = 1');
+        expect(text).to.be('window.x = 1');
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should create a script tag', () => {
+        let t = new JavascriptRenderer();
+        let w = t.render('text/javascript', 'window.x = 1');
+        let el = w.node.firstChild as HTMLElement;
+        expect(el.localName).to.be('script');
+        expect(el.textContent).to.be('window.x = 1');
+
+        // Ensure script has not been run yet
+        expect((window as any).x).to.be(void 0);
+        // Put it on the DOM
+        w.attach(document.body);
+        // Should be evaluated now
+        expect((window as any).x).to.be(1);
+        w.dispose();
+      });
+
     });
 
   });
 
-
   describe('SVGRenderer', () => {
 
-    it('should have the image/svg+xml mimetype', () => {
-      let t = new SVGRenderer();
-      expect(t.mimetypes).to.eql(['image/svg+xml']);
+    describe('#mimetypes', () => {
+
+      it('should have the image/svg+xml mimetype', () => {
+        let t = new SVGRenderer();
+        expect(t.mimetypes).to.eql(['image/svg+xml']);
+      });
+
     });
 
-    it('should create an svg tag', () => {
-      const svg = `
-          <?xml version="1.0" standalone="no"?>
-          <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-          SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-          <svg></svg>
-      `;
-      let t = new SVGRenderer();
-      let w = t.render('image/svg+xml', svg);
+    describe('#sanitizable()', () => {
+
+      it('should be `true`', () => {
+        let t = new SVGRenderer();
+        expect(t.sanitizable('image/svg+xml')).to.be(true);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new SVGRenderer();
+        expect(t.isSafe('image/svg+xml')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        const svg = `
+            <?xml version="1.0" standalone="no"?>
+            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+            SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+            <svg></svg>`;
+        let t = new SVGRenderer();
+        let text = t.transform('image/svg+xml', svg);
+        expect(text).to.be(svg);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should create an svg tag', () => {
+        const svg = `
+            <?xml version="1.0" standalone="no"?>
+            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+            SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+            <svg></svg>
+        `;
+        let t = new SVGRenderer();
+        let w = t.render('image/svg+xml', svg);
+        let svgEl = w.node.getElementsByTagName('svg')[0];
+        expect(svgEl).to.be.ok();
+      });
+
     });
 
   });
 
   describe('MarkdownRenderer', () => {
 
-    it('should have the text/markdown mimetype', function() {
-      let t = new MarkdownRenderer();
-      expect(t.mimetypes).to.eql(['text/markdown']);
+    describe('#mimetypes', () => {
+
+      it('should have the text/markdown mimetype', function() {
+        let t = new MarkdownRenderer();
+        expect(t.mimetypes).to.eql(['text/markdown']);
+      });
+
     });
 
-    it('should create nice markup', (done) => {
-      let md = require('../../../examples/filebrowser/sample.md');
-      let t = new MarkdownRenderer();
-      t.transform('text/markdown', md as string).then(text => {
-        expect(text).to.be(`<h1 id="title-first-level">Title first level</h1>\n<h2 id="title-second-level">Title second Level</h2>\n<h3 id="title-third-level">Title third level</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h5">h5</h5>\n<h6 id="h6">h6</h6>\n<h1 id="h1">h1</h1>\n<h2 id="h2">h2</h2>\n<h3 id="h3">h3</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h6">h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2 id="and-another-one">and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th style="text-align:center">Are</th>\n<th style="text-align:right">Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td style="text-align:center">right-aligned</td>\n<td style="text-align:right">1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td style="text-align:center">centered</td>\n<td style="text-align:right">12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td style="text-align:center">are neat</td>\n<td style="text-align:right">1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don&#39;t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
-      }).then(done, done);
+    describe('#sanitizable()', () => {
+
+      it('should be `true`', () => {
+        let t = new MarkdownRenderer();
+        expect(t.sanitizable('text/markdown')).to.be(true);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new MarkdownRenderer();
+        expect(t.isSafe('text/markdown')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should create nice markup', (done) => {
+        let md = require('../../../examples/filebrowser/sample.md');
+        let t = new MarkdownRenderer();
+        t.transform('text/markdown', md as string).then(text => {
+          expect(text).to.be(`<h1 id="title-first-level">Title first level</h1>\n<h2 id="title-second-level">Title second Level</h2>\n<h3 id="title-third-level">Title third level</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h5">h5</h5>\n<h6 id="h6">h6</h6>\n<h1 id="h1">h1</h1>\n<h2 id="h2">h2</h2>\n<h3 id="h3">h3</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h6">h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2 id="and-another-one">and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th style="text-align:center">Are</th>\n<th style="text-align:right">Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td style="text-align:center">right-aligned</td>\n<td style="text-align:right">1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td style="text-align:center">centered</td>\n<td style="text-align:right">12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td style="text-align:center">are neat</td>\n<td style="text-align:right">1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don&#39;t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
+        }).then(done, done);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should set the inner html', () => {
+        let t = new MarkdownRenderer();
+        let html = '<p>hello</p>';
+        let w = t.render('text/markdown', html);
+        expect(w.node.innerHTML).to.be(html);
+      });
+
     });
 
   });
 
   describe('HTMLRenderer', () => {
 
-    it('should have the text/html mimetype', () => {
-      let t = new HTMLRenderer();
-      expect(t.mimetypes).to.eql(['text/html']);
+    describe('#mimetypes', () => {
+
+      it('should have the text/html mimetype', () => {
+        let t = new HTMLRenderer();
+        expect(t.mimetypes).to.eql(['text/html']);
+      });
+
     });
 
-    it('should create a div with all the passed in elements', () => {
-      let t = new HTMLRenderer();
-      const htmlText = '<h1>This is great</h1>';
-      let w = t.render('text/html', htmlText);
-      let el = w.node.firstChild as HTMLElement;
-      expect(el.innerHTML).to.be('This is great');
+    describe('#sanitizable()', () => {
+
+      it('should be `true`', () => {
+        let t = new HTMLRenderer();
+        expect(t.sanitizable('text/html')).to.be(true);
+      });
+
     });
 
-    it('should execute a script tag when attached', () => {
-      const htmlText = '<script>window.y=3;</script>';
-      let t = new HTMLRenderer();
-      let w = t.render('text/html', htmlText);
-      expect((window as any).y).to.be(void 0);
-      w.attach(document.body);
-      expect((window as any).y).to.be(3);
-      w.dispose();
+    describe('#isSafe()', () => {
+
+      it('should be `false`', () => {
+        let t = new HTMLRenderer();
+        expect(t.isSafe('text/html')).to.be(false);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        let t = new HTMLRenderer();
+        const htmlText = '<h1>This is great</h1>';
+        let text = t.transform('text/html', htmlText);
+        expect(text).to.be(htmlText);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should set the inner HTML', () => {
+        let t = new HTMLRenderer();
+        const htmlText = '<h1>This is great</h1>';
+        let w = t.render('text/html', htmlText);
+        expect(w.node.innerHTML).to.be('<h1>This is great</h1>');
+      });
+
+      it('should execute a script tag when attached', () => {
+        const htmlText = '<script>window.y=3;</script>';
+        let t = new HTMLRenderer();
+        let w = t.render('text/html', htmlText);
+        expect((window as any).y).to.be(void 0);
+        w.attach(document.body);
+        expect((window as any).y).to.be(3);
+        w.dispose();
+      });
+
     });
 
   });
 
   describe('ImageRenderer', () => {
 
-    it('should support multiple mimetypes', () => {
-      let t = new ImageRenderer();
-      expect(t.mimetypes).to.eql(['image/png', 'image/jpeg', 'image/gif']);
+    describe('#mimetypes', () => {
+
+      it('should support multiple mimetypes', () => {
+        let t = new ImageRenderer();
+        expect(t.mimetypes).to.eql(['image/png', 'image/jpeg', 'image/gif']);
+      });
+
     });
 
-    it('should create an <img> with the right mimetype', () => {
-      const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-      let t = new ImageRenderer();
-      let w = t.render('image/png', imageData);
-      let el = w.node.firstChild as HTMLImageElement;
-      expect(el.src).to.be('data:image/png;base64,' + imageData);
-      expect(el.localName).to.be('img');
-      expect(el.innerHTML).to.be('');
+    describe('#sanitizable()', () => {
 
-      const imageData2 = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
-      w = t.render('image/gif', imageData2);
-      el = w.node.firstChild as HTMLImageElement;
-      expect(el.src).to.be('data:image/gif;base64,' + imageData2);
-      expect(el.localName).to.be('img');
-      expect(el.innerHTML).to.be('');
+      it('should be `false`', () => {
+        let t = new ImageRenderer();
+        expect(t.sanitizable('image/png')).to.be(false);
+      });
+
+    });
+
+    describe('#isSafe()', () => {
+
+      it('should be `true`', () => {
+        let t = new ImageRenderer();
+        expect(t.isSafe('image/png')).to.be(true);
+      });
+
+    });
+
+    describe('#transform()', () => {
+
+      it('should be a no-op', () => {
+        let t = new ImageRenderer();
+        const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        let text = t.transform('image/png', imageData);
+        expect(text).to.be(imageData);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should create an <img> with the right mimetype', () => {
+        const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        let t = new ImageRenderer();
+        let w = t.render('image/png', imageData);
+        let el = w.node.firstChild as HTMLImageElement;
+        expect(el.src).to.be('data:image/png;base64,' + imageData);
+        expect(el.localName).to.be('img');
+        expect(el.innerHTML).to.be('');
+
+        const imageData2 = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
+        w = t.render('image/gif', imageData2);
+        el = w.node.firstChild as HTMLImageElement;
+        expect(el.src).to.be('data:image/gif;base64,' + imageData2);
+        expect(el.localName).to.be('img');
+        expect(el.innerHTML).to.be('');
+      });
+
     });
 
   });

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -25,20 +25,20 @@ describe('renderers', () => {
 
     describe('#sanitizable()', () => {
 
-      it('should be `true`', () => {
+      it('should be `false`', () => {
         let t = new TextRenderer();
-        expect(t.sanitizable('text/plain')).to.be(true);
-        expect(t.sanitizable('application/vnd.jupyter.console-text')).to.be(true);
+        expect(t.sanitizable('text/plain')).to.be(false);
+        expect(t.sanitizable('application/vnd.jupyter.console-text')).to.be(false);
       });
 
     });
 
     describe('#isSafe()', () => {
 
-      it('should be `false`', () => {
+      it('should be `true`', () => {
         let t = new TextRenderer();
-        expect(t.isSafe('text/plain')).to.be(false);
-        expect(t.isSafe('application/vnd.jupyter.console-text')).to.be(false);
+        expect(t.isSafe('text/plain')).to.be(true);
+        expect(t.isSafe('application/vnd.jupyter.console-text')).to.be(true);
       });
 
     });
@@ -56,6 +56,13 @@ describe('renderers', () => {
         let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
         text = t.transform('application/vnd.jupyter.console-text', text);
         expect(text).to.be('<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
+      });
+
+      it('should escape inline html', () => {
+        let t = new TextRenderer();
+        let text = 'There is no text <script>window.x=1</script> but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+        text = t.transform('application/vnd.jupyter.console-text', text);
+        expect(text).to.be('<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
       });
 
     });
@@ -86,9 +93,9 @@ describe('renderers', () => {
 
     describe('#sanitizable()', () => {
 
-      it('should be `true`', () => {
+      it('should be `false`', () => {
         let t = new LatexRenderer();
-        expect(t.sanitizable('text/latex')).to.be(true);
+        expect(t.sanitizable('text/latex')).to.be(false);
       });
 
     });

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../lib/renderers';
 
 
-describe('jupyter-ui', () => {
+describe('renderers', () => {
 
   describe('TextRenderer', () => {
 
@@ -24,15 +24,16 @@ describe('jupyter-ui', () => {
       let t = new TextRenderer();
       let w = t.render('application/vnd.jupyter.console-text', consoleText);
       let el = w.node;
-      expect(el.innerHTML).to.be("<pre>x = 2 ** a</pre>");
+      expect(el.innerHTML).to.be('<pre>x = 2 ** a</pre>');
       expect(el.textContent).to.be(consoleText);
     });
 
     it('should output the correct HTML with ansi colors', () => {
-      let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.'
-      let plainText = 'There is no text but text.\nWoo.'
-      let innerHTML = '<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>'
+      let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+      let plainText = 'There is no text but text.\nWoo.';
+      let innerHTML = '<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>';
       let t = new TextRenderer();
+      text = t.transform('application/vnd.jupyter.console-text', text);
       let w = t.render('application/vnd.jupyter.console-text', text);
       let el = w.node;
       expect(el.innerHTML).to.be(innerHTML);
@@ -50,7 +51,6 @@ describe('jupyter-ui', () => {
     });
 
     it('should output the correct MathJax script', () => {
-      let latex = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
       let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
       let t = new LatexRenderer();
       let w = t.render('text/latex', mathJaxScript);
@@ -87,8 +87,8 @@ describe('jupyter-ui', () => {
       let t = new JavascriptRenderer();
       let w = t.render('text/javascript', 'window.x = 1');
       let el = w.node.firstChild as HTMLElement;
-      expect(el.localName).to.be("script");
-      expect(el.textContent).to.be("window.x = 1");
+      expect(el.localName).to.be('script');
+      expect(el.textContent).to.be('window.x = 1');
 
       // Ensure script has not been run yet
       expect((window as any).x).to.be(void 0);
@@ -126,14 +126,15 @@ describe('jupyter-ui', () => {
 
     it('should have the text/markdown mimetype', function() {
       let t = new MarkdownRenderer();
-      expect(t.mimetypes).to.eql(["text/markdown"]);
+      expect(t.mimetypes).to.eql(['text/markdown']);
     });
 
-    it('should create nice markup', () => {
+    it('should create nice markup', (done) => {
       let md = require('../../../examples/filebrowser/sample.md');
       let t = new MarkdownRenderer();
-      let w = t.render('text/markdown', md as string);
-      expect(w.node.innerHTML).to.be(`<h1>Title first level</h1>\n<h2>Title second Level</h2>\n<h3>Title third level</h3>\n<h4>h4</h4>\n<h5>h5</h5>\n<h6>h6</h6>\n<h1>h1</h1>\n<h2>h2</h2>\n<h3>h3</h3>\n<h4>h4</h4>\n<h5>h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2>and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th>Are</th>\n<th>Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td>right-aligned</td>\n<td>1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td>centered</td>\n<td>12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td>are neat</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don\'t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
+      t.transform('text/markdown', md as string).then(text => {
+        expect(text).to.be(`<h1 id="title-first-level">Title first level</h1>\n<h2 id="title-second-level">Title second Level</h2>\n<h3 id="title-third-level">Title third level</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h5">h5</h5>\n<h6 id="h6">h6</h6>\n<h1 id="h1">h1</h1>\n<h2 id="h2">h2</h2>\n<h3 id="h3">h3</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h6">h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2 id="and-another-one">and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th style="text-align:center">Are</th>\n<th style="text-align:right">Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td style="text-align:center">right-aligned</td>\n<td style="text-align:right">1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td style="text-align:center">centered</td>\n<td style="text-align:right">12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td style="text-align:center">are neat</td>\n<td style="text-align:right">1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don&#39;t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
+      }).then(done, done);
     });
 
   });
@@ -181,10 +182,10 @@ describe('jupyter-ui', () => {
       expect(el.localName).to.be('img');
       expect(el.innerHTML).to.be('');
 
-      const imageData2 = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs='
+      const imageData2 = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
       w = t.render('image/gif', imageData2);
       el = w.node.firstChild as HTMLImageElement;
-      expect(el.src).to.be('data:image/gif;base64,' + imageData2)
+      expect(el.src).to.be('data:image/gif;base64,' + imageData2);
       expect(el.localName).to.be('img');
       expect(el.innerHTML).to.be('');
     });

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -78,9 +78,63 @@ describe('jupyter-ui', () => {
           'text/html': '<h1>foo</h1>'
         };
         let r = defaultRenderMime();
-        r.render(bundle).then(w => {
+        r.render(bundle, true).then(w => {
           let el = w.node.firstChild as HTMLElement;
           expect(el.localName).to.be('h1');
+        }).then(done, done);
+      });
+
+      it('should render the mimetype that is safe', (done) => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'text/plain': 'foo',
+          'text/javascript': 'window.x = 1',
+          'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        };
+        let r = defaultRenderMime();
+        r.render(bundle, false).then(w => {
+          let el = w.node.firstChild as HTMLElement;
+          expect(el.localName).to.be('img');
+        }).then(done, done);
+      });
+
+      it('should render the mimetype that is sanitizable', (done) => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'text/plain': 'foo',
+          'text/html': '<h1>foo</h1>'
+        };
+        let r = defaultRenderMime();
+        r.render(bundle, false).then(w => {
+          let el = w.node.firstChild as HTMLElement;
+          expect(el.localName).to.be('h1');
+        }).then(done, done);
+      });
+
+      it('should sanitize markdown', (done) => {
+        let md = require('../../../examples/filebrowser/sample.md');
+        let r = defaultRenderMime();
+        r.render({ 'text/markdown': md as string }).then(widget => {
+          expect(widget.node.innerHTML).to.be(`<h1>Title first level</h1>\n<h2>Title second Level</h2>\n<h3>Title third level</h3>\n<h4>h4</h4>\n<h5>h5</h5>\n<h6>h6</h6>\n<h1>h1</h1>\n<h2>h2</h2>\n<h3>h3</h3>\n<h4>h4</h4>\n<h5>h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2>and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th>Are</th>\n<th>Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td>right-aligned</td>\n<td>1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td>centered</td>\n<td>12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td>are neat</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don\'t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
+        }).then(done, done);
+      });
+
+      it('should sanitize html', (done) => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'text/html': '<h1>foo <script>window.x=1></scrip></h1>'
+        };
+        let r = defaultRenderMime();
+        r.render(bundle).then(widget => {
+          expect(widget.node.innerHTML).to.be('<h1>foo </h1>');
+        }).then(done, done);
+      });
+
+      it('should sanitize svg', (done) => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'image/svg+xml': '<svg><script>windox.x=1</script></svg>'
+        };
+        let r = defaultRenderMime();
+        r.render(bundle).then(widget => {
+          expect(widget.node.innerHTML.indexOf('svg')).to.not.be(-1);
+          expect(widget.node.innerHTML.indexOf('script')).to.be(-1);
         }).then(done, done);
       });
 
@@ -102,6 +156,24 @@ describe('jupyter-ui', () => {
         expect(r.preferredMimetype({ 'text/fizz': 'buzz' })).to.be(void 0);
       });
 
+      it('should select the mimetype that is safe', () => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'text/plain': 'foo',
+          'text/javascript': 'window.x = 1',
+          'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+        };
+        let r = defaultRenderMime();
+        expect(r.preferredMimetype(bundle, false)).to.be('image/png');
+      });
+
+      it('should render the mimetype that is sanitizable', () => {
+        let bundle: RenderMime.MimeMap<string> = {
+          'text/plain': 'foo',
+          'text/html': '<h1>foo</h1>'
+        };
+        let r = defaultRenderMime();
+        expect(r.preferredMimetype(bundle, false)).to.be('text/html');
+      });
     });
 
     describe('#clone()', () => {

--- a/typings/codemirror/codemirror.d.ts
+++ b/typings/codemirror/codemirror.d.ts
@@ -42,6 +42,8 @@ declare module CodeMirror {
     }
     var modeInfo: modeinfo[];
 
+    function runMode(code: string, mode: modespec, el: HTMLElement): void;
+
     var version: string;
 
     /** If you want to define extra methods in terms of the CodeMirror API, it is possible to use defineExtension.

--- a/typings/marked/marked.d.ts
+++ b/typings/marked/marked.d.ts
@@ -11,7 +11,7 @@ interface MarkedStatic {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    (src: string, callback: Function): string;
+    (src: string, callback: (err: Error, content: string) => void): string;
 
     /**
      * Compiles markdown to HTML.
@@ -21,7 +21,7 @@ interface MarkedStatic {
      * @param callback Function called when the markdownString has been fully parsed when using async highlighting
      * @return String of compiled HTML
      */
-    (src: string, options?: MarkedOptions, callback?: Function): string;
+    (src: string, options?: MarkedOptions, callback?: (err: Error, content: string) => void): string;
 
     /**
      * @param src String of markdown source to be compiled


### PR DESCRIPTION
Moves the sanitization and trusted handling onto the RenderMime instance.
Also adds code highlighting, which prompted the need for an asynchronous render method.

cf https://github.com/jupyter/jupyterlab/issues/446#issuecomment-234672802
Fixes https://github.com/jupyter/jupyterlab/issues/131

<img width="206" alt="screen shot 2016-07-25 at 11 15 56 am" src="https://cloud.githubusercontent.com/assets/2096628/17108453/35438550-5259-11e6-9e8b-574cba0c75db.png">
