### PR TITLE
Prototype of vega/vega-lite file rendering...

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -29,6 +29,7 @@ var app = new phosphide.Application({
     require('jupyterlab/lib/running/plugin').runningSessionsExtension,
     require('jupyterlab/lib/shortcuts/plugin').shortcutsExtension,
     require('jupyterlab/lib/terminal/plugin').terminalExtension,
+    require('jupyterlab/lib/vegawidget/plugin').vegaHandlerExtension,
     require('phosphide/lib/extensions/commandpalette').commandPaletteExtension,
     require('jupyter-js-widgets-labextension/lib/plugin').widgetManagerExtension,
   ],

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ansi_up": "^1.3.0",
     "backbone": "^1.2.0",
     "codemirror": "^5.12.0",
+    "d3": "^4.1.1",
     "d3-dsv": "^1.0.0",
     "diff-match-patch": "^1.0.0",
     "es6-promise": "^3.2.1",
@@ -36,6 +37,9 @@
     "phosphor-widget": "^1.0.0-rc.1",
     "sanitize-html": "^1.12.0",
     "simulate-event": "^1.2.0",
+    "vega": "^2.6.1",
+    "vega-embed": "^2.2.0",
+    "vega-lite": "^1.0.16",
     "xterm": "^0.33.0"
   },
   "devDependencies": {

--- a/src/index.css
+++ b/src/index.css
@@ -10,5 +10,6 @@
 @import './mainmenu/index.css';
 @import './notebook/completion/index.css';
 @import './terminal/index.css';
+@import './vegawidget/base.css';
 
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -11,3 +11,4 @@
 /// <reference path="../typings/marked/marked.d.ts"/>
 /// <reference path="../typings/leaflet/leaflet.d.ts"/>
 /// <reference path="../typings/d3-dsv/d3-dsv.d.ts"/>
+/// <reference path="../typings/vega-embed/vega-embed.d.ts"/>

--- a/src/vegawidget/base.css
+++ b/src/vegawidget/base.css
@@ -1,0 +1,17 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+.jp-VegaWidget, .jp-VegaLiteWidget {
+  padding: 8px;
+  overflow: auto;
+}
+
+.vega-embed svg, .vega-embed canvas {
+  border: 1px dotted gray;
+}
+
+.vega-embed .vega-actions a {
+  margin-right: 8px;
+}

--- a/src/vegawidget/plugin.ts
+++ b/src/vegawidget/plugin.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Application
+} from 'phosphide/lib/core/application';
+
+import {
+  DocumentRegistry
+} from '../docregistry';
+
+import {
+  VegaWidget, VegaWidgetFactory, VegaLiteWidget, VegaLiteWidgetFactory
+} from './widget';
+
+
+/**
+ * The list of file extensions for vega and vegalite.
+ */
+const VEGA_EXTENSIONS = ['.vg', 'vg.json', '.json'];
+const VEGALITE_EXTENSIONS = ['.vl', 'vl.json', '.json'];
+
+
+/**
+ * The table file handler extension.
+ */
+export
+const vegaHandlerExtension = {
+  id: 'jupyter.extensions.vegaHandler',
+  requires: [DocumentRegistry],
+  activate: activateVegaWidget
+};
+
+
+/**
+ * Activate the table widget extension.
+ */
+function activateVegaWidget(app: Application, registry: DocumentRegistry): void {
+
+    let options = {
+      fileExtensions: VEGA_EXTENSIONS,
+      defaultFor: VEGA_EXTENSIONS.slice(0,2),
+      displayName: 'Vega',
+      modelName: 'text',
+      preferKernel: false,
+      canStartKernel: false
+    };
+
+    registry.addWidgetFactory(new VegaWidgetFactory(), options);
+
+    options = {
+      fileExtensions: VEGALITE_EXTENSIONS,
+      defaultFor: VEGALITE_EXTENSIONS.slice(0,2),
+      displayName: 'VegaLite',
+      modelName: 'text',
+      preferKernel: false,
+      canStartKernel: false
+    };
+
+    registry.addWidgetFactory(new VegaLiteWidgetFactory(), options);
+}

--- a/src/vegawidget/widget.ts
+++ b/src/vegawidget/widget.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IKernel
+} from 'jupyter-js-services';
+
+import {
+  Message
+} from 'phosphor-messaging';
+
+import {
+  Widget
+} from 'phosphor-widget';
+
+import {
+  ABCWidgetFactory, IDocumentModel, IDocumentContext
+} from '../docregistry';
+
+import embed = require('vega-embed');
+
+
+/**
+ * The class name added to a Vega widget.
+ */
+const VEGA_CLASS = 'jp-VegaWidget';
+
+/**
+ * The class name added to a VegaLite widget.
+ */
+const VEGALITE_CLASS = 'jp-VegaLiteWidget';
+
+
+/**
+ * A widget for csv tables.
+ */
+export
+class BaseVegaWidget extends Widget {
+
+  protected _vegaEmbedMode: string;
+  private _vegaNode: HTMLElement;
+
+  /**
+   * Construct a new csv table widget.
+   */
+  constructor(context: IDocumentContext<IDocumentModel>) {
+    super();
+    this._context = context;
+    this.node.tabIndex = -1;
+    this._vegaNode = document.createElement('div');
+    this._vegaNode.className = 'vega-embed';
+    this.node.appendChild(this._vegaNode);
+
+    if (context.model.toString()) {
+      this.update();
+    }
+    context.pathChanged.connect(() => {
+      this.update();
+    });
+    context.model.contentChanged.connect(() => {
+      this.update();
+    });
+    context.contentsModelChanged.connect(() => {
+      this.update();
+    });
+  }
+
+  /**
+   * Dispose of the resources used by the widget.
+   */
+  dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this._context = null;
+    super.dispose();
+  }
+
+  /**
+   * Handle `update-request` messages for the widget.
+   */
+  protected onUpdateRequest(msg: Message): void {
+    this.title.text = this._context.path.split('/').pop();
+    let cm = this._context.contentsModel;
+    if (cm === null) {
+      return;
+    }
+    let content = this._context.model.toString();
+    this.renderVega(content);
+  }
+
+  /**
+   * Render an html table from a csv string.
+   */
+  renderVega(content: string) {
+    let embedSpec = {
+      mode: this._vegaEmbedMode,
+      source: content
+    };
+
+    embed(this._vegaNode, embedSpec, function(error: any, result: any): any {});
+  }
+
+  private _context: IDocumentContext<IDocumentModel>;
+}
+
+
+/**
+ * A widget for rendering Vega JSON
+ */
+export
+class VegaWidget extends BaseVegaWidget {
+  /**
+   * Construct a VegaWidget
+   */
+  constructor(context: IDocumentContext<IDocumentModel>) {
+    super(context);
+    this.addClass(VEGA_CLASS);
+    this._vegaEmbedMode = 'vega';
+  }
+}
+
+
+/**
+ * A widget for rendering VegaLite JSON
+ */
+export
+class VegaLiteWidget extends BaseVegaWidget {
+  /**
+   * Construct a VegaLiteWidget
+   */
+  constructor(context: IDocumentContext<IDocumentModel>) {
+    super(context);
+    this.addClass(VEGALITE_CLASS);
+    this._vegaEmbedMode = 'vega-lite';
+  }
+}
+
+
+/**
+ * A widget factory for the Vega widget
+ */
+export
+class VegaWidgetFactory extends ABCWidgetFactory<VegaWidget, IDocumentModel> {
+  /**
+   * Create a new widget given a context.
+   */
+  createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernel.IModel): VegaWidget {
+    let widget = new VegaWidget(context);
+    this.widgetCreated.emit(widget);
+    return widget;
+  }
+}
+
+
+/**
+ * A widget factory for the VegaLite widget
+ */
+export
+class VegaLiteWidgetFactory extends ABCWidgetFactory<VegaLiteWidget, IDocumentModel> {
+  /**
+   * Create a new widget given a context.
+   */
+  createNew(context: IDocumentContext<IDocumentModel>, kernel?: IKernel.IModel): VegaLiteWidget {
+    let widget = new VegaLiteWidget(context);
+    this.widgetCreated.emit(widget);
+    return widget;
+  }
+}

--- a/typings/vega-embed/vega-embed.d.ts
+++ b/typings/vega-embed/vega-embed.d.ts
@@ -1,0 +1,5 @@
+
+declare module 'vega-embed' {
+    function embed(el: any, opt: any, callback: any): any;
+    export = embed;
+}


### PR DESCRIPTION
Probably don't want to merge this yet as it introduces top-level d3/vega/vega-lite dependencies. Works well, but brings up a question:

Arbitrary files, such as vega JSON can refer to other files using relative paths. These alternative files can be parsed by arbitrary JS libraries (in this case by vega/vega-lite/d3). How on earth will be ever get those relative paths to be recognized?

<img width="1271" alt="screen shot 2016-07-25 at 9 24 51 pm" src="https://cloud.githubusercontent.com/assets/27600/17126133/2c40ba26-52af-11e6-8754-8cfa67adc6be.png">
