### PR TITLE
Open console in current working directory.

### DIFF
--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -144,10 +144,11 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
         count++;
         let file = `console-${count}`;
         let path = `${pathTracker.path}/${file}.${FILE_EXTENSION}`;
+        let cwd = pathTracker.path;
         let label = `Console ${count}`;
         let kernelName = `${displayNameMap[displayName]}`;
         let captionOptions: Private.ICaptionOptions = {
-          label, path, displayName,
+          label, cwd, displayName,
           opened: new Date()
         };
         manager.startNew({ path, kernelName }).then(session => {
@@ -286,9 +287,9 @@ namespace Private {
     executed?: Date;
 
     /**
-     * The path of the console file on the server.
+     * The current working directory that the console was opened in.
      */
-    path: string;
+    cwd: string;
 
     /**
      * The label of the console (as displayed in tabs).
@@ -306,10 +307,10 @@ namespace Private {
    */
   export
   function caption(options: ICaptionOptions): string {
-    let { label, path, displayName, opened, executed } = options;
+    let { label, cwd, displayName, opened, executed } = options;
     let caption = (
       `Name: ${label}\n` +
-      `Path: ${path}\n` +
+      `Directory: ${cwd || '/'}\n` +
       `Kernel: ${displayName}\n` +
       `Opened: ${dateTime(opened.toISOString())}`
     );

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -164,6 +164,10 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
           panel.title.closable = true;
           app.shell.addToMainArea(panel);
           tracker.add(panel);
+          panel.content.executed.connect((sender, executed) => {
+            captionOptions.executed = executed;
+            panel.title.caption = Private.caption(captionOptions);
+          });
         });
       }
     });

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -6,7 +6,7 @@ import {
 } from 'jupyter-js-services';
 
 import {
-  clearSignalData
+  clearSignalData, defineSignal, ISignal
 } from 'phosphor/lib/core/signaling';
 
 import {
@@ -147,6 +147,12 @@ class ConsoleWidget extends Widget {
   }
 
   /**
+   * A signal emitted when the console executes its prompt.
+   */
+  executed: ISignal<ConsoleWidget, Date>;
+
+
+  /**
    * Get the inspection handler used by the console.
    *
    * #### Notes
@@ -214,6 +220,7 @@ class ConsoleWidget extends Widget {
     this.newPrompt();
     return prompt.execute(this._session.kernel).then(
       (value: KernelMessage.IExecuteReplyMsg) => {
+        this.executed.emit(new Date());
         if (!value) {
           this._inspectionHandler.handleExecuteReply(null);
           return;
@@ -372,6 +379,11 @@ class ConsoleWidget extends Widget {
   private _history: IConsoleHistory = null;
   private _session: ISession = null;
 }
+
+
+// Define the signals for the `ConsoleWidget` class.
+defineSignal(ConsoleWidget.prototype, 'executed');
+
 
 /**
  * A namespace for ConsoleWidget statics.


### PR DESCRIPTION
- [x] Open console in current working directory.
- [x] Add an `executed` signal to the console widget to emit time of last prompt execution.
- [x] Add rich caption for console tabs. 

cf. https://github.com/jupyter/jupyterlab/issues/483

![cwd](https://cloud.githubusercontent.com/assets/159529/17955486/7de0c6d6-6a7a-11e6-849a-b24f3061c01d.gif)
