### PR TITLE
Terminal fixes

### DIFF
--- a/examples/terminal/index.html
+++ b/examples/terminal/index.html
@@ -5,7 +5,6 @@
     <link href="http://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
     <script type="text/javascript" src="https://www.promisejs.org/polyfills/promise-6.1.0.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.2.0/require.js"></script>
-    <link href="index.css" rel="stylesheet">
   </head>
   <body>
     <script id='jupyter-config-data' type="application/json">{ "baseUrl": "{{base_url}}" }</script>

--- a/examples/terminal/package.json
+++ b/examples/terminal/package.json
@@ -12,7 +12,7 @@
     "jupyter-js-services": "^0.18.0",
     "jupyterlab": "file:../..",
     "phosphor": "^0.6.0",
-    "xterm": "^1.0.0"
+    "xterm": "^1.1.3"
   },
   "devDependencies": {
     "css-loader": "^0.23.1",

--- a/examples/terminal/src/index.ts
+++ b/examples/terminal/src/index.ts
@@ -19,20 +19,21 @@ import {
 
 import 'jupyterlab/lib/basestyle/index.css';
 import 'jupyterlab/lib/default-theme/index.css';
+import '../index.css';
 
 
 function main(): void {
-  let term1 = new TerminalWidget({ background: 'black',
-                                  color: 'white'});
-  let term2 = new TerminalWidget({ background: 'white',
-                                  color: 'black'});
+  let term1 = new TerminalWidget({
+    background: 'black',
+    color: 'white'
+  });
+  let term2 = new TerminalWidget({
+    background: 'white',
+    color: 'black'
+  });
 
-  createTerminalSession().then(session => {
-    term1.session = session;
-  });
-  createTerminalSession().then(session => {
-    term2.session = session;
-  });
+  createTerminalSession().then(session => term1.session = session);
+  createTerminalSession().then(session => term2.session = session);
 
   term1.title.closable = true;
   term2.title.closable = true;

--- a/src/default-theme/terminal.less
+++ b/src/default-theme/terminal.less
@@ -11,7 +11,6 @@
   min-height: 200px;
   padding: 8px;
   margin: 0;
-  background: red;
 }
 
 

--- a/src/terminal/index.ts
+++ b/src/terminal/index.ts
@@ -248,12 +248,30 @@ class TerminalWidget extends Widget {
    */
   protected onUpdateRequest(msg: Message): void {
     // Set the fg and bg colors of the terminal and cursor.
-    this.node.style.backgroundColor = this.background;
-    this.node.style.color = this.color;
-    this._term.element.style.backgroundColor = this.background;
-    this._term.element.style.color = this.color;
-    this._sheet.innerHTML = (`#${this.node.id} .terminal-cursor {background:
-                             ${this.color};color:${this.background};}`);
+    const style = (`
+      #${this.node.id} {
+        background: ${this.background};
+        color: ${this.color};
+      }
+      #${this.node.id} .xterm-viewport, #${this.node.id} .xterm-rows {
+        background-color: ${this.background};
+        color: ${this.color};
+      }
+      #${this.node.id} .terminal.focus .terminal-cursor.blinking {
+          animation: ${this.node.id}-blink-cursor 1.2s infinite step-end;
+      }
+      @keyframes ${this.node.id}-blink-cursor {
+          0% {
+              background-color: ${this.color};
+              color: ${this.background};
+          }
+          50% {
+              background-color: transparent;
+              color: ${this.color};
+          }
+      }
+    `);
+    this._sheet.innerHTML = style;
   }
 
   /**


### PR DESCRIPTION
- [x] Remove superfluous style in terminal `.less` file.
- [x] Update example version of xterm.js.
- [x] Dynamically populate the xterm instance stylesheet to account for background color, foreground color, and blinking cursor. (This fixes rendering bug with background/foreground not rendering properly.)
- [x] Clean up terminal example.