### PR TITLE
Clean up notebook focus behavior

### DIFF
--- a/src/notebook/index.css
+++ b/src/notebook/index.css
@@ -28,7 +28,6 @@
 .jp-InputArea-prompt {
   flex-grow: 0;
   flex-shrink: 0;
-  padding-top: 8px !important;
 }
 
 

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -335,7 +335,8 @@ namespace NotebookActions {
       promises.push(Private.runCell(widget, child, kernel));
     }
     return Promise.all(promises).then(results => {
-      widget.activate();
+      // Post an update request.
+      widget.update();
       for (let result of results) {
         if (!result) {
           return false;

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -371,9 +371,11 @@ namespace NotebookActions {
     if (widget.activeCellIndex === widget.childCount() - 1) {
       let cell = model.factory.createCodeCell();
       model.cells.add(cell);
+      widget.activeCellIndex++;
       widget.mode = 'edit';
+    } else {
+      widget.activeCellIndex++;
     }
-    widget.activeCellIndex++;
     return promise;
   }
 

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -626,7 +626,7 @@ class Notebook extends StaticNotebook {
       if (activeCell instanceof MarkdownCellWidget) {
         activeCell.rendered = false;
       }
-      this._isActive = true;
+      this.activate();
     }
   }
 
@@ -946,7 +946,7 @@ class Notebook extends StaticNotebook {
    * Handle `mousedown` events for the widget.
    */
   private _evtMouseDown(event: MouseEvent): void {
-    this._isActive = true;
+    this.activate();
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -965,7 +965,7 @@ class Notebook extends StaticNotebook {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: MouseEvent): void {
-    this._isActive = true;
+    this.activate();
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -989,7 +989,7 @@ class Notebook extends StaticNotebook {
    * Handle `dblclick` events for the widget.
    */
   private _evtDblClick(event: MouseEvent): void {
-    this._isActive = true;
+    this.activate();
     let model = this.model;
     if (!model || model.readOnly) {
       return;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -809,7 +809,6 @@ class Notebook extends StaticNotebook {
     let activeCell = this.activeCell;
     // Ensure we have the correct focus.
     if (this._isActive) {
-      console.log(this.mode, activeCell);
       if (this.mode === 'edit' && activeCell) {
         activeCell.editor.activate();
       } else {
@@ -967,7 +966,6 @@ class Notebook extends StaticNotebook {
    */
   private _evtFocus(event: MouseEvent): void {
     this._isActive = true;
-    console.log(event);
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -10,7 +10,7 @@ import {
 } from 'phosphor/lib/algorithm/searching';
 
 import {
-  Message
+  sendMessage, Message
 } from 'phosphor/lib/core/messaging';
 
 import {
@@ -30,7 +30,7 @@ import {
 } from 'phosphor/lib/ui/panel';
 
 import {
-  Widget
+  Widget, WidgetMessage
 } from 'phosphor/lib/ui/widget';
 
 import {
@@ -626,7 +626,9 @@ class Notebook extends StaticNotebook {
       if (activeCell instanceof MarkdownCellWidget) {
         activeCell.rendered = false;
       }
-      this.activate();
+      if (!this._isActive) {
+        sendMessage(this, WidgetMessage.ActivateRequest);
+      }
     }
   }
 
@@ -946,7 +948,9 @@ class Notebook extends StaticNotebook {
    * Handle `mousedown` events for the widget.
    */
   private _evtMouseDown(event: MouseEvent): void {
-    this.activate();
+    if (!this._isActive) {
+      sendMessage(this, WidgetMessage.ActivateRequest);
+    }
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -965,7 +969,9 @@ class Notebook extends StaticNotebook {
    * Handle `focus` events for the widget.
    */
   private _evtFocus(event: MouseEvent): void {
-    this.activate();
+    if (!this._isActive) {
+      sendMessage(this, WidgetMessage.ActivateRequest);
+    }
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -989,7 +995,9 @@ class Notebook extends StaticNotebook {
    * Handle `dblclick` events for the widget.
    */
   private _evtDblClick(event: MouseEvent): void {
-    this.activate();
+    if (!this._isActive) {
+      sendMessage(this, WidgetMessage.ActivateRequest);
+    }
     let model = this.model;
     if (!model || model.readOnly) {
       return;

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -626,6 +626,7 @@ class Notebook extends StaticNotebook {
       if (activeCell instanceof MarkdownCellWidget) {
         activeCell.rendered = false;
       }
+      this._isActive = true;
     }
   }
 

--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -809,6 +809,7 @@ class Notebook extends StaticNotebook {
     let activeCell = this.activeCell;
     // Ensure we have the correct focus.
     if (this._isActive) {
+      console.log(this.mode, activeCell);
       if (this.mode === 'edit' && activeCell) {
         activeCell.editor.activate();
       } else {
@@ -966,6 +967,7 @@ class Notebook extends StaticNotebook {
    */
   private _evtFocus(event: MouseEvent): void {
     this._isActive = true;
+    console.log(event);
     let target = event.target as HTMLElement;
     let i = this._findCell(target);
     if (i !== -1) {
@@ -978,6 +980,7 @@ class Notebook extends StaticNotebook {
       } else {
         this.mode = 'command';
       }
+      this.activeCellIndex = i;
     } else {
       // No cell has focus, ensure command mode.
       this.mode = 'command';

--- a/src/notebook/theme.css
+++ b/src/notebook/theme.css
@@ -33,7 +33,7 @@
   font-family: monospace;
   padding: 0.4em;
   text-align: right;
-  line-height: 20px;
+  line-height: 1.2em;
   font-size: 14px;
 }
 
@@ -44,12 +44,11 @@
 }
 
 
-.jp-CellEditor {
+.jp-CellEditor.p-Widget {
   border: 1px solid #cfcfcf;
   border-radius: 2px;
   background: #f7f7f7;
   line-height: 1.2em;
-  padding: 4px;
 }
 
 
@@ -59,12 +58,12 @@
 
 
 .jp-MarkdownCell.jp-mod-rendered {
-  padding-left: 100px;
+  padding-left: 90px;
 }
 
 
 .jp-MarkdownCell-renderer {
-  padding-left: 4px;
+  padding: 0.5em 0.5em 0.5em 0.4em;
 }
 
 

--- a/test/src/notebook/cells/widget.spec.ts
+++ b/test/src/notebook/cells/widget.spec.ts
@@ -803,7 +803,7 @@ describe('notebook/cells/widget', () => {
     describe('#constructor()', () => {
 
       it('should create a raw cell widget', () => {
-        let widget = new RawCellWidget({renderer:CodeMirrorNotebookRenderer.defaultRawCellRenderer});
+        let widget = new RawCellWidget({renderer: CodeMirrorNotebookRenderer.defaultRawCellRenderer});
         expect(widget).to.be.a(RawCellWidget);
       });
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -704,13 +704,19 @@ describe('notebook/notebook/widget', () => {
         });
       });
 
-      it('should activate if switching to edit mode', (done) => {
+      it('should focus the cell if switching to edit mode', (done) => {
         let widget = createActiveWidget();
         Widget.attach(widget, document.body);
         widget.mode = 'edit';
+        let cell = widget.childAt(widget.activeCellIndex);
+        // Wait for update-request.
         requestAnimationFrame(() => {
+          // Notebook activates the editor.
           expect(widget.methods).to.contain('onActivateRequest');
-          done();
+          requestAnimationFrame(() => {
+            expect(cell.node.contains(document.activeElement)).to.be(true);
+            done();
+          });
         });
       });
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -704,18 +704,13 @@ describe('notebook/notebook/widget', () => {
         });
       });
 
-      it('should focus the cell if switching to edit mode', (done) => {
+      it('should activate if switching to edit mode', (done) => {
         let widget = createActiveWidget();
         Widget.attach(widget, document.body);
         widget.mode = 'edit';
-        let cell = widget.childAt(widget.activeCellIndex);
-        // Wait for update-request.
         requestAnimationFrame(() => {
-          // Notebook activates the editor.
-          requestAnimationFrame(() => {
-            expect(cell.node.contains(document.activeElement)).to.be(true);
-            done();
-          });
+          expect(widget.methods).to.contain('onActivateRequest');
+          done();
         });
       });
 

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -709,12 +709,11 @@ describe('notebook/notebook/widget', () => {
         Widget.attach(widget, document.body);
         widget.mode = 'edit';
         let cell = widget.childAt(widget.activeCellIndex);
-        // Notebook activates cell.
+        // Wait for update-request.
         requestAnimationFrame(() => {
-          // Cell activates editor.
+          // Notebook activates the editor.
           requestAnimationFrame(() => {
             expect(cell.node.contains(document.activeElement)).to.be(true);
-            widget.dispose();
             done();
           });
         });
@@ -1044,13 +1043,16 @@ describe('notebook/notebook/widget', () => {
 
     describe('#onActivateRequest()', () => {
 
-      it('should focus the node', () => {
+      it('should focus the node after an update', (done) => {
         let widget = createActiveWidget();
         Widget.attach(widget, document.body);
         sendMessage(widget, WidgetMessage.ActivateRequest);
         expect(widget.methods).to.contain('onActivateRequest');
-        expect(document.activeElement).to.be(widget.node);
-        widget.dispose();
+        requestAnimationFrame(() => {
+          expect(document.activeElement).to.be(widget.node);
+          widget.dispose();
+          done();
+        });
       });
 
       it('should post an `update-request', (done) => {


### PR DESCRIPTION
The following now all work:
- Run a cell with `time.sleep()` and it does not affect editing in the next cell
- Run a cell with `input()` and the cell always gets focus in command mode
- Click in an out of the stdin input field in `input()`
- The notebook will now only explicitly take focus if it has been explicitly activated by a DOM event or `activate()` or the mode is set to `edit`.  Any actions after `deactivate()` will not take focus, allowing you to start editing another notebook while the previous one finishes an execution.

Also fixes some styling issues in cells.

