### PR TITLE
Add a saveas dialog for contexts

### DIFF
--- a/src/docregistry/interfaces.ts
+++ b/src/docregistry/interfaces.ts
@@ -191,9 +191,9 @@ export interface IDocumentContext<T extends IDocumentModel> extends IDisposable 
   save(): Promise<void>;
 
   /**
-   * Save the document to a different path.
+   * Save the document to a different path chosen by the user.
    */
-  saveAs(path: string): Promise<void>;
+  saveAs(): Promise<void>;
 
   /**
    * Revert the document contents to disk contents.

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -117,7 +117,7 @@ const TEXTEDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 /**
  * Activate the file browser.
  */
-function activateFileBrowser(app: Application, manager: ServiceManager, registry: DocumentRegistry, mainMenu: MainMenu): Promise<void> {
+function activateFileBrowser(app: Application, manager: ServiceManager, registry: DocumentRegistry, mainMenu: MainMenu): void {
   let id = 0;
 
   let tracker = new WidgetTracker<Widget>();
@@ -252,6 +252,30 @@ function activateFileBrowser(app: Application, manager: ServiceManager, registry
     }
   ]);
 
+
+// Add the command for saving a document with a new name.
+  let saveDocumentAsId = 'file-operations:saveas';
+
+  app.commands.add([
+    {
+      id: saveDocumentAsId,
+      handler: () => {
+        if (activeWidget) {
+          let context = docManager.contextForWidget(activeWidget);
+          context.saveAs().then(() => { fbModel.refresh(); });
+        }
+      }
+    }
+  ]);
+  app.palette.add([
+    {
+      command: saveDocumentAsId,
+      category: 'File Operations',
+      text: 'Save As...',
+      caption: 'Save the current document as...'
+    }
+  ]);
+
   // Add the command for closing a document.
   let closeDocumentId = 'file-operations:close';
 
@@ -331,66 +355,67 @@ function activateFileBrowser(app: Application, manager: ServiceManager, registry
 
 
 
-    // Adding Top Menu
-      let newSubMenu = new Menu ([
-        new MenuItem({
-          text: 'Notebook',
-          handler: () => {
-            app.commands.execute(newNotebookId);
-          }
-        }),
-        new MenuItem({
-          text: 'Text File',
-          handler: () => {
-            app.commands.execute(newTextFileId);
-          }
-        })
+  // Adding Top Menu
+  let newSubMenu = new Menu ([
+    new MenuItem({
+      text: 'Notebook',
+      handler: () => {
+        app.commands.execute(newNotebookId);
+      }
+    }),
+    new MenuItem({
+      text: 'Text File',
+      handler: () => {
+        app.commands.execute(newTextFileId);
+      }
+    })
 
-      ]);
+  ]);
 
+  let menu = new Menu ([
+    new MenuItem({
+      text: 'New',
+      submenu: newSubMenu
 
+    }),
+    new MenuItem({
+      text: 'Save Document',
+      handler: () => {
+        app.commands.execute(saveDocumentId);
+      }
+    }),
+    new MenuItem({
+      text: 'Save Document As...',
+      handler: () => {
+        app.commands.execute(saveDocumentAsId);
+      }
+    }),
+    new MenuItem({
+      text: 'Revert Document',
+      handler: () => {
+        app.commands.execute(revertDocumentId);
+      }
+    }),
+    new MenuItem({
+      text: 'Close Current',
+      handler: () => {
+        app.commands.execute(closeDocumentId);
+      }
+    }),
+    new MenuItem({
+      text: 'Close All',
+      handler: () => {
+        app.commands.execute(closeAllId);
+      }
+    }),
 
-      let menu = new Menu ([
-        new MenuItem({
-          text: 'New',
-          submenu: newSubMenu
+  ]);
 
-        }),
-        new MenuItem({
-          text: 'Save Document',
-          handler: () => {
-            app.commands.execute(saveDocumentId);
-          }
-        }),
-        new MenuItem({
-          text: 'Revert Document',
-          handler: () => {
-            app.commands.execute(revertDocumentId);
-          }
-        }),
-        new MenuItem({
-          text: 'Close Current',
-          handler: () => {
-            app.commands.execute(closeDocumentId);
-          }
-        }),
-        new MenuItem({
-          text: 'Close All',
-          handler: () => {
-            app.commands.execute(closeAllId);
-          }
-        }),
-
-      ]);
-
-      let fileMenu = new MenuItem({
-        text: 'File',
-        submenu: menu
-      });
-      mainMenu.addItem(fileMenu, {rank: 1});
-
-
-  return Promise.resolve(void 0);
+  let fileMenu = new MenuItem({
+    text: 'File',
+    submenu: menu
+  });
+  mainMenu.addItem(fileMenu, {rank: 1});
 
   function showBrowser(): void {
     app.shell.activateLeft(fbWidget.id);

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -526,7 +526,7 @@ function createDocumentMenu(context: IDocumentContext<IDocumentModel>): Menu {
       handler: () => { context.save(); }
     }),
     new MenuItem({
-      text: 'Save &As',
+      text: 'Save &As...',
       handler: () => { context.saveAs(); }
     }),
     new MenuItem({
@@ -534,7 +534,7 @@ function createDocumentMenu(context: IDocumentContext<IDocumentModel>): Menu {
       handler: () => { context.revert(); }
     }),
     new MenuItem({
-      text: 'Change &Kernel',
+      text: 'Change &Kernel...',
       handler: () => { selectKernelForContext(context); }
     })
   ];

--- a/test/src/docmanager/mockcontext.ts
+++ b/test/src/docmanager/mockcontext.ts
@@ -101,9 +101,9 @@ class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
     return Promise.resolve(void 0);
   }
 
-  saveAs(path: string): Promise<void> {
-    this._path = path;
-    this.pathChanged.emit(path);
+  saveAs(): Promise<void> {
+    this._path = 'foo';
+    this.pathChanged.emit(this._path);
     this.methods.push('saveAs');
     return Promise.resolve(void 0);
   }

--- a/test/src/notebook/notebook/panel.spec.ts
+++ b/test/src/notebook/notebook/panel.spec.ts
@@ -373,7 +373,7 @@ describe('notebook/notebook/panel', () => {
       it('should be called when the path changes', () => {
         let panel = createPanel();
         panel.methods = [];
-        panel.context.saveAs('foo.ipynb');
+        panel.context.saveAs();
         expect(panel.methods).to.contain('onPathChanged');
       });
 
@@ -389,9 +389,9 @@ describe('notebook/notebook/panel', () => {
       it('should update the title text', () => {
         let panel = createPanel();
         panel.methods = [];
-        panel.context.saveAs('test/foo.ipynb');
+        panel.context.saveAs();
         expect(panel.methods).to.contain('onPathChanged');
-        expect(panel.title.text).to.be('foo.ipynb');
+        expect(panel.title.text).to.be('foo');
       });
 
     });


### PR DESCRIPTION
Fixes #428.  Fixes #482.  Currently very naive (just a simple input box with the full server path).


![saveas](https://cloud.githubusercontent.com/assets/2096628/17145258/2265355c-531f-11e6-91a8-da18c5aa154d.gif)


Also adds a context menu for documents (fixes #209).

<img width="229" alt="screen shot 2016-07-26 at 11 36 09 am" src="https://cloud.githubusercontent.com/assets/2096628/17146755/32171c6c-5325-11e6-9ae0-11a871e2b777.png">


