### PR TITLE
Third Party Extensions (cont).

### DIFF
--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -12,6 +12,6 @@ require('jupyterlab/lib/default-theme/index.css');
 
 var lab = new JupyterLab();
 
-lab.registerPlugins(jupyter.plugins);
+lab.registerPlugins(jupyter.application.plugins);
 
 window.onload = function() { lab.start(); }

--- a/jupyterlab/index.js
+++ b/jupyterlab/index.js
@@ -15,3 +15,5 @@ var lab = new JupyterLab();
 lab.registerPlugins(jupyter.application.plugins);
 
 window.onload = function() { lab.start(); }
+
+module.exports = lab;

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -17,7 +17,7 @@ Distributed under the terms of the Modified BSD License.
     <script src="{{static_url("components/jquery-ui/ui/minified/jquery-ui.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
     <link href="{{static_prefix}}/vendor.css" rel="stylesheet">
     <link href="{{static_prefix}}/codemirror.css" rel="stylesheet">
-    <link href="{{static_prefix}}/lab.css" rel="stylesheet">
+    <link href="{{static_prefix}}/jupyterlab.css" rel="stylesheet">
     <link href="{{static_prefix}}/main.css" rel="stylesheet">
 </head>
 
@@ -35,7 +35,7 @@ Distributed under the terms of the Modified BSD License.
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/lab.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/plugins.bundle.js" type="text/javascript" charset="utf-8"></script>
 
 <!-- TODO: Insert third party plugins here using template -->

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -33,7 +33,7 @@ Distributed under the terms of the Modified BSD License.
 
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/jupyter-js-services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/jupyterlab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/plugins.bundle.js" type="text/javascript" charset="utf-8"></script>

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -31,8 +31,8 @@ Distributed under the terms of the Modified BSD License.
   "notebookPath": "{{notebook_path | urlencode}}"
 }</script>
 
-<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/lab.bundle.js" type="text/javascript" charset="utf-8"></script>

--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -32,9 +32,9 @@ Distributed under the terms of the Modified BSD License.
 }</script>
 
 <script src="{{static_prefix}}/codemirror.bundle.js" type="text/javascript" charset="utf-8"></script>
-<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/phosphor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/services.bundle.js" type="text/javascript" charset="utf-8"></script>
+<script src="{{static_prefix}}/vendor.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/lab.bundle.js" type="text/javascript" charset="utf-8"></script>
 <script src="{{static_prefix}}/plugins.bundle.js" type="text/javascript" charset="utf-8"></script>
 

--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -15,6 +15,7 @@
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
+    "find-imports": "^0.5.0",
     "json-loader": "^0.5.4",
     "rimraf": "^2.5.0",
     "style-loader": "^0.13.0",

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = [
     path: './build',
     filename: '[name].bundle.js',
     publicPath: './',
-    library: ['jupyter', '[name]']
+    library: ['jupyter', 'application', '[name]']
   },
   node: {
     fs: 'empty'
@@ -79,14 +79,14 @@ module.exports = [
 // JupyterLab bundles
 {
   entry: {
-    lab: './build/jupyterlab-shim.js',
+    jupyterlab: './build/jupyterlab-shim.js',
     vendor: VENDOR_FILES
   },
   output: {
-      filename: '[name].bundle.js',
+      filename: 'jupyterlab.bundle.js',
       path: './build',
       publicPath: './',
-      library: ['jupyter', '[name]']
+      library: ['jupyter', 'externals', 'jupyterlab']
   },
   module: {
     loaders: loaders

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -19,11 +19,12 @@ try {
   fs.mkdirSync('./build')
 } catch(err) {
   if (err.code !== 'EEXIST') {
-    throw e;
+    throw err;
   }
 }
 fs.writeFileSync('./build/phosphor-shim.js', helpers.createShim('phosphor'));
 fs.writeFileSync('./build/jupyterlab-shim.js', helpers.createShim('jupyterlab'));
+
 
 // The default `module.loaders` config.
 var loaders = [
@@ -96,13 +97,13 @@ module.exports = [
 // CodeMirror bundle
 {
   entry: {
-    'codemirror': helpers.CODEMIRROR_FILES
+    'codemirror': ['codemirror/lib/codemirror.css', 'codemirror']
   },
   output: {
       filename: 'codemirror.bundle.js',
       path: './build',
       publicPath: './',
-      library: ['jupyter', 'CodeMirror'],
+      library: 'CodeMirror'
   },
   module: {
     loaders: loaders

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -98,7 +98,7 @@ module.exports = [
   bail: true,
   devtool: 'source-map',
   externals: helpers.BASE_EXTERNALS.concat([
-    {  'jupyter-js-services': 'jupyter.services' } ])
+    {  'jupyter-js-services': 'jupyter.externals["jupyter-js-services"]' } ])
 },
 // CodeMirror bundle
 {
@@ -109,7 +109,7 @@ module.exports = [
       filename: '[name].bundle.js',
       path: './build',
       publicPath: './',
-      library: 'CodeMirror'
+      library: ['jupyter', 'externals', 'codemirror']
   },
   module: {
     loaders: loaders
@@ -127,7 +127,7 @@ module.exports = [
       filename: 'services.bundle.js',
       path: './build',
       publicPath: './',
-      library: ['jupyter', 'services'],
+      library: ['jupyter', 'externals', 'jupyter-js-services'],
   },
   module: {
     loaders: loaders
@@ -143,7 +143,7 @@ module.exports = [
       filename: 'phosphor.bundle.js',
       path: './build',
       publicPath: './',
-      library: ['jupyter', 'phosphor']
+      library: ['jupyter', 'externals', 'phosphor']
   },
   bail: true,
   devtool: 'source-map'

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -8,10 +8,14 @@ require('es6-promise').polyfill();
 var fs = require('fs');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var findImports = require('find-imports');
+var helpers = require('jupyterlab/scripts/extension_helpers');
 
 
 console.log('Generating config...');
-var helpers = require('jupyterlab/scripts/extension_helpers');
+
+// Get the list of vendor files.
+var VENDOR_FILES = findImports('../lib/**/*.js', { flatten: true });
 
 // Create the Phosphor and JupyterLab shims.
 // First make sure the build folder exists.
@@ -24,7 +28,6 @@ try {
 }
 fs.writeFileSync('./build/phosphor-shim.js', helpers.createShim('phosphor'));
 fs.writeFileSync('./build/jupyterlab-shim.js', helpers.createShim('jupyterlab'));
-
 
 // The default `module.loaders` config.
 var loaders = [
@@ -40,6 +43,9 @@ var loaders = [
   { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file-loader' },
   { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url-loader?limit=10000&mimetype=image/svg+xml' },
 ]
+
+
+console.log('Generating bundles...');
 
 
 // The parallel Webpack build configurations.
@@ -74,10 +80,10 @@ module.exports = [
 {
   entry: {
     lab: './build/jupyterlab-shim.js',
-    vendor: helpers.VENDOR_FILES
+    vendor: VENDOR_FILES
   },
   output: {
-      filename: 'lab.bundle.js',
+      filename: '[name].bundle.js',
       path: './build',
       publicPath: './',
       library: ['jupyter', '[name]']
@@ -86,8 +92,8 @@ module.exports = [
     loaders: loaders
   },
   plugins: [
-    new ExtractTextPlugin("[name].css"),
-    new webpack.optimize.CommonsChunkPlugin("vendor", "vendor.bundle.js")
+    new ExtractTextPlugin('[name].css'),
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
   ],
   bail: true,
   devtool: 'source-map',
@@ -100,7 +106,7 @@ module.exports = [
     'codemirror': ['codemirror/lib/codemirror.css', 'codemirror']
   },
   output: {
-      filename: 'codemirror.bundle.js',
+      filename: '[name].bundle.js',
       path: './build',
       publicPath: './',
       library: 'CodeMirror'
@@ -109,7 +115,7 @@ module.exports = [
     loaders: loaders
   },
   plugins: [
-    new ExtractTextPlugin("[name].css")
+    new ExtractTextPlugin('[name].css')
   ],
   bail: true,
   devtool: 'source-map'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "css-loader": "^0.23.1",
     "expect.js": "^0.3.1",
     "file-loader": "^0.8.5",
-    "find-imports": "^0.5.0",
     "fs-extra": "^0.26.4",
     "istanbul-instrumenter-loader": "^0.1.3",
     "json-loader": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "sanitize-html": "^1.12.0",
     "semver": "^5.3.0",
     "simulate-event": "^1.2.0",
+    "walk-sync": "^0.3.1",
     "xterm": "^1.0.0"
   },
   "devDependencies": {
@@ -45,7 +46,6 @@
     "typedoc": "^0.4.2",
     "typescript": "^1.8.0",
     "url-loader": "^0.5.7",
-    "walk-sync": "^0.3.1",
     "watch": "^0.17.1",
     "webpack": "^1.12.11"
   },

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -8,21 +8,10 @@ var walkSync = require('walk-sync');
 
 // Get the list of vendor files, with CodeMirror files being separate.
 var VENDOR_FILES = findImports('../lib/**/*.js', { flatten: true });
-var CODEMIRROR_FILES = VENDOR_FILES.filter(function(importPath) {
-  return importPath.indexOf('codemirror') !== -1;
-});
-CODEMIRROR_FILES.push('codemirror/lib/codemirror.js');
 VENDOR_FILES = VENDOR_FILES.filter(function (importPath) {
-  return (importPath.indexOf('codemirror') !== 0 &&
-          importPath.indexOf('phosphor') !== 0 &&
-          importPath.indexOf('jupyter-js-services') !== 0);
+  return (importPath.lastIndexOf('phosphor', 0) !== 0 &&
+          importPath.lastIndexOf('jupyter-js-services', 0) !== 0);
 });
-
-// Get the list of codemirror imports.
-var codemirrorPaths = CODEMIRROR_FILES.map(function(importPath) {
-  return importPath.replace('.js', '');
-});
-codeMirrorPaths = codemirrorPaths.concat(['codemirror', '../lib/codemirror', '../../lib/codemirror']);
 
 
 /**
@@ -66,7 +55,7 @@ codeMirrorPaths = codemirrorPaths.concat(['codemirror', '../lib/codemirror', '..
 /**
  * Parse a Webpack request to a module that has been shimmed.
  *
- * @params basePath (string) - The base import path with a trailing slash.
+ * @param basePath (string) - The base import path with a trailing slash.
  *
  * @param outName (string) - The name of the output variable.
  *
@@ -104,9 +93,14 @@ var BASE_EXTERNALS = [
       return callback(null, lib);
     }
 
-    // CodeMirror imports just use the external bundle.
-    if (codemirrorPaths.indexOf(request) !== -1) {
-      return callback(null, 'var jupyter.CodeMirror');
+    // CodeMirror imports use the external bundle.
+    var codeMirrorPaths = [
+      'codemirror/mode/meta',
+      'codemirror', '../lib/codemirror',  '../../lib/codemirror',
+      'codemirror/lib/codemirror.css'
+    ];
+    if (codeMirrorPaths.indexOf(request) !== -1) {
+      return callback(null, 'var CodeMirror');
     }
 
     callback();
@@ -262,6 +256,5 @@ module.exports = {
   parseShimmed: parseShimmed,
   BASE_EXTERNALS: BASE_EXTERNALS,
   DEFAULT_EXTERNALS: DEFAULT_EXTERNALS,
-  CODEMIRROR_FILES: CODEMIRROR_FILES,
   VENDOR_FILES: VENDOR_FILES
 };

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -2,16 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 var path = require('path');
-var findImports = require('find-imports');
 var walkSync = require('walk-sync');
-
-
-// Get the list of vendor files, with CodeMirror files being separate.
-var VENDOR_FILES = findImports('../lib/**/*.js', { flatten: true });
-VENDOR_FILES = VENDOR_FILES.filter(function (importPath) {
-  return (importPath.lastIndexOf('phosphor', 0) !== 0 &&
-          importPath.lastIndexOf('jupyter-js-services', 0) !== 0);
-});
 
 
 /**
@@ -87,13 +78,13 @@ var BASE_EXTERNALS = [
     'jquery-ui': '$'
   },
   function(context, request, callback) {
-    // All phosphor imports get mangled to use the external bundle.
+    // All phosphor imports get mangled to use an external bundle.
     lib = parseShimmed('phosphor/lib/', 'jupyter.phosphor', request);
     if (lib) {
       return callback(null, lib);
     }
 
-    // CodeMirror imports use the external bundle.
+    // CodeMirror imports get mangled to use an external bundle.
     var codeMirrorPaths = [
       'codemirror/mode/meta',
       'codemirror', '../lib/codemirror',  '../../lib/codemirror',
@@ -117,7 +108,7 @@ var DEFAULT_EXTERNALS = BASE_EXTERNALS.concat([
     'jupyter-js-services': 'jupyter.services',
   },
   function(context, request, callback) {
-    // JupyterLab imports get mangled to use the external bundle.
+    // JupyterLab imports get mangled to use an external bundle.
     var lib = parseShimmed('jupyterlab/lib/', 'jupyter.lab', request);
     if (lib) {
       return callback(null, lib);
@@ -256,5 +247,4 @@ module.exports = {
   parseShimmed: parseShimmed,
   BASE_EXTERNALS: BASE_EXTERNALS,
   DEFAULT_EXTERNALS: DEFAULT_EXTERNALS,
-  VENDOR_FILES: VENDOR_FILES
 };

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -79,7 +79,7 @@ var BASE_EXTERNALS = [
   },
   function(context, request, callback) {
     // All phosphor imports get mangled to use an external bundle.
-    lib = parseShimmed('phosphor/lib/', 'jupyter.phosphor', request);
+    var lib = parseShimmed('phosphor/lib/', 'jupyter.externals["phosphor"]', request);
     if (lib) {
       return callback(null, lib);
     }
@@ -91,7 +91,7 @@ var BASE_EXTERNALS = [
       'codemirror/lib/codemirror.css'
     ];
     if (codeMirrorPaths.indexOf(request) !== -1) {
-      return callback(null, 'var CodeMirror');
+      return callback(null, 'var jupyter.externals.codemirror');
     }
 
     callback();
@@ -105,7 +105,7 @@ var BASE_EXTERNALS = [
  */
 var DEFAULT_EXTERNALS = BASE_EXTERNALS.concat([
   {
-    'jupyter-js-services': 'jupyter.services',
+    'jupyter-js-services': 'jupyter.externals["jupyter-js-services"]',
   },
   function(context, request, callback) {
     // JupyterLab imports get mangled to use an external bundle.
@@ -130,7 +130,7 @@ var DEFAULT_EXTERNALS = BASE_EXTERNALS.concat([
 function createShim(modName, sourceFolder) {
   var dirs = [];
   var files = [];
-  var lines = ['var ' + modName + ' = {};'];
+  var lines = ['var shim = {};'];
 
   // Find the path to the module.
   var modPath = require.resolve(modName + '/package.json');
@@ -146,9 +146,9 @@ function createShim(modName, sourceFolder) {
     // Get the relative path to the entry.
     var entryPath = entries[i].relativePath;
     // Add an entries for each file.
-    lines.push(modName + '["' + entryPath + '"] = require("' + path.join(modName, sourceFolder, entryPath) + '");');
+    lines.push('shim["' + entryPath + '"] = require("' + path.join(modName, sourceFolder, entryPath) + '");');
   }
-  lines.push('module.exports = ' + modName + ';');
+  lines.push('module.exports = shim;');
 
   return lines.join('\n');
 }

--- a/scripts/extension_helpers.js
+++ b/scripts/extension_helpers.js
@@ -109,7 +109,7 @@ var DEFAULT_EXTERNALS = BASE_EXTERNALS.concat([
   },
   function(context, request, callback) {
     // JupyterLab imports get mangled to use an external bundle.
-    var lib = parseShimmed('jupyterlab/lib/', 'jupyter.lab', request);
+    var lib = parseShimmed('jupyterlab/lib/', 'jupyter.externals.jupyterlab', request);
     if (lib) {
       return callback(null, lib);
     }

--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,8 @@ class NPM(Command):
 
     # Representative files that should exist after a successful build
     targets = [
-        os.path.join(here, 'jupyterlab', 'build', 'lab.css'),
-        os.path.join(here, 'jupyterlab', 'build', 'lab.bundle.js'),
+        os.path.join(here, 'jupyterlab', 'build', 'jupyterlab.css'),
+        os.path.join(here, 'jupyterlab', 'build', 'jupyterlab.bundle.js'),
     ]
 
     def initialize_options(self):


### PR DESCRIPTION
Continues #687  cf #224

Fix handling of CodeMirror and some cleanup.  The CodeMirror bundle itself now only contains the base `CodeMirror`.  The rest of the things using CodeMirror are in the vendor bundle, but using the global instance.

External libs are added to `jupyter.externals[packageName]`, including `jupyterlab` itself.