### PR TITLE
ENH: Let console attach to existing kernel.

### DIFF
--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -6,7 +6,7 @@ import {
 } from 'jupyterlab/lib/console';
 
 import {
-  startNewSession, ISession
+  startNewSession, findSessionByPath, connectToSession, ISession
 } from 'jupyter-js-services';
 
 import {
@@ -48,11 +48,24 @@ let TITLE = 'Console';
 
 
 function main(): void {
-  startNewSession({
-    path: 'fake_path',
-  }).then(session => {
-    startApp(session);
-  });
+  let foundPath = false;
+  window.location.search.substr(1).split("&").forEach(
+    function(item : string): void {
+      if (item.split("=")[0] === 'path') {
+      findSessionByPath(item.split("=")[1]).then(
+        model => { return connectToSession(model.id) }).then(
+        session => { startApp(session) });
+        foundPath = true;
+      }
+    }
+  )
+  if (!foundPath) {
+    startNewSession({
+      path: 'fake_path',
+    }).then(session => {
+      startApp(session);
+    });
+  }
 }
 
 


### PR DESCRIPTION
This is work-in-progress PR extending the console example to allow attaching to existing sessions. One use case for this is allowing another user to follow along with your console, remotely.

@jasongrout helped me get started on this earlier this week, but I think could use help finishing it off if anyone can spare the bandwidth. I see that `startNewSession` [returns a `Promise <ISession>`](http://jupyter.org/jupyter-js-services/globals.html#startnewsession), which makes sense. I don't understand why `findSessionByPath` [returns a `Promise<IModel>`](http://jupyter.org/jupyter-js-services/globals.html#findsessionbypath) instead. (I only vaguely understand the relationship between ISession and IModel....) Ultimately, I need to obtain from `findSessionByPath` an object I can pass to `startApp`.