### PR TITLE
Remove inline source maps

### DIFF
--- a/examples/console/webpack.conf.js
+++ b/examples/console/webpack.conf.js
@@ -7,7 +7,7 @@ module.exports = {
     publicPath: './build/'
   },
   debug: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/examples/filebrowser/webpack.conf.js
+++ b/examples/filebrowser/webpack.conf.js
@@ -12,7 +12,7 @@ module.exports = {
   },
   bail: true,
   debug: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/examples/lab/webpack.conf.js
+++ b/examples/lab/webpack.conf.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   debug: true,
   bail: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/examples/notebook/webpack.conf.js
+++ b/examples/notebook/webpack.conf.js
@@ -7,7 +7,7 @@ module.exports = {
     publicPath: './build/'
   },
   debug: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/examples/terminal/webpack.conf.js
+++ b/examples/terminal/webpack.conf.js
@@ -10,7 +10,7 @@ module.exports = {
     fs: "empty"
   },
   bail: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   debug: true,
   bail: true,
-  devtool: 'inline-source-map',
+  devtool: 'source-map',
   module: {
     loaders: [
       { test: /\.css$/, loader: 'style-loader!css-loader' },


### PR DESCRIPTION
Source maps appear to be working again in Chrome 52.

cf https://github.com/jupyter/notebook/issues/1668#issuecomment-238672541