### PR TITLE
sanitizable -> isSanitizable for consistency

### DIFF
--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -196,7 +196,7 @@ class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return this.mimetypes.indexOf(mimetype) !== -1;
   }
 
@@ -229,7 +229,7 @@ class ImageRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return false;
   }
 
@@ -267,7 +267,7 @@ class TextRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return false;
   }
 
@@ -306,7 +306,7 @@ class JavascriptRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return false;
   }
 
@@ -345,7 +345,7 @@ class SVGRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return this.mimetypes.indexOf(mimetype) !== -1;
   }
 
@@ -392,7 +392,7 @@ class PDFRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return false;
   }
 
@@ -432,7 +432,7 @@ class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return false;
   }
 
@@ -465,7 +465,7 @@ class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * Whether the input can safely sanitized for a given mimetype.
    */
-  sanitizable(mimetype: string): boolean {
+  isSanitizable(mimetype: string): boolean {
     return this.mimetypes.indexOf(mimetype) !== -1;
   }
 

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -115,7 +115,7 @@ class RenderMime {
     for (let m of this.order) {
       if (m in bundle) {
         let renderer = this._renderers[m];
-        if (trusted || renderer.isSafe(m) || renderer.sanitizable(m)) {
+        if (trusted || renderer.isSafe(m) || renderer.isSanitizable(m)) {
           return m;
         }
       }
@@ -231,7 +231,7 @@ namespace RenderMime {
     /**
      * Whether the input can safely sanitized for a given mimetype.
      */
-    sanitizable(mimetype: string): boolean;
+    isSanitizable(mimetype: string): boolean;
 
     /**
      * Render the transformed mime bundle.

--- a/test/src/renderers/renderers.spec.ts
+++ b/test/src/renderers/renderers.spec.ts
@@ -34,12 +34,12 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `false`', () => {
         let t = new TextRenderer();
-        expect(t.sanitizable('text/plain')).to.be(false);
-        expect(t.sanitizable('application/vnd.jupyter.console-text')).to.be(false);
+        expect(t.isSanitizable('text/plain')).to.be(false);
+        expect(t.isSanitizable('application/vnd.jupyter.console-text')).to.be(false);
       });
 
     });
@@ -95,11 +95,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `false`', () => {
         let t = new LatexRenderer();
-        expect(t.sanitizable('text/latex')).to.be(false);
+        expect(t.isSanitizable('text/latex')).to.be(false);
       });
 
     });
@@ -137,11 +137,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `false`', () => {
         let t = new PDFRenderer();
-        expect(t.sanitizable('application/pdf')).to.be(false);
+        expect(t.isSanitizable('application/pdf')).to.be(false);
       });
 
     });
@@ -180,11 +180,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `false`', () => {
         let t = new JavascriptRenderer();
-        expect(t.sanitizable('text/javascript')).to.be(false);
+        expect(t.isSanitizable('text/javascript')).to.be(false);
       });
 
     });
@@ -232,11 +232,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `true`', () => {
         let t = new SVGRenderer();
-        expect(t.sanitizable('image/svg+xml')).to.be(true);
+        expect(t.isSanitizable('image/svg+xml')).to.be(true);
       });
 
     });
@@ -284,11 +284,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `true`', () => {
         let t = new MarkdownRenderer();
-        expect(t.sanitizable('text/markdown')).to.be(true);
+        expect(t.isSanitizable('text/markdown')).to.be(true);
       });
 
     });
@@ -351,11 +351,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `true`', () => {
         let t = new HTMLRenderer();
-        expect(t.sanitizable('text/html')).to.be(true);
+        expect(t.isSanitizable('text/html')).to.be(true);
       });
 
     });
@@ -412,11 +412,11 @@ describe('renderers', () => {
 
     });
 
-    describe('#sanitizable()', () => {
+    describe('#isSanitizable()', () => {
 
       it('should be `false`', () => {
         let t = new ImageRenderer();
-        expect(t.sanitizable('image/png')).to.be(false);
+        expect(t.isSanitizable('image/png')).to.be(false);
       });
 
     });


### PR DESCRIPTION
This makes the name consistent with `isDisposed`, `isSafe`, etc.