### PR TITLE
Allow enter for execution in the console

### DIFF
--- a/src/console/codemirror/widget.ts
+++ b/src/console/codemirror/widget.ts
@@ -10,6 +10,10 @@ import {
 } from '../../notebook/cells/widget';
 
 import {
+  CodeMirrorCodeCellWidgetRenderer
+} from '../../notebook/codemirror/cells/widget';
+
+import {
   CodeMirrorNotebookRenderer
 } from '../../notebook/codemirror/notebook/widget';
 
@@ -44,7 +48,7 @@ class CodeMirrorConsoleRenderer implements ConsoleWidget.IRenderer {
   createPrompt(rendermime: RenderMime): CodeCellWidget {
     let widget = new CodeCellWidget({
       rendermime,
-      renderer: CodeMirrorNotebookRenderer.defaultCodeCellRenderer
+      renderer: CodeMirrorConsoleRenderer.defaultCodeCellRenderer
     });
     widget.model = new CodeCellModel();
     return widget;
@@ -62,4 +66,16 @@ namespace CodeMirrorConsoleRenderer {
    */
   export
   const defaultRenderer = new CodeMirrorConsoleRenderer();
+
+
+  /**
+   * A default code mirror renderer for a code cell editor.
+   */
+  export
+  const defaultCodeCellRenderer = new CodeMirrorCodeCellWidgetRenderer({
+    editorInitializer: (editor) => {
+      editor.editor.setOption('matchBrackets', false);
+      editor.editor.setOption('autoCloseBrackets', false);
+    }
+  });
 }

--- a/src/console/codemirror/widget.ts
+++ b/src/console/codemirror/widget.ts
@@ -76,6 +76,9 @@ namespace CodeMirrorConsoleRenderer {
     editorInitializer: (editor) => {
       editor.editor.setOption('matchBrackets', false);
       editor.editor.setOption('autoCloseBrackets', false);
+      editor.editor.setOption('extraKeys', {
+        Enter: function() { /* no-op */ }
+      });
     }
   });
 }

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -206,6 +206,30 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   menu.addItem({ command });
 
 
+  command = 'console:execute-forced';
+  commands.addCommand(command, {
+    label: 'Execute Cell (forced)',
+    execute: () => {
+      if (tracker.currentWidget) {
+        tracker.currentWidget.content.execute(true);
+      }
+    }
+  });
+  palette.addItem({ command, category });
+  menu.addItem({ command });
+
+  command = 'console:linebreak';
+  commands.addCommand(command, {
+    label: 'Insert Line Break',
+    execute: () => {
+      if (tracker.currentWidget) {
+        tracker.currentWidget.content.insertLinebreak();
+      }
+    }
+  });
+  palette.addItem({ command, category });
+  menu.addItem({ command });
+
   command = 'console:interrupt-kernel';
   commands.addCommand(command, {
     label: 'Interrupt Kernel',

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -222,7 +222,7 @@ class ConsoleWidget extends Widget {
       return this._execute();
     }
 
-    // Check whether we should execute
+    // Check whether we should execute.
     return this._shouldExecute().then(value => {
       if (value) {
         return this._execute();
@@ -361,7 +361,7 @@ class ConsoleWidget extends Widget {
     let code = prompt.model.source;
     code = code.slice(0, code.lastIndexOf('\n'));
     return new Promise<boolean>((resolve, reject) => {
-      // Allow 250 ms for the response
+      // Allow 250 ms for the response.
       let timer = setTimeout(() => {
         resolve(true);
       }, 250);

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -359,7 +359,6 @@ class ConsoleWidget extends Widget {
   private _shouldExecute(): Promise<boolean> {
     let prompt = this.prompt;
     let code = prompt.model.source;
-    code = code.slice(0, code.lastIndexOf('\n'));
     return new Promise<boolean>((resolve, reject) => {
       // Allow 250 ms for the response.
       let timer = setTimeout(() => {

--- a/src/console/widget.ts
+++ b/src/console/widget.ts
@@ -358,7 +358,7 @@ class ConsoleWidget extends Widget {
    */
   private _shouldExecute(): Promise<boolean> {
     let prompt = this.prompt;
-    let code = prompt.model.source;
+    let code = prompt.model.source + '\n';
     return new Promise<boolean>((resolve, reject) => {
       // Allow 250 ms for the response.
       let timer = setTimeout(() => {
@@ -367,7 +367,7 @@ class ConsoleWidget extends Widget {
       this._session.kernel.isComplete({ code }).then(isComplete => {
         clearTimeout(timer);
         if (isComplete.content.status === 'incomplete') {
-          prompt.model.source = code + '\n' + isComplete.content.indent;
+          prompt.model.source = code + isComplete.content.indent;
           prompt.editor.setCursorPosition(prompt.model.source.length);
           resolve(false);
         } else {

--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -253,7 +253,7 @@ const SHORTCUTS = [
   {
     command: 'console:execute',
     selector: '.jp-ConsolePanel',
-    keys: ['Shift Enter']
+    keys: ['Enter']
   },
   {
     command: 'console:dismiss-completion',

--- a/src/shortcuts/plugin.ts
+++ b/src/shortcuts/plugin.ts
@@ -256,6 +256,16 @@ const SHORTCUTS = [
     keys: ['Enter']
   },
   {
+    command: 'console:execute-forced',
+    selector: '.jp-ConsolePanel',
+    keys: ['Shift Enter']
+  },
+  {
+    command: 'console:linebreak',
+    selector: '.jp-ConsolePanel',
+    keys: ['Ctrl Enter']
+  },
+  {
     command: 'console:dismiss-completion',
     selector: '.jp-ConsolePanel',
     keys: ['Escape']


### PR DESCRIPTION
Fixes #789.

Mimics the behavior of the QtConsole: 
- Enter uses `is_complete` to determine whether to execute.  If the message is not implemented by the kernel or takes longer than 0.25, execute.
- Shift+Enter forces an execute
- Ctrl+Enter forces a line break

![console-enter](https://cloud.githubusercontent.com/assets/2096628/18053655/2d6134da-6dc6-11e6-8309-aae152ef3cc7.gif)
