### PR TITLE
Disable text selection on the filebrowser items

### DIFF
--- a/src/filebrowser/theme.css
+++ b/src/filebrowser/theme.css
@@ -174,6 +174,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: none;
 }
 
 


### PR DESCRIPTION
This used to be part of the base `p-Widget` styling.  The lack of this style caused awkward interactions with the file browser items.