### PR TITLE
Context refactor

### DIFF
--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -207,7 +207,7 @@ class Context<T extends IDocumentModel> implements IDocumentContext<T> {
    * #### Notes
    * This is not intended to be called by the user.
    * It is assumed that the file has been renamed on the
-   * contents manager outside of this operation.
+   * contents manager prior to this operation.
    */
   setPath(value: string): void {
     this._path = value;

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -373,7 +373,9 @@ class Context<T extends IDocumentModel> implements IDocumentContext<T> {
    */
   addSibling(widget: Widget): IDisposable {
     let opener = this._opener;
-    opener(widget);
+    if (opener) {
+      opener(widget);
+    }
     return new DisposableDelegate(() => {
       widget.close();
     });
@@ -483,11 +485,6 @@ export namespace Context {
     manager: IServiceManager;
 
     /**
-     * A callback for opening sibling widgets.
-     */
-    opener: (widget: Widget) => void;
-
-    /**
      * The model factory used to create the model.
      */
     factory: IModelFactory<T>;
@@ -496,6 +493,11 @@ export namespace Context {
      * The initial path of the file.
      */
     path: string;
+
+    /**
+     * An optional callback for opening sibling widgets.
+     */
+    opener?: (widget: Widget) => void;
   }
 }
 

--- a/src/docmanager/context.ts
+++ b/src/docmanager/context.ts
@@ -205,7 +205,7 @@ class Context<T extends IDocumentModel> implements IDocumentContext<T> {
    * Set the path of the context.
    *
    * #### Notes
-   * This should only be called by the document manager.
+   * This is not intended to be called by the user.
    * It is assumed that the file has been renamed on the
    * contents manager outside of this operation.
    */

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -207,7 +207,9 @@ class DocumentManager implements IDisposable {
       widgetName = this._registry.defaultWidgetFactory(ContentsManager.extname(path));
     }
     let context = this._contextForPath(path);
-    return this._widgetManager.findWidget(context, widgetName);
+    if (context) {
+      return this._widgetManager.findWidget(context, widgetName);
+    }
   }
 
   /**

--- a/src/docmanager/manager.ts
+++ b/src/docmanager/manager.ts
@@ -6,7 +6,19 @@ import {
 } from 'jupyter-js-services';
 
 import {
-  IDisposable, DisposableDelegate
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
+  find
+} from 'phosphor/lib/algorithm/searching';
+
+import {
+  Vector
+} from 'phosphor/lib/collections/vector';
+
+import {
+  IDisposable
 } from 'phosphor/lib/core/disposable';
 
 import {
@@ -15,7 +27,7 @@ import {
 
 import {
   IDocumentRegistry, IWidgetFactory, IWidgetFactoryOptions,
-  IDocumentModel, IDocumentContext
+  IDocumentModel, IDocumentContext, IModelFactory
 } from '../docregistry';
 
 import {
@@ -23,7 +35,7 @@ import {
 } from '../filebrowser';
 
 import {
-  ContextManager
+  Context
 } from './context';
 
 import {
@@ -49,19 +61,8 @@ class DocumentManager implements IDisposable {
   constructor(options: DocumentManager.IOptions) {
     this._registry = options.registry;
     this._serviceManager = options.manager;
-    let opener = options.opener;
-    this._contextManager = new ContextManager({
-      manager: this._serviceManager,
-      opener: (id: string, widget: Widget) => {
-        this._widgetManager.adoptWidget(id, widget);
-        opener.open(widget);
-        return new DisposableDelegate(() => {
-          widget.close();
-        });
-      }
-    });
+    this._opener = options.opener;
     this._widgetManager = new DocumentWidgetManager({
-      contextManager: this._contextManager,
       registry: this._registry
     });
   }
@@ -101,8 +102,10 @@ class DocumentManager implements IDisposable {
       return;
     }
     this._serviceManager = null;
-    this._contextManager.dispose();
-    this._contextManager = null;
+    each(this._contexts, context => {
+      context.dispose();
+    });
+    this._contexts.clear();
     this._widgetManager.dispose();
     this._widgetManager = null;
   }
@@ -121,32 +124,18 @@ class DocumentManager implements IDisposable {
     if (widgetName === 'default') {
       widgetName = registry.defaultWidgetFactory(ContentsManager.extname(path));
     }
-    let mFactory = registry.getModelFactoryFor(widgetName);
-    if (!mFactory) {
+    let factory = registry.getModelFactoryFor(widgetName);
+    if (!factory) {
       return;
     }
     // Use an existing context if available.
-    let id = this._contextManager.findContext(path, mFactory.name);
-    if (id) {
-      return this._widgetManager.createWidget(widgetName, id, kernel);
+    let context = this._findContext(path, factory.name);
+    if (!context) {
+      context = this._createContext(path, factory);
+      // Load the contents from disk.
+      context.revert();
     }
-    let lang = mFactory.preferredLanguage(path);
-    let model = mFactory.createNew(lang);
-    let ctxManager = this._contextManager;
-    id = ctxManager.createNew(path, model, mFactory);
-    // Load the contents from disk.
-    // Create a checkpoint if none exists.
-    ctxManager.listCheckpoints(id).then(checkpoints => {
-      if (!checkpoints) {
-        return ctxManager.createCheckpoint(id);
-      }
-    }).then(() => {
-      return ctxManager.revert(id);
-    }).then(() => {
-      model.dirty = false;
-      this._contextManager.finalize(id);
-    });
-    return this._widgetManager.createWidget(widgetName, id, kernel);
+    return this._widgetManager.createWidget(widgetName, context, kernel);
   }
 
   /**
@@ -163,21 +152,14 @@ class DocumentManager implements IDisposable {
     if (widgetName === 'default') {
       widgetName = registry.defaultWidgetFactory(ContentsManager.extname(path));
     }
-    let mFactory = registry.getModelFactoryFor(widgetName);
-    if (!mFactory) {
+    let factory = registry.getModelFactoryFor(widgetName);
+    if (!factory) {
       return;
     }
-    let lang = mFactory.preferredLanguage(path);
-    let model = mFactory.createNew(lang);
-    let ctxManager = this._contextManager;
-    let id = ctxManager.createNew(path, model, mFactory);
-    ctxManager.save(id).then(() => {
-      return ctxManager.createCheckpoint(id);
-    }).then(() => {
-      model.dirty = false;
-      ctxManager.finalize(id);
-    });
-    return this._widgetManager.createWidget(widgetName, id, kernel);
+    let context = this._createContext(path, factory);
+    // Immediately save the contents to disk.
+    context.save();
+    return this._widgetManager.createWidget(widgetName, context, kernel);
   }
 
   /**
@@ -195,7 +177,11 @@ class DocumentManager implements IDisposable {
    * @param newPath - The new path.
    */
   handleRename(oldPath: string, newPath: string): void {
-    this._contextManager.handleRename(oldPath, newPath);
+    each(this._contexts, context => {
+      if (context.path === oldPath) {
+        context.setPath(newPath);
+      }
+    });
   }
 
   /**
@@ -220,7 +206,8 @@ class DocumentManager implements IDisposable {
     if (widgetName === 'default') {
       widgetName = this._registry.defaultWidgetFactory(ContentsManager.extname(path));
     }
-    return this._widgetManager.findWidget(path, widgetName);
+    let context = this._contextForPath(path);
+    return this._widgetManager.findWidget(context, widgetName);
   }
 
   /**
@@ -245,20 +232,64 @@ class DocumentManager implements IDisposable {
    * Close the widgets associated with a given path.
    */
   closeFile(path: string): void {
-    this._widgetManager.closeFile(path);
+    let context = this._contextForPath(path);
+    this._widgetManager.close(context);
   }
 
   /**
    * Close all of the open documents.
    */
   closeAll(): void {
-    this._widgetManager.closeAll();
+    each(this._contexts, context => {
+      this._widgetManager.close(context);
+    });
+  }
+
+  /**
+   * Find a context for a given path and factory name.
+   */
+  private _findContext(path: string, factoryName: string): Context<IDocumentModel> {
+    return find(this._contexts, context => {
+      return (context.factoryName === factoryName &&
+              context.path === path);
+    });
+  }
+
+  /**
+   * Get a context for a given path.
+   */
+  private _contextForPath(path: string): Context<IDocumentModel> {
+    return find(this._contexts, context => {
+      return context.path === path;
+    });
+  }
+
+  /**
+   * Create a context from a path and a model factory.
+   */
+  private _createContext(path: string, factory: IModelFactory<IDocumentModel>): Context<IDocumentModel> {
+    let adopter = (widget: Widget) => {
+      this._widgetManager.adoptWidget(context, widget);
+      this._opener.open(widget);
+    };
+    let context = new Context({
+      opener: adopter,
+      manager: this._serviceManager,
+      factory,
+      path
+    });
+    context.disposed.connect(() => {
+      this._contexts.remove(context);
+    });
+    this._contexts.pushBack(context);
+    return context;
   }
 
   private _serviceManager: IServiceManager = null;
-  private _contextManager: ContextManager = null;
   private _widgetManager: DocumentWidgetManager = null;
   private _registry: IDocumentRegistry = null;
+  private _contexts: Vector<Context<IDocumentModel>> = new Vector<Context<IDocumentModel>>();
+  private _opener: IWidgetOpener = null;
 }
 
 

--- a/src/docmanager/savehandler.ts
+++ b/src/docmanager/savehandler.ts
@@ -34,7 +34,7 @@ class SaveHandler implements IDisposable {
    * Construct a new save handler.
    */
   constructor(options: SaveHandler.IOptions) {
-    this._services = options.services;
+    this._manager = options.manager;
     this._context = options.context;
     this._minInterval = options.saveInterval || 120;
     this._interval = this._minInterval;
@@ -110,7 +110,7 @@ class SaveHandler implements IDisposable {
     }
 
     // Make sure the file has not changed on disk.
-    this._services.contents.get(context.path).then(model => {
+    this._manager.contents.get(context.path).then(model => {
       if (model.last_modified !== context.contentsModel.last_modified) {
         return this._timeConflict(model.last_modified);
       }
@@ -163,7 +163,7 @@ class SaveHandler implements IDisposable {
   private _minInterval = -1;
   private _interval = -1;
   private _context: IDocumentContext<IDocumentModel> = null;
-  private _services: IServiceManager = null;
+  private _manager: IServiceManager = null;
   private _stopped = false;
 }
 
@@ -186,7 +186,7 @@ namespace SaveHandler {
     /**
      * The service manager to use for checking last saved.
      */
-    services: IServiceManager;
+    manager: IServiceManager;
 
     /**
      * The minimum save interval in seconds (default is two minutes).

--- a/src/docmanager/widgetmanager.ts
+++ b/src/docmanager/widgetmanager.ts
@@ -6,6 +6,18 @@ import {
 } from 'jupyter-js-services';
 
 import {
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
+  find
+} from 'phosphor/lib/algorithm/searching';
+
+import {
+  Vector
+} from 'phosphor/lib/collections/vector';
+
+import {
   DisposableSet, IDisposable
 } from 'phosphor/lib/core/disposable';
 
@@ -37,10 +49,6 @@ import {
   IDocumentRegistry, IDocumentContext, IDocumentModel
 } from '../docregistry';
 
-import {
-  ContextManager
-} from './context';
-
 
 /**
  * The class name added to document widgets.
@@ -57,7 +65,6 @@ class DocumentWidgetManager implements IDisposable {
    * Construct a new document widget manager.
    */
   constructor(options: DocumentWidgetManager.IOptions) {
-    this._contextManager = options.contextManager;
     this._registry = options.registry;
   }
 
@@ -76,21 +83,14 @@ class DocumentWidgetManager implements IDisposable {
       return;
     }
     this._registry = null;
-    this._contextManager = null;
-    for (let id in this._widgets) {
-      for (let widget of this._widgets[id]) {
-        widget.dispose();
-      }
-    }
     clearSignalData(this);
   }
 
   /**
    * Create a widget for a document and handle its lifecycle.
    */
-  createWidget(name: string, id: string, kernel?: IKernel.IModel): Widget {
+  createWidget(name: string, context: IDocumentContext<IDocumentModel>, kernel?: IKernel.IModel): Widget {
     let factory = this._registry.getWidgetFactory(name);
-    let context = this._contextManager.getContext(id);
     let widget = factory.createNew(context, kernel);
     Private.nameProperty.set(widget, name);
 
@@ -102,7 +102,7 @@ class DocumentWidgetManager implements IDisposable {
     widget.disposed.connect(() => {
       disposables.dispose();
     });
-    this.adoptWidget(id, widget);
+    this.adoptWidget(context, widget);
     this.setCaption(widget);
     context.contentsModelChanged.connect(() => {
       this.setCaption(widget);
@@ -117,54 +117,47 @@ class DocumentWidgetManager implements IDisposable {
    * Install the message hook for the widget and add to list
    * of known widgets.
    */
-  adoptWidget(id: string, widget: Widget): void {
-    if (!(id in this._widgets)) {
-      this._widgets[id] = [];
-    }
-    this._widgets[id].push(widget);
+  adoptWidget(context: IDocumentContext<IDocumentModel>, widget: Widget): void {
+    let widgets = Private.widgetsProperty.get(context);
+    widgets.pushBack(widget);
     installMessageHook(widget, (handler: IMessageHandler, msg: Message) => {
       return this.filterMessage(handler, msg);
     });
     widget.addClass(DOCUMENT_CLASS);
     widget.title.closable = true;
     widget.disposed.connect(() => {
-      // Remove the widget from the widget registry.
-      let index = this._widgets[id].indexOf(widget);
-      this._widgets[id].splice(index, 1);
+      // Remove the widget.
+      widgets.remove(widget);
       // Dispose of the context if this is the last widget using it.
-      if (!this._widgets[id].length) {
-        let context = this._contextManager.getContext(id);
+      if (!widgets.length) {
         context.dispose();
       }
     });
-    Private.idProperty.set(widget, id);
+    Private.contextProperty.set(widget, context);
   }
 
   /**
-   * See if a widget already exists for the given path and widget name.
+   * See if a widget already exists for the given context and widget name.
    *
    * #### Notes
    * This can be used to use an existing widget instead of opening
    * a new widget.
    */
-  findWidget(path: string, widgetName: string): Widget {
-    let ids = this._contextManager.getIdsForPath(path);
-    for (let id of ids) {
-      for (let widget of this._widgets[id]) {
-        let name = Private.nameProperty.get(widget);
-        if (name === widgetName) {
-          return widget;
-        }
+  findWidget(context: IDocumentContext<IDocumentModel>, widgetName: string): Widget {
+    let widgets = Private.widgetsProperty.get(context);
+    return find(widgets, widget => {
+      let name = Private.nameProperty.get(widget);
+      if (name === widgetName) {
+        return true;
       }
-    }
+    });
   }
 
   /**
    * Get the document context for a widget.
    */
   contextForWidget(widget: Widget): IDocumentContext<IDocumentModel> {
-    let id = Private.idProperty.get(widget);
-    return this._contextManager.getContext(id);
+    return Private.contextProperty.get(widget);
   }
 
   /**
@@ -175,35 +168,21 @@ class DocumentWidgetManager implements IDisposable {
    * as this widget.
    */
   clone(widget: Widget): Widget {
-    let id = Private.idProperty.get(widget);
+    let context = Private.contextProperty.get(widget);
     let name = Private.nameProperty.get(widget);
-    let newWidget = this.createWidget(name, id);
-    this.adoptWidget(id, newWidget);
+    let newWidget = this.createWidget(name, context);
+    this.adoptWidget(context, newWidget);
     return widget;
   }
 
   /**
-   * Close the widgets associated with a given path.
+   * Get the widgets associated with a given context.
    */
-  closeFile(path: string): void {
-    let ids = this._contextManager.getIdsForPath(path);
-    for (let id of ids) {
-      let widgets: Widget[] = this._widgets[id] || [];
-      for (let w of widgets) {
-        w.close();
-      }
-    }
-  }
-
-  /**
-   * Close all of the open documents.
-   */
-  closeAll(): void {
-    for (let id in this._widgets) {
-      for (let w of this._widgets[id]) {
-        w.close();
-      }
-    }
+  close(context: IDocumentContext<IDocumentModel>): void {
+    let widgets = Private.widgetsProperty.get(context);
+    each(widgets, widget => {
+      widget.close();
+    });
   }
 
   /**
@@ -231,7 +210,7 @@ class DocumentWidgetManager implements IDisposable {
    * Set the caption for widget title.
    */
   protected setCaption(widget: Widget): void {
-    let context = this.contextForWidget(widget);
+    let context = Private.contextProperty.get(widget);
     let model = context.contentsModel;
     if (!model) {
       widget.title.caption = '';
@@ -272,9 +251,9 @@ class DocumentWidgetManager implements IDisposable {
    */
   private _maybeClose(widget: Widget): Promise<boolean> {
     // Bail if the model is not dirty or other widgets are using the model.
-    let id = Private.idProperty.get(widget);
-    let widgets = this._widgets[id];
-    let model = this._contextManager.getModel(id);
+    let context = Private.contextProperty.get(widget);
+    let widgets = Private.widgetsProperty.get(context);
+    let model = context.model;
     if (!model.dirty || widgets.length > 1) {
       return Promise.resolve(true);
     }
@@ -291,9 +270,7 @@ class DocumentWidgetManager implements IDisposable {
   }
 
   private _closeGuard = false;
-  private _contextManager: ContextManager = null;
   private _registry: IDocumentRegistry = null;
-  private _widgets: { [key: string]: Widget[] } = Object.create(null);
 }
 
 
@@ -311,11 +288,6 @@ namespace DocumentWidgetManager {
      * A document registry instance.
      */
     registry: IDocumentRegistry;
-
-    /**
-     * A context manager instance.
-     */
-    contextManager: ContextManager;
   }
 }
 
@@ -325,11 +297,11 @@ namespace DocumentWidgetManager {
  */
 namespace Private {
   /**
-   * A private attached property for a widget context id.
+   * A private attached property for a widget context.
    */
   export
-  const idProperty = new AttachedProperty<Widget, string>({
-    name: 'id'
+  const contextProperty = new AttachedProperty<Widget, IDocumentContext<IDocumentModel>>({
+    name: 'context'
   });
 
   /**
@@ -338,5 +310,16 @@ namespace Private {
   export
   const nameProperty = new AttachedProperty<Widget, string>({
     name: 'name'
+  });
+
+  /**
+   * A private attached property for the widgets associated with a context.
+   */
+  export
+  const widgetsProperty = new AttachedProperty<IDocumentContext<IDocumentModel>, Vector<Widget>>({
+    name: 'widgets',
+    create: () => {
+      return new Vector<Widget>();
+    }
   });
 }

--- a/src/docregistry/default.ts
+++ b/src/docregistry/default.ts
@@ -169,7 +169,7 @@ defineSignal(DocumentModel.prototype, 'stateChanged');
  * An implementation of a model factory for text files.
  */
 export
-class TextModelFactory implements IModelFactory {
+class TextModelFactory implements IModelFactory<IDocumentModel> {
   /**
    * The name of the model type.
    *

--- a/src/docregistry/interfaces.ts
+++ b/src/docregistry/interfaces.ts
@@ -126,14 +126,6 @@ interface IDocumentContext<T extends IDocumentModel> extends IDisposable {
   disposed: ISignal<IDocumentContext<T>, void>;
 
   /**
-   * The unique id of the context.
-   *
-   * #### Notes
-   * This is a read-only property.
-   */
-  id: string;
-
-  /**
    * Get the model associated with the document.
    *
    * #### Notes
@@ -355,7 +347,7 @@ interface IWidgetExtension<T extends Widget, U extends IDocumentModel> {
  * The interface for a model factory.
  */
 export
-interface IModelFactory extends IDisposable {
+interface IModelFactory<T extends IDocumentModel> extends IDisposable {
   /**
    * The name of the model.
    *
@@ -386,7 +378,7 @@ interface IModelFactory extends IDisposable {
    *
    * @returns A new document model.
    */
-  createNew(languagePreference?: string): IDocumentModel;
+  createNew(languagePreference?: string): T;
 
   /**
    * Get the preferred kernel language given an extension.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -65,7 +65,7 @@ interface IDocumentRegistry extends IDisposable {
    * the given factory is already registered, a warning will be logged
    * and this will be a no-op.
    */
-  addModelFactory(factory: IModelFactory): IDisposable;
+  addModelFactory(factory: IModelFactory<IDocumentModel>): IDisposable;
 
   /**
    * Add a widget extension to the registry.
@@ -190,7 +190,7 @@ interface IDocumentRegistry extends IDisposable {
    *
    * @returns A model factory instance.
    */
-  getModelFactoryFor(widgetName: string): IModelFactory;
+  getModelFactoryFor(widgetName: string): IModelFactory<IDocumentModel>;
 
   /**
    * Get a widget factory by name.
@@ -317,7 +317,7 @@ class DocumentRegistry implements IDocumentRegistry {
    * the given factory is already registered, a warning will be logged
    * and this will be a no-op.
    */
-  addModelFactory(factory: IModelFactory): IDisposable {
+  addModelFactory(factory: IModelFactory<IDocumentModel>): IDisposable {
     let name = factory.name.toLowerCase();
     if (this._modelFactories[name]) {
       console.warn(`Duplicate registered factory ${name}`);
@@ -585,7 +585,7 @@ class DocumentRegistry implements IDocumentRegistry {
    *
    * @returns A model factory instance.
    */
-  getModelFactoryFor(widgetName: string): IModelFactory {
+  getModelFactoryFor(widgetName: string): IModelFactory<IDocumentModel> {
     widgetName = widgetName.toLowerCase();
     let wFactoryEx = this._getWidgetFactoryEx(widgetName);
     if (!wFactoryEx) {
@@ -636,7 +636,7 @@ class DocumentRegistry implements IDocumentRegistry {
     return options;
   }
 
-  private _modelFactories: { [key: string]: IModelFactory } = Object.create(null);
+  private _modelFactories: { [key: string]: IModelFactory<IDocumentModel> } = Object.create(null);
   private _widgetFactories: { [key: string]: Private.IWidgetFactoryRecord } = Object.create(null);
   private _defaultWidgetFactory = '';
   private _defaultWidgetFactories: { [key: string]: string } = Object.create(null);

--- a/src/notebook/notebook/modelfactory.ts
+++ b/src/notebook/notebook/modelfactory.ts
@@ -18,7 +18,7 @@ import {
  * A model factory for notebooks.
  */
 export
-class NotebookModelFactory implements IModelFactory {
+class NotebookModelFactory implements IModelFactory<INotebookModel> {
   /**
    * The name of the model.
    *


### PR DESCRIPTION
Removes the context manager class and cleans up the document manager and associated files.

This makes it possible to instantiate a `Context` without a document manager, both for testing purposes and for third party use cases.

The removal of the mock context manager will have to wait until after https://github.com/jupyter/jupyter-js-services/issues/190.