### PR TITLE
Never upload with setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ We publish an npm package, a Python source package, and a Python universal binar
 npm version patch
 git push origin master --tags
 npm publish
-python setup.py sdist upload
-python setup.py bdist_wheel --universal upload
+python setup.py sdist
+python setup.py bdist_wheel --universal
+twine upload dist/*
 ```


### PR DESCRIPTION
It **does** upload without checking the certificate of the remote
server, does not use ssl, and send the credential in plaintext on the
wire.


---- 


See https://packaging.python.org/distributing/, for longer description, you will need to install `twine` of course. 

I would recommend checking https://packaging.python.org/distributing/?highlight=twine#create-an-account that ask to update your `.pypirc` to : 

```
[distutils]
index-servers=pypi

[pypi]
repository = https://upload.pypi.io/legacy/
username = <username>
password = <password>
```

In order to use the new endpoint. The old endpoint have a know ~5-10% upload failure. 