### PR TITLE
Clean up the jupyterlab extension package

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -26,7 +26,8 @@ Distributed under the terms of the Modified BSD License.
   "wsUrl": "{{ws_url| urlencode}}",
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
-<script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/main.bundle.js" type="text/javascript" charset="utf-8"></script>
 
 </body>
 

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -6,22 +6,23 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "dependencies": {
+    "css-loader": "^0.23.1",
     "es6-promise": "^3.1.2",
+    "file-loader": "^0.8.5",
+    "find-imports": "^0.5.0",
     "font-awesome": "^4.6.1",
+    "json-loader": "^0.5.4",
     "jupyter-js-widgets-labextension": "^0.1.0",
     "jupyterlab": "file:../",
     "material-design-icons": "^2.2.3",
-    "phosphide": "^0.10.0"
-  },
-  "devDependencies": {
-    "css-loader": "^0.23.1",
-    "file-loader": "^0.8.5",
-    "json-loader": "^0.5.4",
-    "rimraf": "^2.5.0",
+    "phosphide": "^0.10.0",
     "style-loader": "^0.13.0",
     "typescript": "^1.7.5",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.11"
+  },
+  "devDependencies": {
+    "rimraf": "^2.5.0"
   },
   "scripts": {
     "clean": "rimraf build",

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   output: {
     path: __dirname + '/build',
-    filename: "[name].bundle.js",
+    filename: '[name].bundle.js',
     publicPath: 'lab/'
   },
   node: {

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -5,11 +5,28 @@
 // See https://github.com/webpack/css-loader/issues/144
 require('es6-promise').polyfill();
 
+var webpack = require('webpack');
+var findImports = require('find-imports');
+
+
+// Get the list of vendor files.
+console.log('Finding vendored files...')
+var vendorFiles = findImports('../lib/**/*.js', { flatten: true });
+vendorFiles.push('xterm/src/xterm.css');
+console.log('Vendored files:\n', vendorFiles)
+
+// Build the bundles.
+console.log('\nBuilding webpack bundles...')
+
+
 module.exports = {
-  entry: './index.js',
+  entry: {
+     main: './index.js',
+     vendor: vendorFiles
+  },
   output: {
     path: __dirname + '/build',
-    filename: 'bundle.js',
+    filename: "[name].bundle.js",
     publicPath: 'lab/'
   },
   node: {
@@ -36,5 +53,8 @@ module.exports = {
   externals: {
     jquery: '$',
     'jquery-ui': '$'
-  }
+  },
+  plugins: [
+     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
+  ]
 }


### PR DESCRIPTION
- Makes the webpack libs `dependencies` since they are needed at run time.
- Puts the vendor files into a separate file to make it easier to debug.
