### PR TITLE
Relative url handling and renderer cleanup

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -19,6 +19,10 @@ import {
 } from 'jupyterlab/lib/renderers';
 
 import {
+  defaultSanitizer
+} from 'jupyterlab/lib/sanitizer';
+
+import {
   CommandPalette, StandardPaletteModel, IStandardPaletteItemOptions
 } from 'phosphor-commandpalette';
 
@@ -29,10 +33,6 @@ import {
 import {
   SplitPanel
 } from 'phosphor-splitpanel';
-
-import {
-  Widget
-} from 'phosphor-widget';
 
 import 'jupyterlab/lib/console/base.css';
 import 'jupyterlab/lib/default-theme/completion.css';
@@ -74,7 +74,7 @@ function startApp(session: ISession) {
     new LatexRenderer(),
     new TextRenderer()
   ];
-  let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
+  let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];
   for (let t of transformers) {
     for (let m of t.mimetypes) {
@@ -82,7 +82,8 @@ function startApp(session: ISession) {
       order.push(m);
     }
   }
-  let rendermime = new RenderMime<Widget>({ renderers, order });
+  let sanitizer = defaultSanitizer;
+  let rendermime = new RenderMime({ renderers, order, sanitizer });
 
   let consolePanel = new ConsolePanel({ session, rendermime });
   consolePanel.title.text = TITLE;

--- a/examples/notebook/src/index.ts
+++ b/examples/notebook/src/index.ts
@@ -28,6 +28,10 @@ import {
 } from 'jupyterlab/lib/renderers';
 
 import {
+  defaultSanitizer
+} from 'jupyterlab/lib/sanitizer';
+
+import {
   CommandPalette, StandardPaletteModel, IStandardPaletteItemOptions
 } from 'phosphor-commandpalette';
 
@@ -83,7 +87,7 @@ function createApp(manager: IServiceManager): void {
     new LatexRenderer(),
     new TextRenderer()
   ];
-  let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
+  let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
   let order: string[] = [];
   for (let t of transformers) {
     for (let m of t.mimetypes) {
@@ -91,7 +95,8 @@ function createApp(manager: IServiceManager): void {
       order.push(m);
     }
   }
-  let rendermime = new RenderMime<Widget>({ renderers, order });
+  let sanitizer = defaultSanitizer;
+  let rendermime = new RenderMime({ renderers, order, sanitizer });
 
   let opener = {
     open: (widget: Widget) => {

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -14,10 +14,6 @@ import {
 } from 'phosphor-panel';
 
 import {
-  Widget
-} from 'phosphor-widget';
-
-import {
   showDialog
 } from '../dialog';
 
@@ -132,7 +128,7 @@ namespace ConsolePanel {
     /**
      * The mime renderer for the console panel.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
 
     /**
      * The session for the console panel.

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -14,10 +14,6 @@ import {
 } from 'phosphor-menus';
 
 import {
-  Widget
-} from 'phosphor-widget';
-
-import {
   selectKernel
 } from '../docregistry';
 
@@ -67,7 +63,7 @@ const CONSOLE_ICON_CLASS = 'jp-ImageConsole';
 /**
  * Activate the console extension.
  */
-function activateConsole(app: Application, services: ServiceManager, rendermime: RenderMime<Widget>, mainMenu: MainMenu, inspector: Inspector): Promise<void> {
+function activateConsole(app: Application, services: ServiceManager, rendermime: RenderMime, mainMenu: MainMenu, inspector: Inspector): Promise<void> {
   let tracker = new WidgetTracker<ConsolePanel>();
   let manager = services.sessions;
 

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -375,7 +375,7 @@ class ConsoleWidget extends Widget {
   private _completionHandler: CellCompletionHandler = null;
   private _inspectionHandler: InspectionHandler = null;
   private _mimetype = 'text/x-ipython';
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _renderer: ConsoleWidget.IRenderer = null;
   private _history: IConsoleHistory = null;
   private _session: ISession = null;
@@ -399,7 +399,7 @@ namespace ConsoleWidget {
     /**
      * The mime renderer for the console widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
 
     /**
      * The renderer for a console widget.
@@ -425,7 +425,7 @@ namespace ConsoleWidget {
     /**
      * Create a new prompt widget.
      */
-    createPrompt(rendermime: RenderMime<Widget>): CodeCellWidget;
+    createPrompt(rendermime: RenderMime): CodeCellWidget;
   }
 
   /**
@@ -445,7 +445,7 @@ namespace ConsoleWidget {
     /**
      * Create a new prompt widget.
      */
-    createPrompt(rendermime: RenderMime<Widget>): CodeCellWidget {
+    createPrompt(rendermime: RenderMime): CodeCellWidget {
       let widget = new CodeCellWidget({ rendermime });
       widget.model = new CodeCellModel();
       return widget;

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -191,11 +191,10 @@ class Context implements IDocumentContext<IDocumentModel> {
   }
 
   /**
-   * Traverse the DOM hierarchy of a node, translating
-   * relative URLs.
+   * Resolve a url to a correct server path.
    */
-  resolveUrls(node: HTMLElement): void {
-    return this._manager.resolveUrls(this._id, node);
+  resolveUrl(url: string): string {
+    return this._manager.resolveUrl(this._id, url);
   }
 
   /**
@@ -536,21 +535,16 @@ class ContextManager implements IDisposable {
   }
 
   /**
-   * Traverse the DOM hierarchy of a node, translating
-   * relative URLs.
+   * Resolve a relative url to a correct server path.
    */
-  resolveUrls(id: string, node: HTMLElement): void {
+  resolveUrl(id: string, url: string): string {
+    if (url.indexOf('./')) {
+      return url;
+    }
     let contextEx = this._contexts[id];
     let cwd = ContentsManager.dirname(contextEx.path);
-    let imgs = node.getElementsByTagName('img');
-    for (let i = 0; i < imgs.length; i++) {
-      let img = imgs[i];
-      let source = img.getAttribute('src');
-      if (source.indexOf('./') !== -1) {
-        let path = ContentsManager.getAbsolutePath(source, cwd);
-        img.src = this._manager.contents.getDownloadUrl(path);
-      }
-    }
+    let path = ContentsManager.getAbsolutePath(url, cwd);
+    return this._manager.contents.getDownloadUrl(path);
   }
 
   /**

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -539,7 +539,7 @@ class ContextManager implements IDisposable {
    */
   resolveUrl(id: string, url: string): string {
     // TODO: use proper url parser here.
-    if (url.indexOf('http') === 0 || url.indexOf('data') === 0) {
+    if (url.indexOf(':') !== -1) {
       return url;
     }
     let contextEx = this._contexts[id];

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -539,7 +539,7 @@ class ContextManager implements IDisposable {
    */
   resolveUrl(id: string, url: string): string {
     // TODO: use proper url parser here.
-    if (url.indexOf('http') === 0) {
+    if (url.indexOf('http') === 0 || url.indexOf('data') === 0) {
       return url;
     }
     let contextEx = this._contexts[id];

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -538,7 +538,8 @@ class ContextManager implements IDisposable {
    * Resolve a relative url to a correct server path.
    */
   resolveUrl(id: string, url: string): string {
-    if (url.indexOf('./')) {
+    // TODO: use proper url parser here.
+    if (url.indexOf('http') === 0) {
       return url;
     }
     let contextEx = this._contexts[id];

--- a/src/docregistry/interfaces.ts
+++ b/src/docregistry/interfaces.ts
@@ -206,10 +206,9 @@ export interface IDocumentContext<T extends IDocumentModel> extends IDisposable 
   listSessions(): Promise<ISession.IModel[]>;
 
   /**
-   * Traverse the DOM hierarchy of a node, translating
-   * relative URLs.
+   * Resolve a url to a correct server path.
    */
-  resolveUrls(node: HTMLElement): void;
+  resolveUrl(url: string): string;
 
   /**
    * Add a sibling widget to the document manager.

--- a/src/docregistry/interfaces.ts
+++ b/src/docregistry/interfaces.ts
@@ -206,6 +206,12 @@ export interface IDocumentContext<T extends IDocumentModel> extends IDisposable 
   listSessions(): Promise<ISession.IModel[]>;
 
   /**
+   * Traverse the DOM hierarchy of a node, translating
+   * relative URLs.
+   */
+  resolveUrls(node: HTMLElement): void;
+
+  /**
    * Add a sibling widget to the document manager.
    *
    * @param widget - The widget to add to the document manager.

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -42,7 +42,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
   /**
    * Construct a new inspection handler for a widget.
    */
-  constructor(rendermime: RenderMime<Widget>) {
+  constructor(rendermime: RenderMime) {
     this._rendermime = rendermime;
   }
 
@@ -212,7 +212,7 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
   private _isDisposed = false;
   private _kernel: IKernel = null;
   private _pending = 0;
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
 }
 
 

--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -144,10 +144,9 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
     let details = content.payload.filter(i => (i as any).source === 'page')[0];
     if (details) {
       let bundle = (details as any).data as RenderMime.MimeMap<string>;
-      this._rendermime.render(bundle, true).then(widget => {
-        update.content = widget;
-        this.inspected.emit(update);
-      });
+      let widget = this._rendermime.render(bundle, true);
+      update.content = widget;
+      this.inspected.emit(update);
       return;
     }
 
@@ -201,10 +200,9 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
       }
 
       let bundle = value.data as RenderMime.MimeMap<string>;
-      this._rendermime.render(bundle, true).then(widget => {
-        update.content = widget;
-        this.inspected.emit(update);
-      });
+      let widget = this._rendermime.render(bundle, true);
+      update.content = widget;
+      this.inspected.emit(update);
     });
   }
 

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -33,7 +33,7 @@ const TEXTEDITOR_ICON_CLASS = 'jp-ImageTextEditor';
  */
 export
 const markdownHandlerExtension = {
-  id: 'jupyter.extensions.RenderedMarkdown',
+  id: 'jupyter.extensions.rendered-markdown',
   requires: [DocumentRegistry, RenderMime],
   activate: (app: Application, registry: DocumentRegistry, rendermime: RenderMime) => {
     let options: IWidgetFactoryOptions = {

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -10,6 +10,10 @@ import {
 } from '../docregistry';
 
 import {
+  RenderMime
+} from '../rendermime';
+
+import {
   MarkdownWidgetFactory
 } from './widget';
 
@@ -30,8 +34,8 @@ const TEXTEDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 export
 const markdownHandlerExtension = {
   id: 'jupyter.extensions.RenderedMarkdown',
-  requires: [DocumentRegistry],
-  activate: (app: Application, registry: DocumentRegistry) => {
+  requires: [DocumentRegistry, RenderMime],
+  activate: (app: Application, registry: DocumentRegistry, rendermime: RenderMime) => {
     let options: IWidgetFactoryOptions = {
       fileExtensions: ['.md'],
       displayName: 'Rendered Markdown',
@@ -39,7 +43,7 @@ const markdownHandlerExtension = {
       preferKernel: false,
       canStartKernel: false
     };
-    let factory = new MarkdownWidgetFactory();
+    let factory = new MarkdownWidgetFactory(rendermime);
     let icon = `${PORTRAIT_ICON_CLASS} ${TEXTEDITOR_ICON_CLASS}`;
     factory.widgetCreated.connect((sender, widget) => {
       widget.title.icon = icon;

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -72,15 +72,21 @@ class MarkdownWidget extends Widget {
     let context = this._context;
     let model = context.model;
     let layout = this.layout as PanelLayout;
-    let widget = renderer.render({
+    renderer.transform({
       mimetype: 'text/markdown',
       source: model.toString(),
       resolver: context
+    }).then(source => {
+      let widget = renderer.render({
+        mimetype: 'text/markdown',
+        source,
+        resolver: context
+      });
+      if (layout.childCount()) {
+        layout.childAt(0).dispose();
+      }
+      layout.addChild(widget);
     });
-    if (layout.childCount()) {
-      layout.childAt(0).dispose();
-    }
-    layout.addChild(widget);
   }
 
   private _renderer: MarkdownRenderer = null;

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -46,7 +46,7 @@ class MarkdownWidget extends Widget {
     this.layout = new PanelLayout();
     this.title.text = context.path.split('/').pop();
     this._renderer = new MarkdownRenderer();
-    this._model = context.model;
+    this._context = context;
 
     context.pathChanged.connect((c, path) => {
       this.title.text = path.split('/').pop();
@@ -69,9 +69,14 @@ class MarkdownWidget extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     let renderer = this._renderer;
-    let model = this._model;
+    let context = this._context;
+    let model = context.model;
     let layout = this.layout as PanelLayout;
-    let widget = renderer.render('text/markdown', model.toString());
+    let widget = renderer.render({
+      mimetype: 'text/markdown',
+      source: model.toString(),
+      resolver: context
+    });
     if (layout.childCount()) {
       layout.childAt(0).dispose();
     }
@@ -79,7 +84,7 @@ class MarkdownWidget extends Widget {
   }
 
   private _renderer: MarkdownRenderer = null;
-  private _model: IDocumentModel = null;
+  private _context: IDocumentContext<IDocumentModel> = null;
 }
 
 

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -72,14 +72,13 @@ class MarkdownWidget extends Widget {
     let context = this._context;
     let model = context.model;
     let layout = this.layout as PanelLayout;
-    this._rendermime.render({
+    let widget = this._rendermime.render({
      'text/markdown': model.toString(),
-    }).then(widget => {
-      if (layout.childCount()) {
-        layout.childAt(0).dispose();
-      }
-      layout.addChild(widget);
     });
+    if (layout.childCount()) {
+      layout.childAt(0).dispose();
+    }
+    layout.addChild(widget);
   }
 
   private _rendermime: RenderMime = null;

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -532,7 +532,7 @@ class CodeCellWidget extends BaseCellWidget {
   }
 
   private _renderer: CodeCellWidget.IRenderer;
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _output: OutputAreaWidget = null;
   private _collapsedCursor: IMetadataCursor = null;
   private _scrolledCursor: IMetadataCursor = null;
@@ -559,7 +559,7 @@ namespace CodeCellWidget {
     /**
      * The mime renderer for the cell widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
   }
 
 
@@ -571,7 +571,7 @@ namespace CodeCellWidget {
     /**
      * Create a new output area for the widget.
      */
-    createOutputArea(rendermime: RenderMime<Widget>): OutputAreaWidget;
+    createOutputArea(rendermime: RenderMime): OutputAreaWidget;
   }
 
 
@@ -583,7 +583,7 @@ namespace CodeCellWidget {
     /**
      * Create an output area widget.
      */
-    createOutputArea(rendermime: RenderMime<Widget>): OutputAreaWidget {
+    createOutputArea(rendermime: RenderMime): OutputAreaWidget {
       return new OutputAreaWidget({ rendermime });
     }
   }
@@ -683,7 +683,7 @@ class MarkdownCellWidget extends BaseCellWidget {
     super.onUpdateRequest(msg);
   }
 
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _markdownWidget: Widget = null;
   private _rendered = true;
   private _prev = '';
@@ -710,7 +710,7 @@ namespace MarkdownCellWidget {
     /**
      * The mime renderer for the cell widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
   }
 }
 

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -664,13 +664,10 @@ class MarkdownCellWidget extends BaseCellWidget {
       if (text !== this._prev) {
         let bundle: RenderMime.MimeMap<string> = { 'text/markdown': text };
         this._markdownWidget.dispose();
-        this._rendermime.render(bundle, this.trusted).then(widget => {
-          this._markdownWidget = widget || new Widget();
-          this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
-          (this.layout as PanelLayout).addChild(this._markdownWidget);
-        }).catch(err => {
-          console.error(err);
-        });
+        let widget = this._rendermime.render(bundle, this.trusted);
+        this._markdownWidget = widget || new Widget();
+        this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
+        (this.layout as PanelLayout).addChild(this._markdownWidget);
       } else {
         this._markdownWidget.show();
       }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -668,6 +668,8 @@ class MarkdownCellWidget extends BaseCellWidget {
           this._markdownWidget = widget || new Widget();
           this._markdownWidget.addClass(MARKDOWN_CONTENT_CLASS);
           (this.layout as PanelLayout).addChild(this._markdownWidget);
+        }).catch(err => {
+          console.error(err);
         });
       } else {
         this._markdownWidget.show();

--- a/src/notebook/notebook/panel.ts
+++ b/src/notebook/notebook/panel.ts
@@ -162,7 +162,7 @@ class NotebookPanel extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get rendermime(): RenderMime<Widget> {
+  get rendermime(): RenderMime {
     return this._rendermime;
   }
 
@@ -210,6 +210,7 @@ class NotebookPanel extends Widget {
     }
     let oldValue = this._context;
     this._context = newValue;
+    this._rendermime.resolver = newValue;
     // Trigger private, protected, and public changes.
     this._onContextChanged(oldValue, newValue);
     this.onContextChanged(oldValue, newValue);
@@ -356,7 +357,7 @@ class NotebookPanel extends Widget {
   private _content: Notebook = null;
   private _context: IDocumentContext<INotebookModel> = null;
   private _renderer: NotebookPanel.IRenderer = null;
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
 }
 
 
@@ -372,7 +373,7 @@ export namespace NotebookPanel {
     /**
      * The rendermime instance used by the panel.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
 
     /**
      * The application clipboard.

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -172,7 +172,7 @@ class StaticNotebook extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get rendermime(): RenderMime<Widget> {
+  get rendermime(): RenderMime {
     return this._rendermime;
   }
 
@@ -424,7 +424,7 @@ class StaticNotebook extends Widget {
 
   private _mimetype = 'text/plain';
   private _model: INotebookModel = null;
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _renderer: StaticNotebook.IRenderer = null;
 }
 
@@ -442,7 +442,7 @@ namespace StaticNotebook {
     /**
      * The rendermime instance used by the widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
 
     /**
      * The language preference for the model.
@@ -465,12 +465,12 @@ namespace StaticNotebook {
     /**
      * Create a new code cell widget.
      */
-    createCodeCell(model: ICodeCellModel, rendermime: RenderMime<Widget>): CodeCellWidget;
+    createCodeCell(model: ICodeCellModel, rendermime: RenderMime): CodeCellWidget;
 
     /**
      * Create a new markdown cell widget.
      */
-    createMarkdownCell(model: IMarkdownCellModel, rendermime: RenderMime<Widget>): MarkdownCellWidget;
+    createMarkdownCell(model: IMarkdownCellModel, rendermime: RenderMime): MarkdownCellWidget;
 
     /**
      * Create a new raw cell widget.
@@ -499,7 +499,7 @@ namespace StaticNotebook {
     /**
      * Create a new code cell widget.
      */
-    createCodeCell(model: ICodeCellModel, rendermime: RenderMime<Widget>): CodeCellWidget {
+    createCodeCell(model: ICodeCellModel, rendermime: RenderMime): CodeCellWidget {
       let widget = new CodeCellWidget({ rendermime });
       widget.model = model;
       return widget;
@@ -508,7 +508,7 @@ namespace StaticNotebook {
     /**
      * Create a new markdown cell widget.
      */
-    createMarkdownCell(model: IMarkdownCellModel, rendermime: RenderMime<Widget>): MarkdownCellWidget {
+    createMarkdownCell(model: IMarkdownCellModel, rendermime: RenderMime): MarkdownCellWidget {
       let widget = new MarkdownCellWidget({ rendermime });
       widget.model = model;
       return widget;

--- a/src/notebook/notebook/widgetfactory.ts
+++ b/src/notebook/notebook/widgetfactory.ts
@@ -46,7 +46,7 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
    *
    * @param clipboard - The application clipboard.
    */
-  constructor(rendermime: RenderMime<Widget>, clipboard: IClipboard) {
+  constructor(rendermime: RenderMime, clipboard: IClipboard) {
     super();
     this._rendermime = rendermime;
     this._clipboard = clipboard;
@@ -83,6 +83,6 @@ class NotebookWidgetFactory extends ABCWidgetFactory<NotebookPanel, INotebookMod
     return panel;
   }
 
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _clipboard: IClipboard = null;
 }

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -702,12 +702,12 @@ class OutputWidget extends Widget {
    *
    * @param trusted - Whether the output is trusted.
    */
-  render(output: OutputAreaModel.Output, trusted=false): Promise<void> {
+  render(output: OutputAreaModel.Output, trusted=false): void {
     // Handle an input request.
     if (output.output_type === 'input_request') {
       let child = new InputWidget(output as OutputAreaModel.IInputRequest);
       this.setOutput(child);
-      return Promise.resolve(void 0);
+      return;
     }
 
     // Extract the data from the output and sanitize if necessary.
@@ -722,7 +722,7 @@ class OutputWidget extends Widget {
     let msg = 'Did not find renderer for output mimebundle.';
     if (!data) {
       console.log(msg);
-      return Promise.resolve(void 0);
+      return;
     }
 
     // Create the output result area.

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -208,7 +208,7 @@ class OutputAreaWidget extends Widget {
    * #### Notes
    * This is a read-only property.
    */
-  get rendermime(): RenderMime<Widget> {
+  get rendermime(): RenderMime {
     return this._rendermime;
   }
 
@@ -433,7 +433,7 @@ class OutputAreaWidget extends Widget {
   private _fixedHeight = false;
   private _collapsed = false;
   private _model: OutputAreaModel = null;
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _renderer: OutputAreaWidget.IRenderer = null;
 }
 
@@ -451,7 +451,7 @@ namespace OutputAreaWidget {
     /**
      * The rendermime instance used by the widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
 
     /**
      * The output widget renderer.
@@ -838,7 +838,7 @@ class OutputWidget extends Widget {
     return map;
   }
 
-  private _rendermime: RenderMime<Widget> = null;
+  private _rendermime: RenderMime = null;
   private _placeholder: Widget = null;
 }
 
@@ -939,7 +939,7 @@ namespace OutputWidget {
     /**
      * The rendermime instance used by the widget.
      */
-    rendermime: RenderMime<Widget>;
+    rendermime: RenderMime;
   }
 }
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -726,39 +726,38 @@ class OutputWidget extends Widget {
     }
 
     // Create the output result area.
-    return rendermime.render(data, trusted).then(child => {
-      if (!child) {
-        console.log(msg);
-        console.log(data);
-        return;
-      }
-      this.setOutput(child);
+    let child = rendermime.render(data, trusted);
+    if (!child) {
+      console.log(msg);
+      console.log(data);
+      return;
+    }
+    this.setOutput(child);
 
-      // Add classes and output prompt as necessary.
-      switch (output.output_type) {
-      case 'execute_result':
-        child.addClass(EXECUTE_CLASS);
-        let count = (output as nbformat.IExecuteResult).execution_count;
-        this.prompt.node.textContent = `Out[${count === null ? ' ' : count}]:`;
-        break;
-      case 'display_data':
-        child.addClass(DISPLAY_CLASS);
-        break;
-      case 'stream':
-        if ((output as nbformat.IStream).name === 'stdout') {
-          child.addClass(STDOUT_CLASS);
-        } else {
-          child.addClass(STDERR_CLASS);
-        }
-        break;
-      case 'error':
-        child.addClass(ERROR_CLASS);
-        break;
-      default:
-        console.error(`Unrecognized output type: ${output.output_type}`);
-        data = {};
+    // Add classes and output prompt as necessary.
+    switch (output.output_type) {
+    case 'execute_result':
+      child.addClass(EXECUTE_CLASS);
+      let count = (output as nbformat.IExecuteResult).execution_count;
+      this.prompt.node.textContent = `Out[${count === null ? ' ' : count}]:`;
+      break;
+    case 'display_data':
+      child.addClass(DISPLAY_CLASS);
+      break;
+    case 'stream':
+      if ((output as nbformat.IStream).name === 'stdout') {
+        child.addClass(STDOUT_CLASS);
+      } else {
+        child.addClass(STDERR_CLASS);
       }
-    });
+      break;
+    case 'error':
+      child.addClass(ERROR_CLASS);
+      break;
+    default:
+      console.error(`Unrecognized output type: ${output.output_type}`);
+      data = {};
+    }
   }
 
   /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -146,7 +146,7 @@ const notebookTrackerProvider = {
 /**
  * Activate the notebook handler extension.
  */
-function activateNotebookHandler(app: Application, registry: DocumentRegistry, services: ServiceManager, rendermime: RenderMime<Widget>, clipboard: IClipboard, mainMenu: MainMenu, inspector: Inspector): void {
+function activateNotebookHandler(app: Application, registry: DocumentRegistry, services: ServiceManager, rendermime: RenderMime, clipboard: IClipboard, mainMenu: MainMenu, inspector: Inspector): void {
 
   let widgetFactory = new NotebookWidgetFactory(rendermime, clipboard);
   let options: IWidgetFactoryOptions = {

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -455,6 +455,17 @@ class MarkdownRenderer implements RenderMime.IRenderer {
       out += '>';
       return out;
     };
+    let dummy = document.createElement('div');
+    // Catch-all.
+    renderer.paragraph = (text: string) => {
+      text = '<p>' + text + '</p>\n';
+      if (options.sanitizer) {
+        text = options.sanitizer.sanitize(text);
+      }
+      dummy.innerHTML = text;
+      resolveUrls(dummy, options.resolver);
+      return dummy.innerHTML;
+    };
     return new Promise<Widget>((resolve, reject) => {
       marked(parts['text'], { renderer }, (err, content) => {
         if (err) {
@@ -484,12 +495,16 @@ function resolveUrls(node: HTMLElement, resolver: RenderMime.IResolver): void {
   for (let i = 0; i < imgs.length; i++) {
     let img = imgs[i];
     let source = img.getAttribute('src');
-    img.src = resolver.resolveUrl(source);
+    if (source) {
+      img.src = resolver.resolveUrl(source);
+    }
   }
   let anchors = node.getElementsByTagName('a');
   for (let i = 0; i < anchors.length; i++) {
     let anchor = anchors[i];
     let href = anchor.getAttribute('href');
-    anchor.href = resolver.resolveUrl(href);
+    if (href) {
+      anchor.href = resolver.resolveUrl(href);
+    }
   }
 }

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -140,7 +140,7 @@ class LatexWidget extends Widget {
  * A renderer for raw html.
  */
 export
-class HTMLRenderer implements RenderMime.IRenderer<Widget> {
+class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -180,7 +180,7 @@ class HTMLRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for `<img>` data.
  */
 export
-class ImageRenderer implements RenderMime.IRenderer<Widget> {
+class ImageRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -225,7 +225,7 @@ class ImageRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for plain text and Jupyter console text data.
  */
 export
-class TextRenderer implements RenderMime.IRenderer<Widget> {
+class TextRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -269,7 +269,7 @@ class TextRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for raw `<script>` data.
  */
 export
-class JavascriptRenderer implements RenderMime.IRenderer<Widget> {
+class JavascriptRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -315,7 +315,7 @@ class JavascriptRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for `<svg>` data.
  */
 export
-class SVGRenderer implements RenderMime.IRenderer<Widget> {
+class SVGRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -362,7 +362,7 @@ class SVGRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for PDF data.
  */
 export
-class PDFRenderer implements RenderMime.IRenderer<Widget> {
+class PDFRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -409,7 +409,7 @@ class PDFRenderer implements RenderMime.IRenderer<Widget> {
  * A renderer for LateX data.
  */
 export
-class LatexRenderer implements RenderMime.IRenderer<Widget>  {
+class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * The mimetypes this renderer accepts.
    */
@@ -449,7 +449,7 @@ class LatexRenderer implements RenderMime.IRenderer<Widget>  {
  * A renderer for Jupyter Markdown data.
  */
 export
-class MarkdownRenderer implements RenderMime.IRenderer<Widget> {
+class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * The mimetypes this renderer accepts.
    */

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -100,7 +100,9 @@ class HTMLWidget extends Widget {
       source = options.sanitizer.sanitize(source);
     }
     appendHtml(this.node, source);
-    resolveUrls(this.node, options.resolver);
+    if (options.resolver) {
+      resolveUrls(this.node, options.resolver);
+    }
   }
 
   /**
@@ -135,11 +137,13 @@ class MarkdownWidget extends Widget {
         content = options.sanitizer.sanitize(content);
       }
       appendHtml(this.node, content);
-      resolveUrls(this.node, options.resolver);
+      if (options.resolver) {
+        resolveUrls(this.node, options.resolver);
+      }
       this.fit();
+      this._rendered = true;
       if (this.isAttached) {
         typeset(this.node);
-        this._rendered = true;
       }
     });
   }
@@ -366,7 +370,9 @@ class SVGRenderer implements RenderMime.IRenderer {
     if (!svgElement) {
       throw new Error('SVGRender: Error: Failed to create <svg> element');
     }
-    resolveUrls(w.node, options.resolver);
+    if (options.resolver) {
+      resolveUrls(w.node, options.resolver);
+    }
     w.addClass(RENDERED_CLASS);
     return w;
   }

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -241,9 +241,9 @@ namespace RenderMime {
     source: string;
 
     /**
-     * The url resolver.
+     * An optional url resolver.
      */
-    resolver: IResolver;
+    resolver?: IResolver;
 
     /**
      * An optional html santizer.

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -52,10 +52,10 @@ class RenderMime {
    *
    * @param trusted - whether the bundle is trusted.
    */
-  render(bundle: RenderMime.MimeMap<string>, trusted=false): Promise<Widget> {
+  render(bundle: RenderMime.MimeMap<string>, trusted=false): Widget {
     let mimetype = this.preferredMimetype(bundle, trusted);
     if (!mimetype) {
-      return Promise.resolve(void 0);
+      return void 0;
     }
     let options = {
       mimetype,
@@ -63,9 +63,7 @@ class RenderMime {
       resolver: this._resolver,
       sanitizer: trusted ? null : this._sanitizer
     };
-    let renderer = this._renderers[mimetype];
-    let render = renderer.render(options);
-    return Promise.resolve(render);
+    return this._renderers[mimetype].render(options);
   }
 
   /**
@@ -224,7 +222,7 @@ namespace RenderMime {
      *
      * @param options - The options used for rendering.
      */
-    render(options: IRenderOptions): Widget | Promise<Widget>;
+    render(options: IRenderOptions): Widget;
   }
 
   /**

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -32,7 +32,7 @@ const renderMimeProvider = {
       new LatexRenderer(),
       new TextRenderer()
     ];
-    let renderers: RenderMime.MimeMap<RenderMime.IRenderer<Widget>> = {};
+    let renderers: RenderMime.MimeMap<RenderMime.IRenderer> = {};
     let order: string[] = [];
     for (let t of transformers) {
       for (let m of t.mimetypes) {
@@ -40,6 +40,6 @@ const renderMimeProvider = {
         order.push(m);
       }
     }
-    return new RenderMime<Widget>({ renderers, order });
+    return new RenderMime({ renderers, order });
   }
 };

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -11,8 +11,9 @@ import {
 } from '../renderers';
 
 import {
-  Widget
-} from 'phosphor-widget';
+  defaultSanitizer
+} from '../sanitizer';
+
 
 
 /**
@@ -40,6 +41,6 @@ const renderMimeProvider = {
         order.push(m);
       }
     }
-    return new RenderMime({ renderers, order });
+    return new RenderMime({ renderers, order, sanitizer: defaultSanitizer });
   }
 };

--- a/test/src/docmanager/mockcontext.ts
+++ b/test/src/docmanager/mockcontext.ts
@@ -118,6 +118,10 @@ class MockContext<T extends IDocumentModel> implements IDocumentContext<T> {
     return Promise.resolve([] as ISession.IModel[]);
   }
 
+  resolveUrl(url: string): string {
+    return url;
+  }
+
   addSibling(widget: Widget): IDisposable {
     this.methods.push('addSibling');
     return void 0;

--- a/test/src/markdownwidget/widget.spec.ts
+++ b/test/src/markdownwidget/widget.spec.ts
@@ -20,16 +20,16 @@ import {
 } from '../../../lib/markdownwidget/widget';
 
 import {
-  MarkdownRenderer
-} from '../../../lib/renderers';
-
-import {
   DocumentModel
 } from '../../../lib/docregistry';
 
 import {
   MockContext
 } from '../docmanager/mockcontext';
+
+import {
+  defaultRenderMime
+} from '../rendermime/rendermime.spec';
 
 
 class LogWidget extends MarkdownWidget {
@@ -47,15 +47,19 @@ class LogWidget extends MarkdownWidget {
 
 }
 
+
+const RENDERMIME = defaultRenderMime();
+
+
 describe('markdownwidget/widget', () => {
 
   describe('MarkdownWidgetFactory', () => {
 
     describe('#createNew()', () => {
-    
+
       it('should require a context parameter', () => {
         let context = new MockContext(new DocumentModel());
-        let widgetFactory = new MarkdownWidgetFactory();
+        let widgetFactory = new MarkdownWidgetFactory(RENDERMIME);
         expect(widgetFactory.createNew(context)).to.be.a(MarkdownWidget);
       });
 
@@ -69,7 +73,7 @@ describe('markdownwidget/widget', () => {
 
       it('should require a context parameter', () => {
         let context = new MockContext(new DocumentModel());
-        let widget = new MarkdownWidget(context);
+        let widget = new MarkdownWidget(context, RENDERMIME);
         expect(widget).to.be.a(MarkdownWidget);
       });
 
@@ -79,7 +83,7 @@ describe('markdownwidget/widget', () => {
 
       it('should update the widget', () => {
         let context = new MockContext(new DocumentModel());
-        let widget = new LogWidget(context);
+        let widget = new LogWidget(context, RENDERMIME);
         expect(widget.methods).to.not.contain('onAfterAttach');
         widget.attach(document.body);
         expect(widget.methods).to.contain('onAfterAttach');
@@ -92,7 +96,7 @@ describe('markdownwidget/widget', () => {
 
       it('should update rendered markdown', () => {
         let context = new MockContext(new DocumentModel());
-        let widget = new LogWidget(context);
+        let widget = new LogWidget(context, RENDERMIME);
         expect(widget.methods).to.not.contain('onUpdateRequest');
         context.model.contentChanged.emit(void 0);
         sendMessage(widget, Widget.MsgUpdateRequest);
@@ -102,7 +106,7 @@ describe('markdownwidget/widget', () => {
 
       it('should replace children on subsequent updates', () => {
         let context = new MockContext(new DocumentModel());
-        let widget = new LogWidget(context);
+        let widget = new LogWidget(context, RENDERMIME);
         context.model.contentChanged.emit(void 0);
         sendMessage(widget, Widget.MsgUpdateRequest);
 

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -133,7 +133,7 @@ class LogRenderer extends CodeCellWidget.Renderer {
     return super.createInputArea(editor);
   }
 
-  createOutputArea(rendermime: RenderMime<Widget>): OutputAreaWidget {
+  createOutputArea(rendermime: RenderMime): OutputAreaWidget {
     this.methods.push('createOutputArea');
     return super.createOutputArea(rendermime);
   }

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -416,14 +416,13 @@ describe('notebook/output-area/widget', () => {
 
     describe('#clear()', () => {
 
-      it('should clear the current output', (done) => {
+      it('should clear the current output', () => {
         let widget = new OutputWidget({ rendermime });
-        widget.render(DEFAULT_OUTPUTS[0], true).then(() => {
-          let output = widget.output;
-          widget.clear();
-          expect(widget.output).to.not.be(output);
-          expect(widget.output).to.be.a(Widget);
-        }).then(done, done);
+        widget.render(DEFAULT_OUTPUTS[0], true);
+        let output = widget.output;
+        widget.clear();
+        expect(widget.output).to.not.be(output);
+        expect(widget.output).to.be.a(Widget);
       });
 
     });

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -8,6 +8,13 @@ import {
   SVGRenderer, MarkdownRenderer, TextRenderer, HTMLRenderer, ImageRenderer
 } from '../../../lib/renderers';
 
+import {
+  defaultSanitizer
+} from '../../../lib/sanitizer';
+
+
+const EXPECTED_MD = `<h1>Title first level</h1>\n<h2>Title second Level</h2>\n<h3>Title third level</h3>\n<h4>h4</h4>\n<h5>h5</h5>\n<h6>h6</h6>\n<h1>h1</h1>\n<h2>h2</h2>\n<h3>h3</h3>\n<h4>h4</h4>\n<h5>h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2>and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th>Are</th>\n<th>Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td>right-aligned</td>\n<td>1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td>centered</td>\n<td>12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td>are neat</td>\n<td>1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don\'t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`;
+
 
 describe('renderers', () => {
 
@@ -43,37 +50,30 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
+    describe('#render()', () => {
 
       it('should output the correct HTML', () => {
         let t = new TextRenderer();
-        let text = t.transform('text/plain', 'x = 2 ** a');
-        expect(text).to.be('<pre>x = 2 ** a</pre>');
+        let widget = t.render({ mimetype: 'text/plain', source: 'x = 2 ** a' });
+        expect(widget.node.innerHTML).to.be('<pre>x = 2 ** a</pre>');
       });
 
       it('should output the correct HTML with ansi colors', () => {
         let t = new TextRenderer();
-        let text = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
-        text = t.transform('application/vnd.jupyter.console-text', text);
-        expect(text).to.be('<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
+        let source = 'There is no text but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+        let widget = t.render({
+          mimetype: 'application/vnd.jupyter.console-text', source
+        });
+        expect(widget.node.innerHTML).to.be('<pre>There is no text but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
       });
 
       it('should escape inline html', () => {
         let t = new TextRenderer();
-        let text = 'There is no text <script>window.x=1</script> but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
-        text = t.transform('application/vnd.jupyter.console-text', text);
-        expect(text).to.be('<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
-      });
-
-    });
-
-    describe('#render()', () => {
-
-      it('should set the inner html of the widget', () => {
-        let t = new TextRenderer();
-        let html = '<pre>Hello</pre>';
-        let widget = t.render('text/plain', html);
-        expect(widget.node.innerHTML).to.be(html);
+        let source = 'There is no text <script>window.x=1</script> but \x1b[01;41;32mtext\x1b[00m.\nWoo.';
+        let widget = t.render({
+          mimetype: 'application/vnd.jupyter.console-text', source
+        });
+        expect(widget.node.innerHTML).to.be('<pre>There is no text &lt;script&gt;window.x=1&lt;/script&gt; but <span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text</span>.\nWoo.</pre>');
       });
 
     });
@@ -109,24 +109,13 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
-        let t = new LatexRenderer();
-        let text = t.transform('text/latex', mathJaxScript);
-        expect(text).to.be(mathJaxScript);
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should set the textContent of the widget', () => {
-        let mathJaxScript = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
+        let source = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
         let t = new LatexRenderer();
-        let widget = t.render('text/latex', mathJaxScript);
-        expect(widget.node.textContent).to.be(mathJaxScript);
+        let widget = t.render({ mimetype: 'text/latex', source });
+        expect(widget.node.textContent).to.be(source);
       });
 
     });
@@ -162,23 +151,12 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        let base64PDF = "I don't have a b64'd PDF";
-        let t = new PDFRenderer();
-        let text = t.transform('application/pdf', base64PDF);
-        expect(text).to.be(base64PDF);
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should render the correct HTML', () => {
-        let base64PDF = "I don't have a b64'd PDF";
+        let source = "I don't have a b64'd PDF";
         let t = new PDFRenderer();
-        let w = t.render('application/pdf', base64PDF);
+        let w = t.render({ mimetype: 'application/pdf', source });
         expect(w.node.innerHTML.indexOf('data:application/pdf')).to.not.be(-1);
       });
 
@@ -216,24 +194,15 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        let t = new PDFRenderer();
-        let text = t.transform('text/javascript', 'window.x = 1');
-        expect(text).to.be('window.x = 1');
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should create a script tag', () => {
         let t = new JavascriptRenderer();
-        let w = t.render('text/javascript', 'window.x = 1');
+        let source = 'window.x = 1';
+        let w = t.render({ mimetype: 'text/javascript', source });
         let el = w.node.firstChild as HTMLElement;
         expect(el.localName).to.be('script');
-        expect(el.textContent).to.be('window.x = 1');
+        expect(el.textContent).to.be(source);
 
         // Ensure script has not been run yet
         expect((window as any).x).to.be(void 0);
@@ -277,34 +246,23 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        const svg = `
-            <?xml version="1.0" standalone="no"?>
-            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-            SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-            <svg></svg>`;
-        let t = new SVGRenderer();
-        let text = t.transform('image/svg+xml', svg);
-        expect(text).to.be(svg);
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should create an svg tag', () => {
-        const svg = `
-            <?xml version="1.0" standalone="no"?>
-            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-            SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-            <svg></svg>
-        `;
+        const source = '<svg></svg>';
         let t = new SVGRenderer();
-        let w = t.render('image/svg+xml', svg);
+        let w = t.render({ mimetype: 'image/svg+xml', source });
         let svgEl = w.node.getElementsByTagName('svg')[0];
         expect(svgEl).to.be.ok();
+      });
+
+      it('should sanitize when a sanitizer is given', () => {
+        const source = '<svg><script>window.x = 1</script></svg>';
+        let t = new SVGRenderer();
+        let w = t.render({
+          mimetype: 'image/svg+xml', source, sanitizer: defaultSanitizer
+        });
+        expect(w.node.innerHTML).to.be('<svg></svg>');
       });
 
     });
@@ -340,25 +298,38 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should create nice markup', (done) => {
-        let md = require('../../../examples/filebrowser/sample.md');
-        let t = new MarkdownRenderer();
-        t.transform('text/markdown', md as string).then(text => {
-          expect(text).to.be(`<h1 id="title-first-level">Title first level</h1>\n<h2 id="title-second-level">Title second Level</h2>\n<h3 id="title-third-level">Title third level</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h5">h5</h5>\n<h6 id="h6">h6</h6>\n<h1 id="h1">h1</h1>\n<h2 id="h2">h2</h2>\n<h3 id="h3">h3</h3>\n<h4 id="h4">h4</h4>\n<h5 id="h6">h6</h5>\n<p>This is just a sample paragraph<br>You can look at different level of nested unorderd list ljbakjn arsvlasc asc asc awsc asc ascd ascd ascd asdc asc</p>\n<ul>\n<li>level 1<ul>\n<li>level 2</li>\n<li>level 2</li>\n<li>level 2<ul>\n<li>level 3</li>\n<li>level 3<ul>\n<li>level 4<ul>\n<li>level 5<ul>\n<li>level 6</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n<li>level 2</li>\n</ul>\n</li>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<br>Ordered list</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1<ol>\n<li>level 1</li>\n<li>level 1</li>\n<li>level 1</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n</ol>\n</li>\n<li>level 1</li>\n<li>level 1<br>some Horizontal line</li>\n</ul>\n<hr>\n<h2 id="and-another-one">and another one</h2>\n<p>Colons can be used to align columns.</p>\n<table>\n<thead>\n<tr>\n<th>Tables</th>\n<th style="text-align:center">Are</th>\n<th style="text-align:right">Cool</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>col 3 is</td>\n<td style="text-align:center">right-aligned</td>\n<td style="text-align:right">1600</td>\n</tr>\n<tr>\n<td>col 2 is</td>\n<td style="text-align:center">centered</td>\n<td style="text-align:right">12</td>\n</tr>\n<tr>\n<td>zebra stripes</td>\n<td style="text-align:center">are neat</td>\n<td style="text-align:right">1</td>\n</tr>\n</tbody>\n</table>\n<p>There must be at least 3 dashes separating each header cell.<br>The outer pipes (|) are optional, and you don&#39;t need to make the<br>raw Markdown line up prettily. You can also use inline Markdown.</p>\n`);
-        }).then(done, done);
-      });
-
-    });
-
     describe('#render()', () => {
 
-      it('should set the inner html', () => {
+      it('should set the inner html', (done) => {
         let t = new MarkdownRenderer();
-        let html = '<p>hello</p>';
-        let w = t.render('text/markdown', html);
-        expect(w.node.innerHTML).to.be(html);
+        let source = '<p>hello</p>';
+        let widget = t.render({ mimetype: 'text/markdown', source });
+        let loop = () => {
+          if ((widget as any)._rendered) {
+            expect(widget.node.innerHTML).to.be(source);
+            done();
+            return;
+          }
+          setTimeout(loop, 100);
+        };
+        setTimeout(loop, 100);
+      });
+
+      it('should sanitize if a sanitizer is given', (done) => {
+        let source = require('../../../examples/filebrowser/sample.md') as string;
+        let r = new MarkdownRenderer();
+        let widget = r.render({
+          mimetype: 'text/markdown', source, sanitizer: defaultSanitizer
+        });
+        let loop = () => {
+          if ((widget as any)._rendered) {
+            expect(widget.node.innerHTML).to.be(EXPECTED_MD);
+            done();
+            return;
+          }
+          setTimeout(loop, 100);
+        };
+        setTimeout(loop, 100);
       });
 
     });
@@ -394,34 +365,32 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        let t = new HTMLRenderer();
-        const htmlText = '<h1>This is great</h1>';
-        let text = t.transform('text/html', htmlText);
-        expect(text).to.be(htmlText);
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should set the inner HTML', () => {
         let t = new HTMLRenderer();
-        const htmlText = '<h1>This is great</h1>';
-        let w = t.render('text/html', htmlText);
+        const source = '<h1>This is great</h1>';
+        let w = t.render({ mimetype: 'text/html', source });
         expect(w.node.innerHTML).to.be('<h1>This is great</h1>');
       });
 
       it('should execute a script tag when attached', () => {
-        const htmlText = '<script>window.y=3;</script>';
+        const source = '<script>window.y=3;</script>';
         let t = new HTMLRenderer();
-        let w = t.render('text/html', htmlText);
+        let w = t.render({ mimetype: 'text/html', source });
         expect((window as any).y).to.be(void 0);
         w.attach(document.body);
         expect((window as any).y).to.be(3);
         w.dispose();
+      });
+
+      it('should sanitize when a sanitizer is given', () => {
+        const source = '<pre><script>window.y=3;</script></pre>';
+        let t = new HTMLRenderer();
+        let w = t.render({
+          mimetype: 'text/html', source, sanitizer: defaultSanitizer
+        });
+        expect(w.node.innerHTML).to.be('<pre></pre>');
       });
 
     });
@@ -457,32 +426,21 @@ describe('renderers', () => {
 
     });
 
-    describe('#transform()', () => {
-
-      it('should be a no-op', () => {
-        let t = new ImageRenderer();
-        const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-        let text = t.transform('image/png', imageData);
-        expect(text).to.be(imageData);
-      });
-
-    });
-
     describe('#render()', () => {
 
       it('should create an <img> with the right mimetype', () => {
-        const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        let source = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
         let t = new ImageRenderer();
-        let w = t.render('image/png', imageData);
+        let w = t.render({ mimetype: 'image/png', source });
         let el = w.node.firstChild as HTMLImageElement;
-        expect(el.src).to.be('data:image/png;base64,' + imageData);
+        expect(el.src).to.be('data:image/png;base64,' + source);
         expect(el.localName).to.be('img');
         expect(el.innerHTML).to.be('');
 
-        const imageData2 = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
-        w = t.render('image/gif', imageData2);
+        source = 'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
+        w = t.render({ mimetype: 'image/gif', source });
         el = w.node.firstChild as HTMLImageElement;
-        expect(el.src).to.be('data:image/gif;base64,' + imageData2);
+        expect(el.src).to.be('data:image/gif;base64,' + source);
         expect(el.localName).to.be('img');
         expect(el.innerHTML).to.be('');
       });

--- a/typings/codemirror/codemirror.d.ts
+++ b/typings/codemirror/codemirror.d.ts
@@ -17,7 +17,7 @@ declare module CodeMirror {
     // findMode* functions are from loading the codemirror/mode/meta module
     interface modespec {
       [ key: string ]: string;
-      name: string;
+      name?: string;
       mode: string;
       mime: string;
     }
@@ -42,7 +42,7 @@ declare module CodeMirror {
     }
     var modeInfo: modeinfo[];
 
-    function runMode(code: string, mode: modespec, el: HTMLElement): void;
+    function runMode(code: string, mode: modespec | string, el: HTMLElement): void;
 
     var version: string;
 


### PR DESCRIPTION
Pushes sanitization and relative url handling down to the renderer.  We were not previously sanitizing the Markdown Preview.  
Handles markdown images, links, and `<img>` tags (and inline gifs).
I also verified that we were not attempting to fetch the relative urls before they are resolved.
Note that markdown url handling could be done by overriding the markdown renderer, but we leave that as a follow-on optimization.


Fixes #425.  cf https://github.com/jupyter/jupyterlab/issues/446

![relative_path](https://cloud.githubusercontent.com/assets/2096628/17190691/6b535170-540c-11e6-8b27-dfae586bc62e.gif)


![relative_paths](https://cloud.githubusercontent.com/assets/2096628/17193573/5cb3c89a-5419-11e6-9ec1-9a6e33df4b4e.gif)
