### PR TITLE
Landing Opens in a new Tab

### DIFF
--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -17,6 +17,10 @@ import {
   Widget
 } from 'phosphor-widget';
 
+import {
+  TabPanel
+} from 'phosphor-tabs';
+
 /**
  * The landing page extension.
  */
@@ -133,6 +137,14 @@ function activateLanding(app: Application, services: ServiceManager, pathTracker
     handler: () => {
       if (!widget.isAttached) {
         app.shell.addToMainArea(widget);
+      }
+      let stack = widget.parent;
+      if (!stack) {
+        return;
+      }
+      let tabs = stack.parent;
+      if (tabs instanceof TabPanel) {
+        tabs.currentWidget = widget;
       }
       app.shell.activateMain(widget.id);
     }


### PR DESCRIPTION
If Landing page is already open, the view changes to it. Otherwise its brought into view.
![launcher](https://cloud.githubusercontent.com/assets/16314651/17150215/6ef362f0-5323-11e6-8fa1-5288252565dc.gif)

![launcher2](https://cloud.githubusercontent.com/assets/16314651/17150224/76cafff6-5323-11e6-92ec-18203eea8bb1.gif)

