### PR TITLE
Fix race condition when adding a cell to an empty notebook model

### DIFF
--- a/src/notebook/notebook/model.ts
+++ b/src/notebook/notebook/model.ts
@@ -433,7 +433,13 @@ class NotebookModel extends DocumentModel implements INotebookModel {
     }
     // Add code cell if there are no cells remaining.
     if (!this._cells.length) {
-      this._cells.add(this._factory.createCodeCell());
+      // Add the cell in a new context to avoid triggering another
+      // cell changed event during the handling of this signal.
+      requestAnimationFrame(() => {
+        if (!this._cells.length) {
+          this._cells.add(this._factory.createCodeCell());
+        }
+      });
     }
     this.contentChanged.emit(void 0);
     this.dirty = true;

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -264,13 +264,17 @@ describe('notebook/notebook/actions', () => {
         expect(widget.activeCellIndex).to.be(widget.childCount() - 1);
       });
 
-      it('should add a code cell if all cells are deleted', () => {
+      it('should add a code cell if all cells are deleted', (done) => {
         for (let i = 0; i < widget.childCount(); i++) {
           widget.select(widget.childAt(i));
         }
         NotebookActions.deleteCells(widget);
-        expect(widget.childCount()).to.be(1);
-        expect(widget.activeCell).to.be.a(CodeCellWidget);
+        requestAnimationFrame(() => {
+          expect(widget.childCount()).to.be(1);
+          expect(widget.activeCell).to.be.a(CodeCellWidget);
+          done();
+        });
+
       });
 
       it('should be undo-able', () => {

--- a/test/src/notebook/notebook/model.spec.ts
+++ b/test/src/notebook/notebook/model.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../utils';
 
 
-describe('notebook/notebook', () => {
+describe('notebook/notebook/model', () => {
 
   describe('NotebookModel', () => {
 
@@ -150,11 +150,14 @@ describe('notebook/notebook', () => {
           expect(cell.isDisposed).to.be(true);
         });
 
-        it('should add a new code cell when cells are cleared', () => {
+        it('should add a new code cell when cells are cleared', (done) => {
           let model = new NotebookModel();
           model.cells.clear();
-          expect(model.cells.length).to.be(1);
-          expect(model.cells.get(0)).to.be.a(CodeCellModel);
+          requestAnimationFrame(() => {
+            expect(model.cells.length).to.be(1);
+            expect(model.cells.get(0)).to.be.a(CodeCellModel);
+            done();
+          });
         });
 
       });

--- a/test/src/notebook/notebook/widget.spec.ts
+++ b/test/src/notebook/notebook/widget.spec.ts
@@ -284,11 +284,14 @@ describe('notebook/notebook/widget', () => {
           widget.dispose();
         });
 
-        it('should handle changes to the model cell list', () => {
+        it('should handle changes to the model cell list', (done) => {
           widget = createWidget();
           widget.model.cells.clear();
           // The model should add a single code cell.
-          expect(widget.childCount()).to.be(1);
+          requestAnimationFrame(() => {
+            expect(widget.childCount()).to.be(1);
+            done();
+          });
         });
 
         it('should handle a remove', () => {


### PR DESCRIPTION
Fixes #652.

I used `requestAnimationFrame` because having at least one cell is a user-facing issue and not programmatically required.