### PR TITLE
Enable Third Party Extensions

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -27,8 +27,12 @@ Distributed under the terms of the Modified BSD License.
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/jupyter-js-services.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript" charset="utf-8">
+  console.log(phosphor);
+</script>
+<script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/lab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
 </body>
 

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -30,7 +30,7 @@ Distributed under the terms of the Modified BSD License.
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/main.bundle.js" type="text/javascript" charset="utf-8"></script>
 </body>
 
 </html>

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -15,6 +15,9 @@ Distributed under the terms of the Modified BSD License.
     {% endif %}
     <script src="{{static_url("components/jquery/jquery.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- window.$ -->
     <script src="{{static_url("components/jquery-ui/ui/minified/jquery-ui.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
+    <link href="{{static_prefix}}/vendor.css" rel="stylesheet">
+    <link href="{{static_prefix}}/CodeMirror.css" rel="stylesheet">
+    <link href="{{static_prefix}}/main.css" rel="stylesheet">
 </head>
 
 
@@ -26,9 +29,11 @@ Distributed under the terms of the Modified BSD License.
   "wsUrl": "{{ws_url| urlencode}}",
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
+
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/CodeMirror.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/main.bundle.js" type="text/javascript" charset="utf-8"></script>
 </body>

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -27,12 +27,9 @@ Distributed under the terms of the Modified BSD License.
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script type="text/javascript" charset="utf-8">
-  console.log(phosphor);
-</script>
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/lab.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
 </body>
 

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -26,8 +26,10 @@ Distributed under the terms of the Modified BSD License.
   "wsUrl": "{{ws_url| urlencode}}",
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
+<script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyter-js-services.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/bundle.js" type="text/javascript" charset="utf-8"></script>
-
 </body>
 
 </html>

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.5",
+    "find-imports": "^0.5.0",
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -25,7 +25,7 @@
     "clean": "rimraf build",
     "update": "rimraf node_modules/jupyterlab && npm install",
     "build": "npm run update && npm run build:extension",
-    "build:extension": "webpack --config webpack.conf.js",
+    "build:extension": "webpack",
     "postinstall": "node ../scripts/dedupe.js",
     "test": "echo 'no tests specified'"
   },

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -21,7 +21,6 @@
     "style-loader": "^0.13.0",
     "typescript": "^1.7.5",
     "url-loader": "^0.5.7",
-    "walk-sync": "^0.3.1",
     "webpack": "^1.12.11"
   },
   "scripts": {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -19,6 +19,7 @@
     "style-loader": "^0.13.0",
     "typescript": "^1.7.5",
     "url-loader": "^0.5.7",
+    "walk-sync": "^0.3.1",
     "webpack": "^1.12.11"
   },
   "scripts": {

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "css-loader": "^0.23.1",
+    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "find-imports": "^0.5.0",
     "json-loader": "^0.5.4",

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -1,0 +1,64 @@
+
+var path = require('path');
+var fs = require('fs');
+
+/**
+ * Generate a shim for a library that does not have top level indexes.
+ *
+ * @param modName (string) - The name of the module to shim.
+ *
+ * @param sourceFolder (string) - The source folder (default is `/lib`).
+ *
+ * @returns The code for a shim module.
+ */
+function shimmer(modName, sourceFolder) {
+  var modPath = require.resolve(modName + '/package.json');
+  sourceFolder = sourceFolder || 'lib';
+  modPath = path.join(path.dirname(modPath), sourceFolder);
+  var paths = [];
+  var dirNames = [];
+
+  var walk = require('walk');
+  var walker = walk.walk(modPath);
+  var fullPath;
+  var lines = [];
+
+  walker.on("file", function (root, fileStats, next) {
+    if (path.extname(fileStats.name) !== '.js') {
+      next();
+      return;
+    }
+    fullPath = path.join(root, fileStats.name.replace('.js', ''));
+    paths.push(path.relative(modPath, fullPath));
+    next();
+  });
+
+  walker.on("directory", function (root, dirStats, next) {
+    fullPath = path.join(root, dirStats.name)
+    dirNames.push(path.relative(modPath, fullPath));
+    next();
+  });
+
+   walker.on("end", function () {
+    // Lets write the code.
+    lines.push('var ' + modName + ' = { };');
+    for (var i = 0; i < dirNames.length; i++) {
+      lines.push(modName + '["' + dirNames[i] + '"] = {};')
+    }
+    for (var i = 0; i < paths.length; i++) {
+      parts = paths[i].split('/');
+      lines.push(modName + '["' + parts[0] + '"]["' + parts[1] + '"] = require("' + path.join(modName, sourceFolder, paths[i]) + '");')
+    }
+    lines.push('module.exports = ' + modName + ';');
+    var code = lines.join('\n');
+    fs.writeFile(modName + '-shim.js', code, function(err) {
+        if (err) {
+            return console.log(err);
+        }
+        console.log("The file was saved!");
+    }); 
+  });
+}
+
+
+shimmer('phosphor');

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -25,13 +25,16 @@ function shimmer(modName, sourceFolder, regex) {
   // search for index.js file
   // if one exists, use it, otherwise use an empty object to initialize
   // then, for each, if it is a directory, recurse-and-add
-  // if it is a file that matches our regex.
+  // if it is a file that matches our regex, add it
   var lines = getLines(modName, sourceFolder, modPath, modPath, regex);
   lines.push('module.exports = ' + modName);
   return lines.join('\n');
 }
 
 
+/**
+ * Get the appropriate shim lines for the items in a folder.
+ */
 function getLines(modName, sourceFolder, basePath, currentPath, regex) {
   var lines = [];
   var entries = fs.readdirSync(currentPath);

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -8,13 +8,17 @@ var walkSync = require('walk-sync');
  *
  * @param modName (string) - The name of the module to shim.
  *
- * @param sourceFolder (string) - The source folder (default is `/lib`).
+ * @param sourceFolder (string) - The source folder.
+ *
+ * @param indexOnly (boolean) - Whether to only shim index files.
+ *  (default is False).
  *
  * @returns A promise that resolves when the file is created.
  */
-function shimmer(modName, sourceFolder) {
+function shimmer(modName, sourceFolder, indexOnly) {
   var modPath = require.resolve(modName + '/package.json');
   sourceFolder = sourceFolder || 'lib';
+  indexOnly = !!indexOnly;
   modPath = path.join(path.dirname(modPath), sourceFolder);
   var entries = walkSync.entries(modPath);
   var lines = ['var ' + modName + ' = {}'];
@@ -30,6 +34,8 @@ function shimmer(modName, sourceFolder) {
       entryPath = entryPath.replace('.js', '');
       if (path.basename(entryPath) === 'index') {
         entryPath = path.dirname(entryPath);
+      } else if (indexOnly) {
+        continue;
       }
       parts = entryPath.split('/');
       if (parts[0]) {
@@ -37,7 +43,7 @@ function shimmer(modName, sourceFolder) {
       }
     }
   }
-  lines.push('module.exports = ' + modName + ';');
+  lines.push('module.exports = ' + modName + ';')
   return lines.join('\n');
 }
 

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -1,6 +1,5 @@
 var path = require('path');
 var fs = require('fs');
-var walkSync = require('walk-sync');
 
 
 /**
@@ -11,40 +10,71 @@ var walkSync = require('walk-sync');
  * @param sourceFolder (string) - The source folder.
  *
  * @param indexOnly (boolean) - Whether to only shim index files.
- *  (default is False).
  *
  * @returns A promise that resolves when the file is created.
  */
-function shimmer(modName, sourceFolder, indexOnly) {
+function shimmer(modName, sourceFolder, regex) {
   var modPath = require.resolve(modName + '/package.json');
   sourceFolder = sourceFolder || 'lib';
-  indexOnly = !!indexOnly;
+  regex = regex || /.*\.js$/;
   modPath = path.join(path.dirname(modPath), sourceFolder);
-  var entries = walkSync.entries(modPath);
   var lines = ['var ' + modName + ' = {}'];
 
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    var basePath  = path.join(entry.basePath, entry.relativePath);
-    var entryPath = path.relative(modPath, basePath);
-    if (entry.isDirectory()) {
-      var parts = entryPath.split('/');
-      lines.push(modName + '["' + parts.join('"]["') + '"] = {};')
-    } else if (path.extname(entryPath) === '.js') {
-      entryPath = entryPath.replace('.js', '');
-      if (path.basename(entryPath) === 'index') {
-        entryPath = path.dirname(entryPath);
-      } else if (indexOnly) {
-        continue;
-      }
-      parts = entryPath.split('/');
-      if (parts[0]) {
-       lines.push(modName + '["' + parts.join('"]["') + '"] = require("' + path.join(modName, sourceFolder, entryPath) + '");');
-      }
+  var entries = fs.readdirSync(modPath);
+  // Algorithm: 
+  // search for index.js file
+  // if one exists, use it, otherwise use an empty object to initialize
+  // then, for each, if it is a directory, recurse-and-add
+  // if it is a file that matches our regex.
+  var lines = getLines(modName, sourceFolder, modPath, modPath, regex);
+  lines.push('module.exports = ' + modName);
+  return lines.join('\n');
+}
+
+
+function getLines(modName, sourceFolder, basePath, currentPath, regex) {
+  var lines = [];
+  var entries = fs.readdirSync(currentPath);
+  var relPath = path.relative(basePath, currentPath);
+  var parts = relPath.split('/');
+  var modPath = path.join(modName, sourceFolder, relPath);
+
+  // Initialize with the index file if available, else an empty object.
+  if (entries.indexOf('index.js') !== -1) {
+    if (!parts[0]) {
+      lines.push('var ' + modName + ' = require("' + modPath + '");');
+    } else {
+      lines.push(modName + '["' + parts.join('"]["') + '"] = require("' + modPath + '");');
+    }
+  } else {
+    if (!parts[0]) {
+      lines.push('var ' + modName + ' = {};');
+    } else {
+      lines.push(modName + '["' + parts.join('"]["') + '"] = {};');
     }
   }
-  lines.push('module.exports = ' + modName + ';')
-  return lines.join('\n');
+  // Otherwise, handle each file.
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    // Handle directories recursively.
+    var isDirectory = fs.statSync(path.join(currentPath, entry)).isDirectory();
+    if (isDirectory) {
+      lines = lines.concat(getLines(modName, sourceFolder, basePath, path.join(currentPath, entry), regex));
+    } else if (regex.test(entry)) {
+      // Skip index files, already taken care of.
+      if (path.basename(entry) === 'index.js') {
+        continue;
+      }
+      entry = entry.replace(path.extname(entry), '');
+      var entryParts = parts.slice();
+      entryParts.push(entry);
+      if (!entryParts[0]) { 
+        entryParts = entryParts.slice(1);
+      }
+      lines.push(modName + '["' + entryParts.join('"]["') + '"] = require("' + path.join(modPath, entry) + '");');
+    }
+  }
+  return lines;
 }
 
 

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -1,3 +1,6 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
 var path = require('path');
 var fs = require('fs');
 

--- a/jupyterlab/shim-maker.js
+++ b/jupyterlab/shim-maker.js
@@ -12,7 +12,8 @@ var fs = require('fs');
  *
  * @param sourceFolder (string) - The source folder.
  *
- * @param indexOnly (boolean) - Whether to only shim index files.
+ * @param regex - A regular expresion used to match files - the default
+ *  is all `.js` files.
  *
  * @returns A promise that resolves when the file is created.
  */
@@ -24,7 +25,7 @@ function shimmer(modName, sourceFolder, regex) {
   var lines = ['var ' + modName + ' = {}'];
 
   var entries = fs.readdirSync(modPath);
-  // Algorithm: 
+  // Algorithm:
   // search for index.js file
   // if one exists, use it, otherwise use an empty object to initialize
   // then, for each, if it is a directory, recurse-and-add
@@ -74,7 +75,7 @@ function getLines(modName, sourceFolder, basePath, currentPath, regex) {
       entry = entry.replace(path.extname(entry), '');
       var entryParts = parts.slice();
       entryParts.push(entry);
-      if (!entryParts[0]) { 
+      if (!entryParts[0]) {
         entryParts = entryParts.slice(1);
       }
       lines.push(modName + '["' + entryParts.join('"]["') + '"] = require("' + path.join(modPath, entry) + '");');

--- a/jupyterlab/webpack.conf.js
+++ b/jupyterlab/webpack.conf.js
@@ -5,7 +5,25 @@
 // See https://github.com/webpack/css-loader/issues/144
 require('es6-promise').polyfill();
 
-module.exports = {
+var helpers = require('jupyterlab/scripts/extension_helpers');
+
+var loaders = [
+  { test: /\.css$/, loader: 'style-loader!css-loader' },
+  { test: /\.json$/, loader: 'json-loader' },
+  { test: /\.html$/, loader: 'file-loader' },
+  // jquery-ui loads some images
+  { test: /\.(jpg|png|gif)$/, loader: 'file-loader' },
+  // required to load font-awesome
+  { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
+  { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
+  { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream' },
+  { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader' },
+  { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml' }
+]
+
+
+module.exports = [
+{
   entry: './index.js',
   output: {
     path: __dirname + '/build',
@@ -19,22 +37,49 @@ module.exports = {
   bail: true,
   devtool: 'source-map',
   module: {
-    loaders: [
-      { test: /\.css$/, loader: 'style-loader!css-loader' },
-      { test: /\.json$/, loader: 'json-loader' },
-      { test: /\.html$/, loader: 'file-loader' },
-      // jquery-ui loads some images
-      { test: /\.(jpg|png|gif)$/, loader: 'file-loader' },
-      // required to load font-awesome
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/font-woff' },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=application/octet-stream' },
-      { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader' },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml' }
-    ]
+    loaders: loaders
   },
-  externals: {
-    jquery: '$',
-    'jquery-ui': '$'
-  }
+  externals: helpers.DEFAULT_EXTERNALS
+},
+// Codemirror umd bundle
+{
+   entry: 'codemirror',
+   output: {
+      filename: 'codemirror.bundle.js',
+      path: './build',
+      libraryTarget: 'umd',
+      library: 'codemirror'
+   },
+   module: {
+    loaders: loaders
+   },
+   bail: true,
+   devtool: 'source-map'
+},
+// Jupyter-js-services umd bundle
+{
+    entry: 'jupyter-js-services',
+    output: {
+        filename: 'jupyter-js-services.bundle.js',
+        path: './build',
+        library: ['jupyter', 'services'],
+        libraryTarget: 'umd',
+    },
+    module: {
+      loaders: loaders
+    },
+    bail: true,
+    devtool: 'source-map'
+},
+// Phosphor umd bundle.
+{
+    entry: 'phosphor/lib',
+    output: {
+        filename: 'phosphor.bundle.js',
+        path: './build',
+        libraryTarget: 'this'
+    },
+    bail: true,
+    devtool: 'source-map'
 }
+]

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -16,12 +16,12 @@ var CodeMirrorFiles = helpers.CODEMIRROR_FILES;
 CodeMirrorFiles.push('codemirror/lib/codemirror.js');
 
 // Create the Phosphor and JupyterLab shims.
+// First make sure the build folder exists.
 try {
   fs.mkdirSync('./build')
 } catch(err) {
   // Already exists
 }
-
 fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor', 'lib'));
 var jlabShim = shimmer('jupyterlab', 'lib', /.*index\.js$/);
 fs.writeFileSync('./build/jupyterlab-shim.js', jlabShim);

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -5,7 +5,13 @@
 // See https://github.com/webpack/css-loader/issues/144
 require('es6-promise').polyfill();
 
+var fs = require('fs');
 var helpers = require('jupyterlab/scripts/extension_helpers');
+var shimmer = require('./shim-maker');
+
+// Create the phosphor and jupyterlab shims.
+fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor'));
+fs.writeFileSync('./build/jupyterlab-shim.js', shimmer('jupyterlab'));
 
 var loaders = [
   { test: /\.css$/, loader: 'style-loader!css-loader' },
@@ -72,11 +78,25 @@ module.exports = [
 },
 // Phosphor bundle
 {
-    entry: './phosphor-shim.js',
+    entry: './build/phosphor-shim.js',
     output: {
         filename: 'phosphor.bundle.js',
         path: './build',
         library: 'phosphor',
+    },
+    bail: true,
+    devtool: 'source-map'
+},
+// JupyterLab bundle
+{
+    entry: './build/jupyterlab-shim.js',
+    output: {
+        filename: 'jupyterlab.bundle.js',
+        path: './build',
+        library: ['jupyter', 'lab'],
+    },
+    module: {
+      loaders: loaders
     },
     bail: true,
     devtool: 'source-map'

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -9,7 +9,7 @@ var fs = require('fs');
 var helpers = require('jupyterlab/scripts/extension_helpers');
 var shimmer = require('./shim-maker');
 
-// Create the phosphor and jupyterlab shims.
+// Create the Phosphor and JupyterLab shims.
 fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor', 'lib'));
 var jlabShim = shimmer('jupyterlab', 'lib', true);
 fs.writeFileSync('./build/jupyterlab-shim.js', jlabShim);

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -10,8 +10,9 @@ var helpers = require('jupyterlab/scripts/extension_helpers');
 var shimmer = require('./shim-maker');
 
 // Create the phosphor and jupyterlab shims.
-fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor'));
-fs.writeFileSync('./build/jupyterlab-shim.js', shimmer('jupyterlab'));
+fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor', 'lib'));
+var jlabShim = shimmer('jupyterlab', 'lib', true);
+fs.writeFileSync('./build/jupyterlab-shim.js', jlabShim);
 
 var loaders = [
   { test: /\.css$/, loader: 'style-loader!css-loader' },

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -23,6 +23,7 @@ var loaders = [
 
 
 module.exports = [
+// Application bundle
 {
   entry: './index.js',
   output: {
@@ -41,7 +42,7 @@ module.exports = [
   },
   externals: helpers.DEFAULT_EXTERNALS
 },
-// Codemirror umd bundle
+// Codemirror bundle
 {
    entry: 'codemirror',
    output: {
@@ -55,11 +56,11 @@ module.exports = [
    bail: true,
    devtool: 'source-map'
 },
-// Jupyter-js-services umd bundle
+// Jupyter-js-services bundle
 {
     entry: 'jupyter-js-services',
     output: {
-        filename: 'jupyter-js-services.bundle.js',
+        filename: 'services.bundle.js',
         path: './build',
         library: ['jupyter', 'services'],
     },
@@ -69,9 +70,9 @@ module.exports = [
     bail: true,
     devtool: 'source-map'
 },
-// Phosphor umd bundle.
+// Phosphor bundle
 {
-    entry: 'phosphor',
+    entry: './phosphor-shim.js',
     output: {
         filename: 'phosphor.bundle.js',
         path: './build',

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -47,7 +47,6 @@ module.exports = [
    output: {
       filename: 'codemirror.bundle.js',
       path: './build',
-      libraryTarget: 'umd',
       library: 'codemirror'
    },
    module: {
@@ -63,7 +62,6 @@ module.exports = [
         filename: 'jupyter-js-services.bundle.js',
         path: './build',
         library: ['jupyter', 'services'],
-        libraryTarget: 'umd',
     },
     module: {
       loaders: loaders
@@ -73,11 +71,11 @@ module.exports = [
 },
 // Phosphor umd bundle.
 {
-    entry: 'phosphor/lib',
+    entry: 'phosphor',
     output: {
         filename: 'phosphor.bundle.js',
         path: './build',
-        libraryTarget: 'this'
+        library: 'phosphor',
     },
     bail: true,
     devtool: 'source-map'

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -20,7 +20,9 @@ CodeMirrorFiles.push('codemirror/lib/codemirror.js');
 try {
   fs.mkdirSync('./build')
 } catch(err) {
-  // Already exists
+  if (err.code !== 'EEXIST') {
+    throw e;
+  }
 }
 fs.writeFileSync('./build/phosphor-shim.js', shimmer('phosphor', 'lib'));
 var jlabShim = shimmer('jupyterlab', 'lib', /.*index\.js$/);
@@ -96,7 +98,8 @@ module.exports = [
       loaders: loaders
     },
     bail: true,
-    devtool: 'source-map'
+    devtool: 'source-map',
+    externals: helpers.phosphorExternals
 },
 // Phosphor bundle
 {

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -42,7 +42,7 @@ var loaders = [
 
 
 module.exports = [
-// Application bundle
+// Application bundles
 {
   entry: {
     'main': './index.js',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "leaflet": "^0.7.7",
     "marked": "^0.3.5",
     "moment": "^2.11.2",
-    "phosphor": "^0.6.0",
+    "phosphor": "file:../../phosphor",
     "sanitize-html": "^1.12.0",
     "semver": "^5.3.0",
     "simulate-event": "^1.2.0",
@@ -87,7 +87,8 @@
     "lib/**/*.js",
     "lib/**/*.svg",
     "lib/**/*.gif",
-    "scripts/dedupe.js"
+    "scripts/dedupe.js",
+    "scripts/extension_helpers.js"
   ],
   "author": "Project Jupyter",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "leaflet": "^0.7.7",
     "marked": "^0.3.5",
     "moment": "^2.11.2",
-    "phosphor": "file:../../phosphor",
+    "phosphor": "^0.6.1",
     "sanitize-html": "^1.12.0",
     "semver": "^5.3.0",
     "simulate-event": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "css-loader": "^0.23.1",
     "expect.js": "^0.3.1",
     "file-loader": "^0.8.5",
+    "find-imports": "^0.5.0",
     "fs-extra": "^0.26.4",
     "istanbul-instrumenter-loader": "^0.1.3",
     "json-loader": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "typedoc": "^0.4.2",
     "typescript": "^1.8.0",
     "url-loader": "^0.5.7",
+    "walk-sync": "^0.3.1",
     "watch": "^0.17.1",
     "webpack": "^1.12.11"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "typedoc": "^0.4.2",
     "typescript": "^1.8.0",
     "url-loader": "^0.5.7",
-    "walk-sync": "^0.3.1",
     "watch": "^0.17.1",
     "webpack": "^1.12.11"
   },

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -45,10 +45,16 @@ var DEFAULT_EXTERNALS = [
     function(context, request, callback) {
       // Replace this with a call to a function that handles *all*
       // permuations.
-      var regex = /^phosphor\/lib\/([a-z]+)\/([a-z]+)$/;
+      var regex = /^phosphor\/lib\/([a-z\/]+)$/;
       if(regex.test(request)) {
-          var matches = regex.exec(request)
-          var lib = 'var phosphor.' + matches[1] + '.' + matches[2];
+          var matches = regex.exec(request).slice(1);
+          var lib = 'var phosphor.' + matches.join('.');
+          return callback(null, lib);
+      }
+      regex = /^jupyterlab\/lib\/([a-z\/]+)$/;
+      if(regex.test(request)) {
+          var matches = regex.exec(request).slice(1);
+          var lib = 'var jupyter.lab.' + matches.join('.');
           return callback(null, lib);
       }
       callback();

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -54,14 +54,15 @@ var JLAB_FOLDERS = JLAB_ENTRIES.map(function (entry) {
 // The "always ignore" externals used by JupyterLab, Phosphor and friends
 var DEFAULT_EXTERNALS = [
     function(context, request, callback) {
-      // Replace this with a call to a function that handles *all*
-      // permuations.
+      // All phosphor imports get mangled to use the external bundle
       var regex = /^phosphor\/lib\/([a-z\/]+)$/;
       if(regex.test(request)) {
           var matches = regex.exec(request)[1];
           var lib = 'var phosphor.' + matches.split('/').join('.');
           return callback(null, lib);
       }
+      // Imports from JupyterLab index files get mangled to use the
+      // external bundle
       if (JLAB_FOLDERS.indexOf(request + '/') !== -1) {
         regex = /^jupyterlab\/lib\/([a-z\/]+)$/;
         var matches = regex.exec(request)[1];

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -47,14 +47,14 @@ var DEFAULT_EXTERNALS = [
       // permuations.
       var regex = /^phosphor\/lib\/([a-z\/]+)$/;
       if(regex.test(request)) {
-          var matches = regex.exec(request).slice(1);
-          var lib = 'var phosphor.' + matches.join('.');
+          var matches = regex.exec(request)[1];
+          var lib = 'var phosphor.' + matches.split('/').join('.');
           return callback(null, lib);
       }
       regex = /^jupyterlab\/lib\/([a-z\/]+)$/;
       if(regex.test(request)) {
-          var matches = regex.exec(request).slice(1);
-          var lib = 'var jupyter.lab.' + matches.join('.');
+          var matches = regex.exec(request)[1];
+          var lib = 'var jupyter.lab.' + matches.split('/').join('.');
           return callback(null, lib);
       }
       callback();

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -42,11 +42,24 @@ var path = require('path');
 
 // The "always ignore" externals used by JupyterLab, Phosphor and friends
 var DEFAULT_EXTERNALS = [
-    function(context, request, callback){
-      console.log('TODO: Phosphor external rewriter...');
+    function(context, request, callback) {
+      var regex = /phosphor\/lib\/([a-z]+)\/.*$/
+      if(regex.test(request)) {
+          var matches = regex.exec(request)
+          var lib = 'this phosphor/lib/' + matches[1];
+          return callback(null, lib);
+      }
+      callback();
     },
-    'jupyter-js-services',
-    /codemirror/
+    {
+      'jupyter-js-services': 'umd jupyter-js-services',
+      'codemirror': 'codemirror',
+      'codemirror/lib/codemirror': 'codemirror',
+      '../lib/codemirror': 'codemirror',
+      '../../lib/codemirror': 'codemirror',
+      'jquery': '$',
+      'jquery-ui': '$'
+    }
   ];
 
 
@@ -137,5 +150,6 @@ function upstream_externals(_require) {
 
 module.exports = {
   upstream_externals: upstream_externals,
-  validate_extension: validate_extension
+  validate_extension: validate_extension,
+  DEFAULT_EXTERNALS: DEFAULT_EXTERNALS
 };

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -43,6 +43,8 @@ var path = require('path');
 // The "always ignore" externals used by JupyterLab, Phosphor and friends
 var DEFAULT_EXTERNALS = [
     function(context, request, callback) {
+      // Replace this with a call to a function that handles *all*
+      // permuations.
       var regex = /^phosphor\/lib\/([a-z]+)\/([a-z]+)$/;
       if(regex.test(request)) {
           var matches = regex.exec(request)

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -43,16 +43,16 @@ var path = require('path');
 // The "always ignore" externals used by JupyterLab, Phosphor and friends
 var DEFAULT_EXTERNALS = [
     function(context, request, callback) {
-      var regex = /phosphor\/lib\/([a-z]+)\/.*$/
+      var regex = /^phosphor\/lib\/([a-z]+)\/([a-z]+)$/;
       if(regex.test(request)) {
           var matches = regex.exec(request)
-          var lib = 'this phosphor/lib/' + matches[1];
+          var lib = 'var phosphor.' + matches[1] + '.' + matches[2];
           return callback(null, lib);
       }
       callback();
     },
     {
-      'jupyter-js-services': 'umd jupyter-js-services',
+      'jupyter-js-services': 'jupyter.services',
       'codemirror': 'codemirror',
       'codemirror/lib/codemirror': 'codemirror',
       '../lib/codemirror': 'codemirror',

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -3,6 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+npm install
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -12,9 +12,5 @@ conda update -q conda
 conda info -a
 conda install jupyter
 
-# Install in-place and install the server extension
-pip install -e .
-jupyter serverextension enable --py jupyterlab
-
 # create jupyter base dir (needed for config retreival)
 mkdir ~/.jupyter

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-npm install
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
@@ -12,6 +11,10 @@ conda config --set always_yes yes --set changeps1 no
 conda update -q conda
 conda info -a
 conda install jupyter
+
+# Install in-place and install the server extension
+pip install -e .
+jupyter serverextension enable --py jupyterlab
 
 # create jupyter base dir (needed for config retreival)
 mkdir ~/.jupyter

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -7,6 +7,10 @@ set -e
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start || true
 
+# Install in-place and install the server extension
+pip install -e .
+jupyter serverextension enable --py jupyterlab
+
 npm run clean
 npm run build
 npm test

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -8,6 +8,7 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start || true
 
 # Install in-place and install the server extension
+export PATH="$HOME/miniconda/bin:$PATH"
 pip install -v -e .
 jupyter serverextension enable --py jupyterlab
 
@@ -15,7 +16,7 @@ npm run clean
 npm run build
 npm test
 npm run test:coverage
-export PATH="$HOME/miniconda/bin:$PATH"
+
 npm run build:examples
 npm run docs
 cp jupyter-plugins-demo.gif docs

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-set -e
+set -ex
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start || true
 

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -8,7 +8,7 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start || true
 
 # Install in-place and install the server extension
-pip install -e .
+pip install -v -e .
 jupyter serverextension enable --py jupyterlab
 
 npm run clean

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -7,7 +7,7 @@ set -ex
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start || true
 
-# Install in-place and install the server extension
+# Install in-place and enable the server extension
 export PATH="$HOME/miniconda/bin:$PATH"
 pip install -v -e .
 jupyter serverextension enable --py jupyterlab

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -15,3 +15,13 @@ export PATH="$HOME/miniconda/bin:$PATH"
 npm run build:examples
 npm run docs
 cp jupyter-plugins-demo.gif docs
+
+
+# Make sure we can start and kill the lab server
+jupyter lab --no-browser &
+TASK_PID=$!
+# Make sure the task is running
+ps -p $TASK_PID || exit 1
+sleep 5
+kill $TASK_PID
+wait $TASK_PID

--- a/scripts/travis_script.sh
+++ b/scripts/travis_script.sh
@@ -9,7 +9,7 @@ sh -e /etc/init.d/xvfb start || true
 
 # Install in-place and enable the server extension
 export PATH="$HOME/miniconda/bin:$PATH"
-pip install -v -e .
+pip install -v .
 jupyter serverextension enable --py jupyterlab
 
 npm run clean

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,11 @@ class bdist_egg_disabled(bdist_egg):
         sys.exit("Aborting implicit building of eggs. Use `pip install .` to install from source.")
 
 
+
+def get_target_path(target):
+    return os.path.join(here, 'jupyterlab', 'build', target)
+
+
 class NPM(Command):
     description = 'install package.json dependencies using npm'
 
@@ -84,15 +89,12 @@ class NPM(Command):
     node_modules = os.path.join(here, 'node_modules')
     jlab_node_modules = os.path.join(extension_root, 'node_modules')
 
-    targets = [
+    targets = map(get_target_path, [
         'vendor.css', 'CodeMirror.css', 'main.css',
         'phosphor.bundle.js', 'services.bundle.js',
         'vendor.bundle.js', 'CodeMirror.bundle.js',
         'main.bundle.js'
-    ]
-
-    def get_target_path(self, target):
-        return os.path.join(here, 'jupyterlab', 'build', target)
+    ])
 
     def initialize_options(self):
         pass
@@ -120,7 +122,6 @@ class NPM(Command):
         run('npm run build:serverextension')
 
         for t in self.targets:
-            t = self.get_target_path(t)
             if not os.path.exists(t):
                 msg = 'Missing file: %s' % t
                 if not has_npm:

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,14 @@ class NPM(Command):
     jlab_node_modules = os.path.join(extension_root, 'node_modules')
 
     targets = [
-        os.path.join(here, 'jupyterlab', 'build', 'bundle.js'),
+        'vendor.css', 'CodeMirror.css', 'main.css',
+        'phosphor.bundle.js', 'services.bundle.js',
+        'vendor.bundle.js', 'CodeMirror.bundle.js',
+        'main.bundle.js'
     ]
+
+    def get_target_path(self, target):
+        return os.path.join(here, 'jupyterlab', 'build', target)
 
     def initialize_options(self):
         pass
@@ -114,6 +120,7 @@ class NPM(Command):
         run('npm run build:serverextension')
 
         for t in self.targets:
+            t = self.get_target_path(t)
             if not os.path.exists(t):
                 msg = 'Missing file: %s' % t
                 if not has_npm:


### PR DESCRIPTION
JupyterLab will hold the base-level Webpack config for its externals library configuration and a script used to generate the externals for a given third party extension.

The script recursively concats the externals of the upstream jupyter lab extensions, where an extension is a dependency that has a valid ['jupyter']['lab'] config in its package.json.

A third party extension specifies its entry point in ['jupyter']['lab']['main'] and may optionally provide a custom externals configuration in ['jupyter']['lab']['externals'] if something other than the default behavior is desired.

In the cookecutter template, we provide a path to bridge lab and notebook by using the ['jupyter']['notebook'] config, which will assume an all-amd environment.

We propose using labextension to differentiate from nbextension.

The default stance for a third party library is an AMD bundle that exports its API.
Externals synchronously imported by JupyterLab itself will use script tags with accompanying SystemJS config.
Asynchronous imports in JupyterLab will use SystemJS.

The server can use the semver Python library to validate all of the extensions while populating the html template.

Open questions:

How to enable third party extensions to override a default plugin?

cf https://github.com/phosphorjs/phosphor/pull/105 (now closed in favor of shimming phosphor here as part of the WebPack build to expose all of its modules).

cf https://github.com/bollwyvl/widget-cookiecutter/tree/jupyterlab-extension for what a consumer might look like (still a wip).


This PR:
- Adds the ability to shim libraries and uses it to generate the shims for JupyterLab and Phosphor
- Creates appropriate script tags and global variables for `jupyterlab`, `phosphor`, `jupyter.services`, and `CodeMirror`
- Strips out other third party code into a separate `vendor` bundle
- Strips all CSS out into separate CSS files
- Ensures that we can `pip install` and run `jupyter lab` on Travis