### PR TITLE
Terminal Scroll Bar is set to auto

### DIFF
--- a/src/default-theme/terminal.less
+++ b/src/default-theme/terminal.less
@@ -21,9 +21,11 @@
   -webkit-user-select: text;
 }
 
+
 .terminal {
   font-family: monospace;
 }
+
 
 .terminal .xterm-viewport {
   overflow-y: auto;

--- a/src/default-theme/terminal.less
+++ b/src/default-theme/terminal.less
@@ -26,5 +26,5 @@
 }
 
 .terminal .xterm-viewport {
-  overflow-y: hidden;
+  overflow-y: auto;
 }

--- a/src/default-theme/terminal.less
+++ b/src/default-theme/terminal.less
@@ -24,3 +24,7 @@
 .terminal {
   font-family: monospace;
 }
+
+.terminal .xterm-viewport {
+  overflow-y: hidden;
+}


### PR DESCRIPTION
The `xterm-viewport` was setting `overflow-y` to `scroll` causing scroll bars to appear. Now they are set back to `auto`.

Closes: #801 

Before:
![screen shot 2016-08-29 at 10 48 17 am](https://cloud.githubusercontent.com/assets/16314651/18061068/20c6d1b6-6dd6-11e6-9c9b-84aac0e40c91.png)


After:
![screen shot 2016-08-29 at 10 46 51 am](https://cloud.githubusercontent.com/assets/16314651/18061018/ee7b081c-6dd5-11e6-8093-bd0495d860c1.png)
