### PR TITLE
Close All Widgets Functionality Added

### DIFF
--- a/src/application/shell.ts
+++ b/src/application/shell.ts
@@ -21,6 +21,10 @@ import {
 } from 'phosphor/lib/ui/focustracker';
 
 import {
+  each
+} from 'phosphor/lib/algorithm/iteration';
+
+import {
   Panel
 } from 'phosphor/lib/ui/panel';
 
@@ -240,6 +244,15 @@ class ApplicationShell extends Widget {
    */
   collapseRight(): void {
     this._rightHandler.collapse();
+  }
+
+  /**
+   * Close all tracked widgets.
+   */
+  closeAll(): void {
+    each(this._tracker.widgets, widget => {
+      widget.close();
+    });
   }
 
   private _topPanel: Panel;

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -73,7 +73,7 @@ const cmdIds = {
   restoreCheckpoint: 'file-operations:restore-checkpoint',
   saveAs: 'file-operations:saveAs',
   close: 'file-operations:close',
-  closeAll: 'file-operations:closeAll',
+  closeAllFiles: 'file-operations:closeAllFiles',
   open: 'file-operations:open',
   showBrowser: 'file-browser:activate',
   hideBrowser: 'file-browser:hide',
@@ -152,7 +152,7 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
     cmdIds.restoreCheckpoint,
     cmdIds.saveAs,
     cmdIds.close,
-    cmdIds.closeAll,
+    cmdIds.closeAllFiles,
   ].forEach(command => palette.addItem({ command, category }));
 
   mainMenu.addMenu(createMenu(app), {rank: 1});
@@ -233,7 +233,7 @@ function addCommands(app: JupyterLab, tracker: FocusTracker<Widget>, fbWidget: F
       }
     }
   });
-  commands.addCommand(cmdIds.closeAll, {
+  commands.addCommand(cmdIds.closeAllFiles, {
     label: 'Close All',
     execute: () => {
       each(tracker.widgets, widget => widget.close());
@@ -276,7 +276,7 @@ function createMenu(app: JupyterLab): Menu {
     cmdIds.restoreCheckpoint,
     cmdIds.saveAs,
     cmdIds.close,
-    cmdIds.closeAll,
+    cmdIds.closeAllFiles,
   ].forEach(command => menu.addItem({ command }));
 
   return menu;

--- a/src/main/plugin.ts
+++ b/src/main/plugin.ts
@@ -26,7 +26,7 @@ const mainExtension: JupyterLabPlugin<void> = {
       }
     });
 
-    palette.addItem({ command: commandId, category: 'Dock Panel' });
+    palette.addItem({ command: commandId, category: 'Main Area' });
 
     const message = 'Are you sure you want to exit JupyterLab?\n' +
                     'Any unsaved changes will be lost.';

--- a/src/main/plugin.ts
+++ b/src/main/plugin.ts
@@ -5,6 +5,10 @@ import {
   JupyterLab, JupyterLabPlugin
 } from '../application';
 
+import {
+  ICommandPalette
+} from '../commandpalette';
+
 
 /**
  * The main extension.
@@ -12,7 +16,18 @@ import {
 export
 const mainExtension: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.main',
-  activate: (app: JupyterLab) => {
+  requires: [ICommandPalette],
+  activate: (app: JupyterLab, palette: ICommandPalette) => {
+    let commandId = 'main-jupyterlab:closeAll';
+    app.commands.addCommand(commandId, {
+      label: 'Close All Widgets',
+      execute: () => {
+        app.shell.closeAll();
+      }
+    });
+
+    palette.addItem({ command: commandId, category: 'Dock Panel' });
+
     const message = 'Are you sure you want to exit JupyterLab?\n' +
                     'Any unsaved changes will be lost.';
 


### PR DESCRIPTION
Closes #212 .

Functionality for closing all widgets in the main area. Command is added to `Dock Panel` category in command palette. 

Renamed closeAll('file-operations:closeAll') to closeAllFiles('file-operations:closeAllFiles') for clarification.