### PR TITLE
CSS workaround for sidebars on Safari

### DIFF
--- a/src/basestyle/application.less
+++ b/src/basestyle/application.less
@@ -96,6 +96,12 @@ body {
   transform-origin: 0 0 0;
 }
 
+.jp-SideBar .p-TabBar-content {
+  // workaround needed for Safari 9 stable to avoid
+  // incorrect shrink of sidebars.
+  // Tech Preview 9.1.2 is known to not need this workaround.
+  min-width: 100vh;
+}
 
 .jp-SideBar.jp-mod-left .p-TabBar-content {
   flex-direction: row-reverse;


### PR DESCRIPTION
**Disclaimer**: I'm not necessarily proposing that we do this, though it does appear to look right on all browsers. It may be useful just to have as a reference workaround for people.

Safari's flexbox bug appears to miscalculate the stretch window for the side bars, causing the contents of the vertical bars to be shrunk to the point of the content of items being invisible.

From the resulting size, it's possible that it's using the pre-rotate-90º width instead of the vertical 'width'. It could also be coming up with zero, which I've seen Firefox do in a number of circumstances. Not sure.

Setting a minimum width (height) works around this miscalculation, but is probably not the right thing to do in the long run.

Safari Tech Preview, due for release this Fall, does not need any workaround so we could wait for that instead of introducing this workaround.

cf #749