### PR TITLE
Update notebook cell paste behavior

### DIFF
--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -652,7 +652,8 @@ namespace NotebookActions {
       }
     }
     let index = widget.activeCellIndex;
-    widget.model.cells.replace(index, 0, cells);
+    widget.model.cells.replace(index + 1, 0, cells);
+    widget.activeCellIndex += cells.length;
     Private.deselectCells(widget);
   }
 

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -622,6 +622,8 @@ namespace NotebookActions {
    * @param clipboard - The clipboard object.
    *
    * #### Notes
+   * The cells are pasted below the active cell.
+   * The last pasted cell becomes the active cell.
    * This is a no-op if there is no cell data on the clipboard.
    * This action can be undone.
    */

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -994,7 +994,8 @@ describe('notebook/notebook/actions', () => {
         widget.activeCellIndex = 1;
         NotebookActions.paste(widget, clipboard);
         expect(widget.childCount()).to.be(count);
-        expect(widget.childAt(1).model.source).to.be(source);
+        expect(widget.childAt(2).model.source).to.be(source);
+        expect(widget.activeCellIndex).to.be(3);
       });
 
       it('should be a no-op if there is no model', () => {


### PR DESCRIPTION
Fixes #564.  Cells are pasted below the active cell and the last pasted cell is activated, matching the classic notebook behavior.