### PR TITLE
Fix broken console example.

### DIFF
--- a/examples/console/index.css
+++ b/examples/console/index.css
@@ -4,6 +4,7 @@
 | Distributed under the terms of the Modified BSD License.
 |----------------------------------------------------------------------------*/
 body {
+  background: white;
   margin: 0;
   padding: 0;
   font-family: sans-serif;

--- a/examples/console/index.html
+++ b/examples/console/index.html
@@ -6,7 +6,6 @@
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML-full,Safe&amp;delayStartupUntil=configured"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
-    <link href="index.css" rel="stylesheet">
   </head>
   <body>
     <script id='jupyter-config-data' type="application/json">{ "baseUrl": "{{base_url}}" }</script>

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -48,6 +48,7 @@ import {
 
 import 'jupyterlab/lib/basestyle/index.css';
 import 'jupyterlab/lib/default-theme/index.css';
+import '../index.css';
 
 let TITLE = 'Console';
 

--- a/examples/console/src/index.ts
+++ b/examples/console/src/index.ts
@@ -6,6 +6,10 @@ import {
 } from 'jupyterlab/lib/console';
 
 import {
+  CodeMirrorConsoleRenderer
+} from 'jupyterlab/lib/console/codemirror/widget';
+
+import {
   startNewSession, findSessionByPath, connectToSession, ISession
 } from 'jupyter-js-services';
 
@@ -103,8 +107,9 @@ function startApp(session: ISession) {
   }
   let sanitizer = defaultSanitizer;
   let rendermime = new RenderMime({ renderers, order, sanitizer });
+  let renderer = CodeMirrorConsoleRenderer.defaultRenderer;
 
-  let consolePanel = new ConsolePanel({ session, rendermime });
+  let consolePanel = new ConsolePanel({ session, renderer, rendermime });
   consolePanel.title.label = TITLE;
 
   let palette = new CommandPalette({ commands, keymap });

--- a/src/console/panel.ts
+++ b/src/console/panel.ts
@@ -155,7 +155,7 @@ namespace ConsolePanel {
     /**
      * The renderer for a console widget.
      */
-    renderer?: ConsoleWidget.IRenderer;
+    renderer: ConsoleWidget.IRenderer;
 
     /**
      * The session for the console panel.


### PR DESCRIPTION
- [x] Make `renderer` required in `ConsolePanel.IOptions`.
- [x] Use `defaultRenderer` in console example.
- [x] Use correct CSS style priority in console example.