### PR TITLE
Use local jquery

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -13,8 +13,6 @@ Distributed under the terms of the Modified BSD License.
     {% if mathjax_url %}
     <script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&amp;delayStartupUntil=configured" charset="utf-8"></script>
     {% endif %}
-    <script src="{{static_url("components/jquery/jquery.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- window.$ -->
-    <script src="{{static_url("components/jquery-ui/ui/minified/jquery-ui.min.js") }}" type="text/javascript" charset="utf-8"></script> <!-- extends window.$ -->
     <link href="{{static_prefix}}/vendor.css" rel="stylesheet">
     <link href="{{static_prefix}}/jupyterlab.css" rel="stylesheet">
 </head>

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -55,9 +55,5 @@ module.exports = {
   plugins: [
     new ExtractTextPlugin('[name].css'),
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.bundle.js')
-  ],
-  externals: {
-    jquery: '$',
-    'jquery-ui': '$'
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "diff-match-patch": "^1.0.0",
     "es6-promise": "^3.2.1",
     "jquery": "^2.2.0",
-    "jquery-ui": "^1.10.5 <1.12",
     "jupyter-js-services": "^0.18.0",
     "leaflet": "^0.7.7",
     "less": "^2.7.1",


### PR DESCRIPTION
Uses the local `jquery` instead of the one in `jupyter/notebook`, because they are not guaranteed to be compatible.  `jquery-ui` is no longer needed.