### PR TITLE
Replace our use of main with directories config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "jupyterlab",
   "version": "0.2.0",
   "description": "A computational environment for Jupyter.",
-  "main": "lib/index.js",
+  "directories": {
+    "lib": "lib/"
+  },
   "typings": "lib/index.d.ts",
   "dependencies": {
     "ansi_up": "^1.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,0 @@
-// Copyright (c) Jupyter Development Team.
-// Distributed under the terms of the Modified BSD License.
-


### PR DESCRIPTION
Used to "Tell people where the bulk of your library is. Nothing special is done with the lib folder in any way, but it's useful meta info."
https://docs.npmjs.com/files/package.json#directorieslib

This signifies the location of our public API and removes the implication that our `index.js` file has the entire API.

cf #728
cf https://github.com/jupyter/jupyterlab/issues/224#issuecomment-241551346
cf https://github.com/phosphorjs/phosphor/pull/136
