### PR TITLE
Plugin refactor

### DIFF
--- a/examples/lab/index.js
+++ b/examples/lab/index.js
@@ -17,7 +17,7 @@ lab.registerPlugins([
   require('jupyterlab/lib/commandpalette/plugin').commandPaletteProvider,
   require('jupyterlab/lib/console/plugin').consoleExtension,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
-  require('jupyterlab/lib/editorwidget/plugin').editorHandlerExtension,
+  require('jupyterlab/lib/editorwidget/plugin').editorHandlerProvider,
   require('jupyterlab/lib/faq/plugin').faqExtension,
   require('jupyterlab/lib/filebrowser/plugin').fileBrowserProvider,
   require('jupyterlab/lib/help/plugin').helpHandlerExtension,

--- a/examples/lab/index.js
+++ b/examples/lab/index.js
@@ -14,7 +14,7 @@ var lab = new JupyterLab();
 lab.registerPlugins([
   require('jupyterlab/lib/about/plugin').aboutExtension,
   require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
-  require('jupyterlab/lib/commandpalette/plugin').commandPaletteExtension,
+  require('jupyterlab/lib/commandpalette/plugin').commandPaletteProvider,
   require('jupyterlab/lib/console/plugin').consoleExtension,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
   require('jupyterlab/lib/editorwidget/plugin').editorHandlerExtension,

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -15,7 +15,7 @@ var lab = new JupyterLab();
 lab.registerPlugins([
   require('jupyterlab/lib/about/plugin').aboutExtension,
   require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
-  require('jupyterlab/lib/commandpalette/plugin').commandPaletteExtension,
+  require('jupyterlab/lib/commandpalette/plugin').commandPaletteProvider,
   require('jupyterlab/lib/console/plugin').consoleExtension,
   require('jupyterlab/lib/csvwidget/plugin').csvHandlerExtension,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -19,7 +19,7 @@ lab.registerPlugins([
   require('jupyterlab/lib/console/plugin').consoleExtension,
   require('jupyterlab/lib/csvwidget/plugin').csvHandlerExtension,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
-  require('jupyterlab/lib/editorwidget/plugin').editorHandlerExtension,
+  require('jupyterlab/lib/editorwidget/plugin').editorHandlerProvider,
   require('jupyterlab/lib/faq/plugin').faqExtension,
   require('jupyterlab/lib/filebrowser/plugin').fileBrowserProvider,
   require('jupyterlab/lib/help/plugin').helpHandlerExtension,

--- a/src/about/plugin.ts
+++ b/src/about/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   html

--- a/src/clipboard/index.ts
+++ b/src/clipboard/index.ts
@@ -1,6 +1,29 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import {
+  MimeData
+} from 'phosphor/lib/core/mimedata';
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+/* tslint:disable */
+/**
+ * The clipboard token.
+ */
+export
+const IClipboard = new Token<IClipboard>('jupyter.services.clipboard');
+/* tslint:enable */
+
+
+/**
+ * The clipboard interface.
+ */
+export
+interface IClipboard extends MimeData {}
+
 /**
  * Copy text to the system clipboard.
  *

--- a/src/clipboard/plugin.ts
+++ b/src/clipboard/plugin.ts
@@ -6,28 +6,12 @@ import {
 } from 'phosphor/lib/core/mimedata';
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   JupyterLabPlugin
 } from '../application';
 
-
-/* tslint:disable */
-/**
- * The clipboard token.
- */
-export
-const IClipboard = new Token<IClipboard>('jupyter.services.clipboard');
-/* tslint:enable */
-
-
-/**
- * The clipboard interface.
- */
-export
-interface IClipboard extends MimeData {}
+import {
+  IClipboard
+} from './';
 
 
 /**

--- a/src/commandpalette/index.ts
+++ b/src/commandpalette/index.ts
@@ -1,0 +1,24 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) Jupyter Development Team.
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
+  CommandPalette
+} from 'phosphor/lib/ui/commandpalette';
+
+
+/* tslint:disable */
+/**
+ * The command palette token.
+ */
+export
+const ICommandPalette = new Token<ICommandPalette>('jupyter.services.commandpalette');
+/* tslint:enable */
+
+export
+interface ICommandPalette extends CommandPalette {}

--- a/src/commandpalette/plugin.ts
+++ b/src/commandpalette/plugin.ts
@@ -4,10 +4,6 @@
 |----------------------------------------------------------------------------*/
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   CommandPalette
 } from 'phosphor/lib/ui/commandpalette';
 
@@ -15,29 +11,22 @@ import {
   JupyterLab, JupyterLabPlugin
 } from '../application';
 
+import {
+  ICommandPalette
+} from './';
 
-/* tslint:disable */
-/**
- * The command palette token.
- */
-export
-const ICommandPalette = new Token<ICommandPalette>('jupyter.services.commandpalette');
-/* tslint:enable */
 
 
 /**
  * The default commmand palette extension.
  */
 export
-const commandPaletteExtension: JupyterLabPlugin<ICommandPalette> = {
+const commandPaletteProvider: JupyterLabPlugin<ICommandPalette> = {
   id: 'jupyter.services.commandpalette',
   provides: ICommandPalette,
   activate: activateCommandPalette,
   autoStart: true
 };
-
-export
-interface ICommandPalette extends CommandPalette {}
 
 
 /**

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 import {
   IRenderMime

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -35,7 +35,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 import {
   WidgetTracker

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   selectKernel

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import {
   IInspector
-} from '../inspector/plugin';
+} from '../inspector';
 
 import {
   IMainMenu

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   IRenderMime
-} from '../rendermime/plugin';
+} from '../rendermime';
 
 import {
   IServiceManager

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -92,6 +92,9 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
     inspector.source = panel.content.inspectionHandler;
   });
 
+  // Set the main menu title.
+  menu.title.label = 'Console';
+
   // Add the ability to create new consoles for each kernel.
   let specs = services.kernelspecs;
   let displayNameMap: { [key: string]: string } = Object.create(null);

--- a/src/editorwidget/index.ts
+++ b/src/editorwidget/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+export * from './widget';

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 import {
   WidgetTracker

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   Menu
 } from 'phosphor/lib/ui/menu';
 
@@ -32,6 +28,10 @@ import {
 import {
   WidgetTracker
 } from '../widgettracker';
+
+import {
+  IEditorTracker
+} from './index';
 
 import 'codemirror/theme/material.css';
 import 'codemirror/theme/zenburn.css';
@@ -63,27 +63,11 @@ const EDITOR_ICON_CLASS = 'jp-ImageTextEditor';
 
 
 /**
- * A class that tracks editor widgets.
- */
-export
-interface IEditorTracker extends WidgetTracker<EditorWidget> { }
-
-
-/* tslint:disable */
-/**
- * The editor tracker token.
- */
-export
-const IEditorTracker = new Token<IEditorTracker>('jupyter.services.editor-tracker');
-/* tslint:enable */
-
-
-/**
  * The editor handler extension.
  */
 export
-const editorHandlerExtension: JupyterLabPlugin<IEditorTracker> = {
-  id: 'jupyter.extensions.editor-handler',
+const editorHandlerProvider: JupyterLabPlugin<IEditorTracker> = {
+  id: 'jupyter.services.editor-handler',
   requires: [IDocumentRegistry, IMainMenu, ICommandPalette],
   provides: IEditorTracker,
   activate: activateEditorHandler,

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IMainMenu

--- a/src/editorwidget/widget.ts
+++ b/src/editorwidget/widget.ts
@@ -11,6 +11,10 @@ import {
 } from 'jupyter-js-services';
 
 import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
   loadModeByFileName
 } from '../codemirror';
 
@@ -22,6 +26,10 @@ import {
   ABCWidgetFactory, IDocumentModel, IDocumentContext
 } from '../docregistry';
 
+import {
+  WidgetTracker
+} from '../widgettracker';
+
 
 /**
  * The class name added to a dirty widget.
@@ -32,6 +40,22 @@ const DIRTY_CLASS = 'jp-mod-dirty';
  * The class name added to a jupyter code mirror widget.
  */
 const EDITOR_CLASS = 'jp-EditorWidget';
+
+
+/**
+ * A class that tracks editor widgets.
+ */
+export
+interface IEditorTracker extends WidgetTracker<EditorWidget> {}
+
+
+/* tslint:disable */
+/**
+ * The editor tracker token.
+ */
+export
+const IEditorTracker = new Token<IEditorTracker>('jupyter.services.editor-tracker');
+/* tslint:enable */
 
 
 /**

--- a/src/faq/plugin.ts
+++ b/src/faq/plugin.ts
@@ -17,7 +17,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 
 /**

--- a/src/filebrowser/index.ts
+++ b/src/filebrowser/index.ts
@@ -3,3 +3,4 @@
 
 export * from './browser';
 export * from './model';
+export * from './tracker';

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -6,14 +6,6 @@ import {
 } from 'phosphor/lib/core/disposable';
 
 import {
-  ISignal
-} from 'phosphor/lib/core/signaling';
-
-import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   Menu
 } from 'phosphor/lib/ui/menu';
 
@@ -28,10 +20,6 @@ import {
 import {
   ICommandPalette
 } from '../commandpalette';
-
-import {
-  IChangedArgs
-} from '../common/interfaces';
 
 import {
   DocumentManager
@@ -54,41 +42,8 @@ import {
 } from '../widgettracker';
 
 import {
-  IWidgetOpener, FileBrowserWidget
-} from './browser';
-
-import {
-  FileBrowserModel
-} from './model';
-
-
-/* tslint:disable */
-/**
- * The path tracker token.
- */
-export
-const IPathTracker = new Token<IPathTracker>('jupyter.services.file-browser');
-/* tslint:enable */
-
-
-/**
- * An interface a file browser path tracker.
- */
-export
-interface IPathTracker {
-  /**
-   * A signal emitted when the current path changes.
-   */
-  pathChanged: ISignal<IPathTracker, IChangedArgs<string>>;
-
-  /**
-   * The current path of the filebrowser.
-   *
-   * #### Notes
-   * This is a read-only property.
-   */
-  path: string;
-}
+  FileBrowserModel, FileBrowserWidget, IPathTracker, IWidgetOpener
+} from './';
 
 
 /**

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -35,7 +35,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 import {
   WidgetTracker

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 import {
   IServiceManager

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -27,7 +27,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IChangedArgs

--- a/src/filebrowser/tracker.ts
+++ b/src/filebrowser/tracker.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
+  IChangedArgs
+} from '../common/interfaces';
+
+
+/* tslint:disable */
+/**
+ * The path tracker token.
+ */
+export
+const IPathTracker = new Token<IPathTracker>('jupyter.services.file-browser');
+/* tslint:enable */
+
+
+/**
+ * An interface a file browser path tracker.
+ */
+export
+interface IPathTracker {
+  /**
+   * A signal emitted when the current path changes.
+   */
+  pathChanged: ISignal<IPathTracker, IChangedArgs<string>>;
+
+  /**
+   * The current path of the filebrowser.
+   *
+   * #### Notes
+   * This is a read-only property.
+   */
+  path: string;
+}

--- a/src/help/plugin.ts
+++ b/src/help/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IFrame

--- a/src/help/plugin.ts
+++ b/src/help/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 
 /**

--- a/src/imagewidget/plugin.ts
+++ b/src/imagewidget/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IDocumentRegistry

--- a/src/inspector/inspector.ts
+++ b/src/inspector/inspector.ts
@@ -10,6 +10,10 @@ import {
 } from 'phosphor/lib/core/signaling';
 
 import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
   Panel
 } from 'phosphor/lib/ui/panel';
 
@@ -65,6 +69,15 @@ const BOTTOM_TOGGLE_CLASS = 'jp-InspectorItem-bottom';
  * The orientation toggle right button class name.
  */
 const RIGHT_TOGGLE_CLASS = 'jp-InspectorItem-right';
+
+
+/* tslint:disable */
+/**
+ * The inspector panel token.
+ */
+export
+const IInspector = new Token<IInspector>('jupyter.services.inspector');
+/* tslint:enable */
 
 
 /**

--- a/src/inspector/plugin.ts
+++ b/src/inspector/plugin.ts
@@ -2,28 +2,13 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   JupyterLab, JupyterLabPlugin
 } from '../application';
 
 import {
-  IInspector as IBaseInspector, Inspector
+  IInspector, Inspector
 } from './';
 
-
-export
-interface IInspector extends IBaseInspector {}
-
-/* tslint:disable */
-/**
- * The inspector panel token.
- */
-export
-const IInspector = new Token<IInspector>('jupyter.services.inspector');
-/* tslint:enable */
 
 
 /**

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IPathTracker

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   IPathTracker
-} from '../filebrowser/plugin';
+} from '../filebrowser';
 
 import {
   IServiceManager

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 /**
  * The landing page extension.

--- a/src/leafletwidget/plugin.ts
+++ b/src/leafletwidget/plugin.ts
@@ -27,7 +27,7 @@ const EXTENSIONS = ['.geojson'];
  */
 export
 const mapHandlerExtension: JupyterLabPlugin<void> = {
-  id: 'jupyter.extensions.mapHandler',
+  id: 'jupyter.extensions.map-handler',
   requires: [IDocumentRegistry],
   activate: activateMapWidget,
   autoStart: true

--- a/src/main/plugin.ts
+++ b/src/main/plugin.ts
@@ -13,11 +13,17 @@ export
 const mainExtension: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.main',
   activate: (app: JupyterLab) => {
-    window.onbeforeunload = event => {
-      let msg = 'Are you sure you want to exit JupyterLab?';
-      msg += '\nAny unsaved changes will be lost.';
-      return msg;
-    };
+    const message = 'Are you sure you want to exit JupyterLab?\n' +
+                    'Any unsaved changes will be lost.';
+
+    // The spec for the `beforeunload` event is implemented differently by
+    // the different browser vendors. Consequently, the `event.returnValue`
+    // attribute needs to set in addition to a return value being returned.
+    // For more information, see:
+    // https://developer.mozilla.org/en/docs/Web/Events/beforeunload
+    window.addEventListener('beforeunload', event => {
+      return (event as any).returnValue = message;
+    });
   },
   autoStart: true
 };

--- a/src/mainmenu/index.ts
+++ b/src/mainmenu/index.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  indexOf, upperBound
+  find, indexOf, upperBound
 } from 'phosphor/lib/algorithm/searching';
 
 import {
@@ -20,25 +20,6 @@ import {
 import {
   MenuBar
 } from 'phosphor/lib/ui/menubar';
-
-import {
-  Widget
-} from 'phosphor/lib/ui/widget';
-
-import {
-  JupyterLab, JupyterLabPlugin
-} from '../application';
-
-
-/**
- * The class name for all main area portrait tab icons.
- */
-const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
-
-/**
- * The class name for the jupyter icon from the default theme.
- */
-const JUPYTER_ICON_CLASS = 'jp-JupyterIcon';
 
 
 /* tslint:disable */
@@ -78,12 +59,12 @@ interface IAddMenuOptions {
  * The main menu class.  It is intended to be used as a singleton.
  */
 export
-class MainMenu implements IMainMenu {
+class MainMenu extends MenuBar implements IMainMenu {
   /**
    * Add a new menu to the main menu bar.
    */
   addMenu(menu: Menu, options: IAddMenuOptions = {}): void {
-    if (indexOf(Private.menuBar.menus, menu) > -1) {
+    if (indexOf(this.menus, menu) > -1) {
       return;
     }
 
@@ -95,7 +76,7 @@ class MainMenu implements IMainMenu {
     menu.disposed.connect(() => this._items.remove(rankItem));
 
     this._items.insert(index, rankItem);
-    Private.menuBar.insertMenu(index, menu);
+    this.insertMenu(index, menu);
   }
 
   private _items = new Vector<Private.IRankItem>();
@@ -103,51 +84,9 @@ class MainMenu implements IMainMenu {
 
 
 /**
- * A service providing an interface to the main menu.
- */
-export
-const mainMenuProvider: JupyterLabPlugin<IMainMenu> = {
-  id: 'jupyter.services.main-menu',
-  provides: IMainMenu,
-  activate: activateMainMenu
-};
-
-
-/**
- * Activate the main menu extension.
- */
-function activateMainMenu(app: JupyterLab): IMainMenu {
-  Private.menuBar = new MenuBar({ keymap: app.keymap });
-  Private.menuBar.id = 'jp-MainMenu';
-
-  let logo = new Widget();
-  logo.node.className = `${PORTRAIT_ICON_CLASS} ${JUPYTER_ICON_CLASS}`;
-  logo.id = 'jp-MainLogo';
-
-  app.shell.addToTopArea(logo);
-  app.shell.addToTopArea(Private.menuBar);
-
-  return Private.mainMenu;
-}
-
-
-/**
  * A namespace for private data.
  */
 namespace Private {
-  /**
-   * The singleton menu bar instance.
-   */
-  export
-  let menuBar: MenuBar;
-
-  /**
-   * The singleton main menu instance.
-   */
-  export
-  const mainMenu = new MainMenu();
-
-
   /**
    * An object which holds a menu and its sort rank.
    */

--- a/src/mainmenu/plugin.ts
+++ b/src/mainmenu/plugin.ts
@@ -2,14 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Menu
-} from 'phosphor/lib/ui/menu';
-
-import {
-  MenuBar
-} from 'phosphor/lib/ui/menubar';
-
-import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -48,58 +40,15 @@ const mainMenuProvider: JupyterLabPlugin<IMainMenu> = {
  * Activate the main menu extension.
  */
 function activateMainMenu(app: JupyterLab): IMainMenu {
-  Private.menuBar = new MenuBar({ keymap: app.keymap });
-  Private.menuBar.id = 'jp-MainMenu';
+  let menu = new MainMenu({ keymap: app.keymap });
+  menu.id = 'jp-MainMenu';
 
   let logo = new Widget();
   logo.node.className = `${PORTRAIT_ICON_CLASS} ${JUPYTER_ICON_CLASS}`;
   logo.id = 'jp-MainLogo';
 
   app.shell.addToTopArea(logo);
-  app.shell.addToTopArea(Private.menuBar);
+  app.shell.addToTopArea(menu);
 
-  return Private.mainMenu;
-}
-
-
-/**
- * A namespace for private data.
- */
-namespace Private {
-  /**
-   * The singleton menu bar instance.
-   */
-  export
-  let menuBar: MenuBar;
-
-  /**
-   * The singleton main menu instance.
-   */
-  export
-  const mainMenu = new MainMenu();
-
-
-  /**
-   * An object which holds a menu and its sort rank.
-   */
-  export
-  interface IRankItem {
-    /**
-     * The menu for the item.
-     */
-    menu: Menu;
-
-    /**
-     * The sort rank of the menu.
-     */
-    rank: number;
-  }
-
-  /**
-   * A comparator function for menu rank items.
-   */
-  export
-  function itemCmp(first: IRankItem, second: IRankItem): number {
-    return first.rank - second.rank;
-  }
+  return menu;
 }

--- a/src/markdownwidget/plugin.ts
+++ b/src/markdownwidget/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IRenderMime
-} from '../rendermime/plugin';
+} from '../rendermime';
 
 import {
   MarkdownWidgetFactory

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -2,3 +2,4 @@
 // Distributed under the terms of the Modified BSD License.
 
 export * from './notebook/index';
+export * from './tracker';

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -36,7 +36,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 import {
   WidgetTracker

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -31,7 +31,7 @@ import {
 
 import {
   IInspector
-} from '../inspector/plugin';
+} from '../inspector';
 
 import {
   IRenderMime

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   Menu
 } from 'phosphor/lib/ui/menu';
 
@@ -26,7 +22,8 @@ import {
 } from '../mainmenu';
 
 import {
-  IDocumentRegistry, restartKernel, selectKernelForContext, IWidgetFactoryOptions
+  IDocumentRegistry, IWidgetFactoryOptions,
+  restartKernel, selectKernelForContext
 } from '../docregistry';
 
 import {
@@ -46,7 +43,8 @@ import {
 } from '../widgettracker';
 
 import {
-  NotebookPanel, NotebookModelFactory, NotebookWidgetFactory, NotebookActions
+  INotebookTracker, NotebookPanel, NotebookModelFactory,
+  NotebookWidgetFactory, NotebookActions
 } from './index';
 
 
@@ -59,7 +57,6 @@ const PORTRAIT_ICON_CLASS = 'jp-MainAreaPortraitIcon';
  * The class name for the notebook icon from the default theme.
  */
 const NOTEBOOK_ICON_CLASS = 'jp-ImageNotebook';
-
 
 /**
  * The map of command ids used by the notebook.
@@ -104,22 +101,6 @@ const cmdIds = {
   markdown5: 'notebook-cells:markdown-header5',
   markdown6: 'notebook-cells:markdown-header6',
 };
-
-
-/* tslint:disable */
-/**
- * The notebook tracker token.
- */
-export
-const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebook-handler');
-/* tslint:enable */
-
-
-/**
- * A class that tracks notebook widgets.
- */
-export
-interface INotebookTracker extends WidgetTracker<NotebookPanel> { }
 
 
 /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IMainMenu

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -23,7 +23,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 import {
   IDocumentRegistry, restartKernel, selectKernelForContext, IWidgetFactoryOptions

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   IClipboard
-} from '../clipboard/plugin';
+} from '../clipboard';
 
 import {
   ICommandPalette

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -32,7 +32,7 @@ import {
 
 import {
   IRenderMime
-} from '../rendermime/plugin';
+} from '../rendermime';
 
 import {
   IServiceManager

--- a/src/notebook/tracker.ts
+++ b/src/notebook/tracker.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
+  WidgetTracker
+} from '../widgettracker';
+
+import {
+  NotebookPanel
+} from './';
+
+
+/* tslint:disable */
+/**
+ * The notebook tracker token.
+ */
+export
+const INotebookTracker = new Token<INotebookTracker>('jupyter.services.notebook-handler');
+/* tslint:enable */
+
+
+/**
+ * A class that tracks notebook widgets.
+ */
+export
+interface INotebookTracker extends WidgetTracker<NotebookPanel> {}

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -2,12 +2,25 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
 import {
   ISanitizer
 } from '../sanitizer';
+
+
+/* tslint:disable */
+/**
+ * The rendermime token.
+ */
+export
+const IRenderMime = new Token<IRenderMime>('jupyter.services.rendermime');
+/* tslint:enable */
 
 
 /**

--- a/src/rendermime/plugin.ts
+++ b/src/rendermime/plugin.ts
@@ -2,10 +2,6 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   JupyterLabPlugin
 } from '../application';
 
@@ -19,24 +15,8 @@ import {
 } from '../sanitizer';
 
 import {
-  IRenderMime as IBaseRenderMime, RenderMime
-} from './index';
-
-
-/* tslint:disable */
-/**
- * The rendermime token.
- */
-export
-const IRenderMime = new Token<IRenderMime>('jupyter.services.rendermime');
-/* tslint:enable */
-
-
-/**
- * The rendermime interface.
- */
-export
-interface IRenderMime extends IBaseRenderMime {}
+  IRenderMime, RenderMime
+} from './';
 
 
 /**

--- a/src/running/plugin.ts
+++ b/src/running/plugin.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 import {
   RunningSessions

--- a/src/sanitizer/index.ts
+++ b/src/sanitizer/index.ts
@@ -24,7 +24,8 @@ class Sanitizer implements ISanitizer {
   }
 
   private _options: sanitize.IOptions = {
-    allowedTags: sanitize.defaults.allowedTags.concat('svg', 'h1', 'h2', 'img', 'span'),
+    allowedTags: sanitize.defaults.allowedTags
+      .concat('svg', 'h1', 'h2', 'img', 'span'),
     allowedAttributes: {
       // Allow the "rel" attribute for <a> tags.
       'a': sanitize.defaults.allowedAttributes['a'].concat('rel'),

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  IServiceManager as IBaseServiceManager
+} from 'jupyter-js-services';
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+
+/* tslint:disable */
+/**
+ * The default services provider token.
+ */
+export
+const IServiceManager = new Token<IServiceManager>('jupyter.services.services');
+/* tslint:enable */
+
+
+/**
+ * The service manager interface.
+ */
+export
+interface IServiceManager extends IBaseServiceManager { };

--- a/src/services/plugin.ts
+++ b/src/services/plugin.ts
@@ -2,32 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  createServiceManager, IServiceManager as IBaseServiceManager
+  createServiceManager
 } from 'jupyter-js-services';
-
-import {
-  Token
-} from 'phosphor/lib/core/token';
 
 import {
   JupyterLabPlugin
 } from '../application';
 
-
-/* tslint:disable */
-/**
- * The default services provider token.
- */
-export
-const IServiceManager = new Token<IServiceManager>('jupyter.services.services');
-/* tslint:enable */
-
-
-/**
- * The service manager interface.
- */
-export
-interface IServiceManager extends IBaseServiceManager { };
+import {
+  IServiceManager
+} from './';
 
 
 /**

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   ICommandPalette
-} from '../commandpalette/plugin';
+} from '../commandpalette';
 
 import {
   IMainMenu

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -15,7 +15,7 @@ import {
 
 import {
   IMainMenu
-} from '../mainmenu/plugin';
+} from '../mainmenu';
 
 import {
   IServiceManager

--- a/src/terminal/plugin.ts
+++ b/src/terminal/plugin.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   IServiceManager
-} from '../services/plugin';
+} from '../services';
 
 import {
   WidgetTracker


### PR DESCRIPTION
Code that imports a `foo` plugin should never need to import from `./foo/plugin`, the `IFoo` interface and `Token` should be defined at `./foo`.