### PR TITLE
Fix CSS display specificity issues

### DIFF
--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -45,6 +45,11 @@ body {
 }
 
 
+.p-mod-hidden {
+  display: none !important;
+}
+
+
 .p-TabBar-tab.jp-mod-current {
   border-top: 1px solid #2196F3;
 }

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -45,11 +45,6 @@ body {
 }
 
 
-.p-Widget.p-mod-hidden {
-  background: none;
-}
-
-
 .p-TabBar-tab.jp-mod-current {
   border-top: 1px solid #2196F3;
 }

--- a/src/default-theme/shell.css
+++ b/src/default-theme/shell.css
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-#main:not(.p-mod-hidden) {
+#main {
   display: flex;
   flex-direction: column;
   font-size: 14px;
@@ -15,26 +15,26 @@
 }
 
 
-#jp-main-content-panel:not(.p-mod-hidden) {
+#jp-main-content-panel {
   display: flex;
   flex: 1 1 auto;
 }
 
 
-#jp-top-panel:not(.p-mod-hidden) {
+#jp-top-panel {
   display: flex;
   flex: 0 0 auto;
   min-height: 24px;
 }
 
 
-#jp-main-split-panel:not(.p-mod-hidden) {
+#jp-main-split-panel {
   display: flex;
   flex: 1 1 auto;
 }
 
 
-#jp-left-stack, #jp-right-stack:not(.p-mod-hidden) {
+#jp-left-stack, #jp-right-stack {
   display: flex;
   flex: 1 1 auto;
 }

--- a/src/default-theme/shell.css
+++ b/src/default-theme/shell.css
@@ -3,7 +3,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 
-#main {
+#main:not(.p-mod-hidden) {
   display: flex;
   flex-direction: column;
   font-size: 14px;
@@ -15,26 +15,26 @@
 }
 
 
-#jp-main-content-panel {
+#jp-main-content-panel:not(.p-mod-hidden) {
   display: flex;
   flex: 1 1 auto;
 }
 
 
-#jp-top-panel {
+#jp-top-panel:not(.p-mod-hidden) {
   display: flex;
   flex: 0 0 auto;
   min-height: 24px;
 }
 
 
-#jp-main-split-panel {
+#jp-main-split-panel:not(.p-mod-hidden) {
   display: flex;
   flex: 1 1 auto;
 }
 
 
-#jp-left-stack, #jp-right-stack {
+#jp-left-stack, #jp-right-stack:not(.p-mod-hidden) {
   display: flex;
   flex: 1 1 auto;
 }


### PR DESCRIPTION
We were previously preventing `p-mod-hidden` from setting `display: None` properly.