### PR TITLE
Add cell move actions

### DIFF
--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -249,6 +249,52 @@ namespace NotebookActions {
   }
 
   /**
+   * Move the selected cell(s) down.
+   *
+   * @param widget = The target notebook widget.
+   */
+  export
+  function moveDown(widget: Notebook): void {
+    if (!widget.model || !widget.activeCell) {
+      return;
+    }
+    let cells = widget.model.cells;
+    cells.beginCompoundOperation();
+    for (let i = cells.length - 2; i > 0; i--) {
+      if (widget.isSelected(widget.childAt(i))) {
+        if (!widget.isSelected(widget.childAt(i + 1))) {
+          cells.move(i, i + 1);
+          widget.select(widget.childAt(i + 1));
+        }
+      }
+    }
+    cells.endCompoundOperation();
+  }
+
+  /**
+   * Move the selected cell(s) up.
+   *
+   * @param widget - The target notebook widget.
+   */
+  export
+  function moveUp(widget: Notebook): void {
+    if (!widget.model || !widget.activeCell) {
+      return;
+    }
+    let cells = widget.model.cells;
+    cells.beginCompoundOperation();
+    for (let i = 1; i < cells.length; i++) {
+      if (widget.isSelected(widget.childAt(i))) {
+        if (!widget.isSelected(widget.childAt(i - 1))) {
+          cells.move(i, i - 1);
+          widget.select(widget.childAt(i - 1));
+        }
+      }
+    }
+    cells.endCompoundOperation();
+  }
+
+  /**
    * Change the selected cell type(s).
    *
    * @param widget - The target notebook widget.

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -260,11 +260,15 @@ namespace NotebookActions {
     }
     let cells = widget.model.cells;
     cells.beginCompoundOperation();
-    for (let i = cells.length - 2; i > 0; i--) {
+    for (let i = cells.length - 2; i > -1; i--) {
       if (widget.isSelected(widget.childAt(i))) {
         if (!widget.isSelected(widget.childAt(i + 1))) {
           cells.move(i, i + 1);
+          if (widget.activeCellIndex === i) {
+            widget.activeCellIndex++;
+          }
           widget.select(widget.childAt(i + 1));
+          widget.deselect(widget.childAt(i));
         }
       }
     }
@@ -287,7 +291,11 @@ namespace NotebookActions {
       if (widget.isSelected(widget.childAt(i))) {
         if (!widget.isSelected(widget.childAt(i - 1))) {
           cells.move(i, i - 1);
+          if (widget.activeCellIndex === i) {
+            widget.activeCellIndex--;
+          }
           widget.select(widget.childAt(i - 1));
+          widget.deselect(widget.childAt(i));
         }
       }
     }
@@ -726,6 +734,7 @@ namespace NotebookActions {
     }
     widget.mode = 'command';
     widget.model.cells.undo();
+    Private.deselectCells(widget);
   }
 
   /**
@@ -743,6 +752,7 @@ namespace NotebookActions {
     }
     widget.mode = 'command';
     widget.model.cells.redo();
+    Private.deselectCells(widget);
   }
 
   /**
@@ -881,6 +891,8 @@ namespace Private {
       let child = widget.childAt(i);
       widget.deselect(child);
     }
+    // Make sure we have a valid active cell.
+    widget.activeCellIndex = widget.activeCellIndex;
   }
 
   /**

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -78,6 +78,8 @@ const cmdIds = {
   cut: 'notebook-cells:cut',
   copy: 'notebook-cells:copy',
   paste: 'notebook-cells:paste',
+  moveUp: 'notebook-cells:move-up',
+  moveDown: 'notebook-cells:move-down',
   clearOutputs: 'notebook-cells:clear-output',
   deleteCell: 'notebook-cells:delete',
   insertAbove: 'notebook-cells:insert-above',
@@ -428,6 +430,24 @@ function addCommands(app: JupyterLab, tracker: INotebookTracker): void {
       }
     }
   });
+  commands.addCommand(cmdIds.moveUp, {
+    label: 'Move Cell(s) Up',
+    execute: () => {
+      if (tracker.currentWidget) {
+        let nbWidget = tracker.currentWidget;
+        NotebookActions.moveUp(nbWidget.content);
+      }
+    }
+  });
+  commands.addCommand(cmdIds.moveDown, {
+    label: 'Move Cell(s) Down',
+    execute: () => {
+      if (tracker.currentWidget) {
+        let nbWidget = tracker.currentWidget;
+        NotebookActions.moveDown(nbWidget.content);
+      }
+    }
+  });
   commands.addCommand(cmdIds.toggleLines, {
     label: 'Toggle Line Numbers',
     execute: () => {
@@ -576,6 +596,8 @@ function populatePalette(palette: ICommandPalette): void {
     cmdIds.selectBelow,
     cmdIds.extendAbove,
     cmdIds.extendBelow,
+    cmdIds.moveDown,
+    cmdIds.moveUp,
     cmdIds.toggleLines,
     cmdIds.undo,
     cmdIds.redo,

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -970,6 +970,74 @@ describe('notebook/notebook/actions', () => {
 
     });
 
+    describe('#moveUp()', () => {
+
+      it('should move the selected cells up', () => {
+        widget.activeCellIndex = 2;
+        NotebookActions.extendSelectionAbove(widget);
+        NotebookActions.moveUp(widget);
+        expect(widget.isSelected(widget.childAt(0))).to.be(true);
+        expect(widget.isSelected(widget.childAt(1))).to.be(true);
+        expect(widget.isSelected(widget.childAt(2))).to.be(false);
+        expect(widget.activeCellIndex).to.be(0);
+      });
+
+      it('should be a no-op if there is no model', () => {
+        widget.model = null;
+        NotebookActions.moveUp(widget);
+        expect(widget.activeCellIndex).to.be(-1);
+      });
+
+      it('should not wrap around to the bottom', () => {
+        expect(widget.activeCellIndex).to.be(0);
+        NotebookActions.moveUp(widget);
+        expect(widget.activeCellIndex).to.be(0);
+      });
+
+      it('should be undo-able', () => {
+        widget.activeCellIndex++;
+        let source = widget.activeCell.model.source;
+        NotebookActions.moveUp(widget);
+        expect(widget.model.cells.get(0).source).to.be(source);
+        NotebookActions.undo(widget);
+        expect(widget.model.cells.get(1).source).to.be(source);
+      });
+
+    });
+
+    describe('#moveDown()', () => {
+
+      it('should move the selected cells down', () => {
+        NotebookActions.extendSelectionBelow(widget);
+        NotebookActions.moveDown(widget);
+        expect(widget.isSelected(widget.childAt(0))).to.be(false);
+        expect(widget.isSelected(widget.childAt(1))).to.be(true);
+        expect(widget.isSelected(widget.childAt(2))).to.be(true);
+        expect(widget.activeCellIndex).to.be(2);
+      });
+
+      it('should be a no-op if there is no model', () => {
+        widget.model = null;
+        NotebookActions.moveUp(widget);
+        expect(widget.activeCellIndex).to.be(-1);
+      });
+
+      it('should not wrap around to the top', () => {
+        widget.activeCellIndex = widget.childCount() - 1;
+        NotebookActions.moveDown(widget);
+        expect(widget.activeCellIndex).to.be(widget.childCount() - 1);
+      });
+
+      it('should be undo-able', () => {
+        let source = widget.activeCell.model.source;
+        NotebookActions.moveDown(widget);
+        expect(widget.model.cells.get(1).source).to.be(source);
+        NotebookActions.undo(widget);
+        expect(widget.model.cells.get(0).source).to.be(source);
+      });
+
+    });
+
     describe('#copy()', () => {
 
       it('should copy the selected cells to a clipboard', () => {
@@ -1146,6 +1214,10 @@ describe('notebook/notebook/actions', () => {
         let count = widget.childCount();
         NotebookActions.redo(widget);
         expect(widget.childCount()).to.be(count);
+      });
+
+      it('should deactivate the cells', () => {
+
       });
 
     });

--- a/test/src/notebook/notebook/actions.spec.ts
+++ b/test/src/notebook/notebook/actions.spec.ts
@@ -1216,10 +1216,6 @@ describe('notebook/notebook/actions', () => {
         expect(widget.childCount()).to.be(count);
       });
 
-      it('should deactivate the cells', () => {
-
-      });
-
     });
 
     describe('#toggleLineNumbers()', () => {


### PR DESCRIPTION
cf #641.

Adds actions and command palette entries for moving cells up and down.  It does not add any shortcuts, since there were no shortcuts for these commands in the classic notebook.