### PR TITLE
Fix file browser context menu handling on non-items

### DIFF
--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -154,12 +154,12 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
   let node = fbWidget.node.getElementsByClassName('jp-DirListing-content')[0];
   node.addEventListener('contextmenu', (event: MouseEvent) => {
     event.preventDefault();
-    let path = fbWidget.pathForClick(event);
+    let path = fbWidget.pathForClick(event) || '';
     let ext = '.' + path.split('.').pop();
     let widgetNames = registry.listWidgetFactories(ext);
     let prefix = `file-browser-contextmenu-${++Private.id}`;
     let openWith: Menu = null;
-    if (widgetNames.length > 1) {
+    if (path && widgetNames.length > 1) {
       let disposables = new DisposableSet();
       let command: string;
 


### PR DESCRIPTION
Handle the case of right-clicking in the file browser not on a file, which can be used for the `paste` operation.