### PR TITLE
Add --sys-prefix command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ From the command line:
 
 ```bash
 pip install jupyterlab
-jupyter serverextension enable --py jupyterlab
+jupyter serverextension enable --py jupyterlab --sys-prefix
 ```
 
 Start up JupyterLab:


### PR DESCRIPTION
As mentioned by @jasongrout in https://github.com/jupyter/jupyterlab/issues/312 

> When you install jupyterlab, you should enable it with --sys-prefix to make sure it stays in the environment it was installed in.

This PR simply adds that to the recommended step in the README.