### PR TITLE
add environment.yml, binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # [JupyterLab](http://jupyter.github.io/jupyterlab/)
 
+[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/jupyter/jupyterlab/lab)
+
 An extensible computational environment for Jupyter.
 
 **JupyterLab is a very early developer preview, and is not suitable for

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: jupyterlab
+channels:
+  - conda-forge
+dependencies:
+  - jupyterlab
+  - ipywidgets
+  - pandas
+  - nodejs


### PR DESCRIPTION
This adds the `environment.yml` used at JupyterDay Atlanta such that binder can find it, and a direct link to the `/lab` endpoint through the deep-linking mechanism. Exactly what else one would want in the binder environment remains to be seen!

Here's my one built off this:
http://mybinder.org/repo/bollwyvl/jupyterlab/lab
(the PR has the correct repo)

It only runs off master, and does have to be updated each time a new conda-forge release is cut, but as it is provides a pretty good experience.

Fixes #659.