### PR TITLE
Set version to 0.1.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab",
-  "version": "0.1.3-0",
+  "version": "0.1.3",
   "description": "A computational environment for Jupyter.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
The previous version `0.1.3-0` breaks the built application upon loading because the `jupyter-js-widgets-labextension` external package specifies that it needs JupyterLab version [`^0.1.0`](https://github.com/ipython/ipywidgets/blob/279ba53fa1f20623ec84484e67eeb5d829bc6cb1/labextension/package.json#L9). While `0.1.3-0` *is* a legitimate semver version, it does *not* satisfy the `^0.1.0` constraint because the `-0` substring makes it a *provisional* release. In fact, these substrings are typically meant for things like `-alpha`, `-beta`, `-rc.1`, `-rc.2` and should *not* be necessary for a simple patch release like this one.

Because it is a runtime error, the automatic build process does not catch it.

<img width="786" src="https://cloud.githubusercontent.com/assets/159529/17214947/1b1a8832-54d3-11e6-8267-0994d13f8424.png">

This is a helpful site for determining semver constraint matching: http://jubianchi.github.io/semver-check/

In general, I think the liability that is raised by having `jupyter-js-widgets-labextension` capable of breaking JupyterLab for all users checking out `master` is something we need to address. One solution is to have some sort of sanity check. Another is to fold in the widgets extension into JupyterLab. A third idea is to not include widgets by default. But one way or another, we should try to create a process that prevents this from happening.

cc: @jasongrout @blink1073 