### PR TITLE
allow trailing `/` on `/lab/` URL

### DIFF
--- a/jupyterlab/__init__.py
+++ b/jupyterlab/__init__.py
@@ -53,8 +53,8 @@ class LabHandler(IPythonHandler):
 #-----------------------------------------------------------------------------
 
 default_handlers = [
-    (PREFIX, LabHandler),
-    (PREFIX+r"/(.*)", FileFindHandler,
+    (PREFIX + r'/?', LabHandler),
+    (PREFIX+r"/(.+)", FileFindHandler,
         {'path': BUILT_FILES}),
     ]
 


### PR DESCRIPTION
handle both /lab and /lab/, avoiding 404 on /lab/