### PR TITLE
Clear codemirror history when populating a cell

### DIFF
--- a/src/notebook/codemirror/cells/editor.ts
+++ b/src/notebook/codemirror/cells/editor.ts
@@ -111,6 +111,7 @@ class CodeMirrorCellEditorWidget extends CodeMirrorWidget implements ICellEditor
 
     this._model = model;
     doc.setValue(this._model.source || '');
+    doc.clearHistory();
     this._model.stateChanged.connect(this.onModelStateChanged, this);
   }
 


### PR DESCRIPTION
Fixes #343.

cc @Carreau 