### PR TITLE
DragPanel: Panel which can be reordered with drag and drop

### DIFF
--- a/src/common/dragpanel.css
+++ b/src/common/dragpanel.css
@@ -5,13 +5,13 @@
 |----------------------------------------------------------------------------*/
 
 
-.jp-DragPanel-dragHandle{
+.jp-DragWidget-dragHandle{
   background:
     radial-gradient(rgba(255,255,255, .6) 30%, transparent 31%) 0 0,
     radial-gradient(transparent 19%,rgba(0,0,0,.4) 20%, transparent 50%) 0 1px;
   background-size:6px 6px;
 }
 
-.jp-DragPanel .p-Widget.jp-mod-dropTarget {
+.p-Panel.jp-DragWidget .p-Widget.jp-mod-dropTarget {
   border-top: 1px dashed black;
 }

--- a/src/common/dragpanel.css
+++ b/src/common/dragpanel.css
@@ -1,11 +1,17 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
 
-.jp-DragOrderPanel-dragHandle{
+
+.jp-DragPanel-dragHandle{
   background:
     radial-gradient(rgba(255,255,255, .6) 30%, transparent 31%) 0 0,
     radial-gradient(transparent 19%,rgba(0,0,0,.4) 20%, transparent 50%) 0 1px;
   background-size:6px 6px;
 }
 
-.jp-DragOrderPanel .p-Widget.jp-mod-dropTarget {
+.jp-DragPanel .p-Widget.jp-mod-dropTarget {
   border-top: 1px dashed black;
 }

--- a/src/common/dragpanel.css
+++ b/src/common/dragpanel.css
@@ -1,0 +1,11 @@
+
+.jp-DragOrderPanel-dragHandle{
+  background:
+    radial-gradient(rgba(255,255,255, .6) 30%, transparent 31%) 0 0,
+    radial-gradient(transparent 19%,rgba(0,0,0,.4) 20%, transparent 50%) 0 1px;
+  background-size:6px 6px;
+}
+
+.jp-DragOrderPanel .p-Widget.jp-mod-dropTarget {
+  border-top: 1px dashed black;
+}

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -152,8 +152,8 @@ class DragPanel extends Panel {
    * index, for example if the data should be able to be dropped on an external
    * target that only understands direct mime data.
    *
-   * As the method simply adds metadata for a specific key, overriders can call
-   * this method before/after adding their own metadata to still support default
+   * As the method simply adds mime data for a specific key, overriders can call
+   * this method before/after adding their own mime data to still support default
    * dragging behavior.
    */
   protected addMimeData(handle: HTMLElement, mimeData: MimeData): void {

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -99,9 +99,6 @@ function belongsToUs(node: HTMLElement, parentClass: string,
  * Alternatively, parent can be a collection of children.
  *
  * Returns null if not found.
- *
- * It is normally not recommended to overload this function, but to rather
- * overload `findDragTarget`/`findDropTarget`.
  */
 export
 function findChild(parent: HTMLElement | HTMLElement[], node: HTMLElement): HTMLElement {

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -162,7 +162,7 @@ class DragPanel extends Panel {
       this._evtDragOver(event as IDragEvent);
       break;
     case 'p-drop':
-      this._evtDrop(event as IDragEvent);
+      this.evtDrop(event as IDragEvent);
       break;
     default:
       break;
@@ -370,23 +370,23 @@ class DragPanel extends Panel {
    * Should normally only be overriden if you cannot achive your goal by
    * other overrides.
    */
-  protected _startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
+  protected startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
     // Create the drag image.
     let dragImage = this.getDragImage(handle);
 
     // Set up the drag event.
-    this._drag = new Drag({
+    this.drag = new Drag({
       dragImage: dragImage,
       mimeData: new MimeData(),
       supportedActions: 'all',
       proposedAction: 'link',
       source: this
     });
-    this.addMimeData(handle, this._drag.mimeData);
+    this.addMimeData(handle, this.drag.mimeData);
 
     // Start the drag and remove the mousemove listener.
-    this._drag.start(clientX, clientY).then(action => {
-      this._drag = null;
+    this.drag.start(clientX, clientY).then(action => {
+      this.drag = null;
     });
     document.removeEventListener('mousemove', this, true);
   }
@@ -399,7 +399,7 @@ class DragPanel extends Panel {
    * Should normally only be overriden if you cannot achive your goal by
    * other overrides.
    */
-  protected _evtDrop(event: IDragEvent): void {
+  protected evtDrop(event: IDragEvent): void {
     let target = event.target as HTMLElement;
     while (target && target.parentElement) {
       if (target.classList.contains(DROP_TARGET_CLASS)) {
@@ -427,7 +427,7 @@ class DragPanel extends Panel {
   /**
    * Drag data stored in _startDrag
    */
-  protected _drag: Drag = null;
+  protected drag: Drag = null;
 
   /**
    * Check if node, or any of nodes ancestors are a drag handle
@@ -481,10 +481,10 @@ class DragPanel extends Panel {
    * Handle the `'mouseup'` event for the widget.
    */
   private _evtMouseup(event: MouseEvent): void {
-    if (event.button !== 0 || !this._drag) {
+    if (event.button !== 0 || !this.drag) {
       document.removeEventListener('mousemove', this, true);
       document.removeEventListener('mouseup', this, true);
-      this._drag = null;
+      this.drag = null;
       return;
     }
     event.preventDefault();
@@ -496,7 +496,7 @@ class DragPanel extends Panel {
    */
   private _evtMousemove(event: MouseEvent): void {
     // Bail if we are already dragging.
-    if (this._drag) {
+    if (this.drag) {
       return;
     }
 
@@ -511,7 +511,7 @@ class DragPanel extends Panel {
       return;
     }
 
-    this._startDrag(data.handle, event.clientX, event.clientY);
+    this.startDrag(data.handle, event.clientX, event.clientY);
     this._clickData = null;
   }
 

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -1,0 +1,596 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+'use strict';
+
+import {
+  Panel, PanelLayout
+} from 'phosphor/lib/ui/panel';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  Message
+} from 'phosphor/lib/core/messaging';
+
+import {
+  ISignal, defineSignal
+} from 'phosphor/lib/core/signaling';
+
+import {
+  MimeData
+} from 'phosphor/lib/core/mimedata';
+
+import {
+  Drag, IDragEvent, DropAction, SupportedActions
+} from 'phosphor/lib/dom/dragdrop';
+
+import './dragpanel.css';
+
+/**
+ * The class name added to the DragPanel
+ */
+const PANEL_CLASS = 'jp-DragPanel';
+
+/**
+ * The class name added to something which can be used to drag a box
+ */
+const DRAG_HANDLE = 'jp-mod-dragHandle';
+
+/**
+ * The class name of the default drag handle
+ */
+const DEFAULT_DRAG_HANDLE_CLASS = 'jp-DragPanel-dragHandle';
+
+
+/**
+ * The class name added to a drop target.
+ */
+const DROP_TARGET_CLASS = 'jp-mod-dropTarget';
+
+/**
+ * MIME type representing drag data by index
+ */
+const MIME_INDEX = 'application/vnd.jupyter.dragindex';
+
+/**
+ * The threshold in pixels to start a drag event.
+ */
+const DRAG_THRESHOLD = 5;
+
+
+
+/**
+ * A panel which allows the user to rearrange elements.
+ *
+ *
+ */
+export
+class DragPanel extends Panel {
+
+  constructor(options: Panel.IOptions={}) {
+    super(options);
+    this.addClass(PANEL_CLASS);
+  }
+
+  /**
+   * Signal that is emitted after a widget has been moved internally in the list.
+   *
+   * The first argument is the panel in which the move occurred.
+   * The second argument is the old and the new keys of the widget.
+   *
+   * In the default implementation the keys are indices to the widget positions
+   */
+  moved: ISignal<DragPanel, {from: any, to: any}>;
+
+
+  /**
+   * Whether all direct children of the list are handles, or only those widgets
+   * designated as handles. Defaults to false.
+   */
+  childrenAreDragHandles = false;
+
+  /**
+   * Whether the list should accept drops from an external source.
+   * Defaults to false.
+   *
+   * This option only makes sense to set for subclasses that accept drops from
+   * external sources.
+   */
+  acceptExternalDropSource = false;
+
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the dock panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'mousedown':
+      this._evtMousedown(event as MouseEvent);
+      break;
+    case 'mouseup':
+      this._evtMouseup(event as MouseEvent);
+      break;
+    case 'mousemove':
+      this._evtMousemove(event as MouseEvent);
+      break;
+    case 'p-dragenter':
+      this._evtDragEnter(event as IDragEvent);
+      break;
+    case 'p-dragleave':
+      this._evtDragLeave(event as IDragEvent);
+      break;
+    case 'p-dragover':
+      this._evtDragOver(event as IDragEvent);
+      break;
+    case 'p-drop':
+      this._evtDrop(event as IDragEvent);
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Adds mime data represeting the drag data to the drag event's MimeData bundle.
+   *
+   * The default implementation adds mime data indicating the index of the direct
+   * child being dragged (as indicated by findDragTarget).
+   */
+  protected addMimeData(handle: HTMLElement, mimeData: MimeData): void {
+    let target = this.findDragTarget(handle);
+    let key = this.getIndexOfChildNode(this, target);
+
+    mimeData.setData(MIME_INDEX, key);
+  }
+
+  /**
+   * Processes a drop event.
+   *
+   * This function is called after checking:
+   *  - That the `dropTarget` is a valid drop target
+   *  - The value of `event.source` if `acceptExternalDropSource` is true
+   *
+   * The default implementation assumes `dropTarget` is a direct child and that
+   * the mime data of `MIME_INDEX` holds an index to a direct child, and will
+   * call `move` with the indices of this source and destination.
+   */
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): DropAction {
+    if (!DragPanel.isValidAction(event.supportedActions, 'move') ||
+        event.proposedAction === 'none' ||
+        event.source !== this) {
+      // The default implementation only handles move action OR
+      // Accept proposed none action, and perform no-op
+      //
+      event.dropAction = 'none';
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    let sourceKey = event.mimeData.getData(MIME_INDEX);
+    let targetKey = this.getIndexOfChildNode(this, dropTarget);
+    if (targetKey === null) {
+      // Invalid target somehow
+      return null;
+    }
+
+    // We have an acceptable drop, handle:
+    this.move(sourceKey, targetKey);
+    event.preventDefault();
+    event.stopPropagation();
+    event.dropAction = 'move';
+  }
+
+  /**
+   * Finds the drag target (the widget to move) from a drag handle.
+   *
+   * Returns null if no valid drop target was found.
+   *
+   * The default implementation returns the direct child that is the ancestor of
+   * or equal to the handle.
+   */
+  protected findDragTarget(handle: HTMLElement): HTMLElement {
+    return Private.findChild(this.node, handle);
+  }
+
+  /**
+   * Find a drop target from a given drag event target.
+   *
+   * Returns null if no valid drop target was found.
+   *
+   * The default implementation returns the direct child that is the parent of
+   * `node`, or `node` if it is itself a direct child.
+   */
+  protected findDropTarget(input: HTMLElement, mimeData: MimeData): HTMLElement {
+    return Private.findChild(this.node, input);
+  }
+
+  /**
+   * Returns the drag image to use when dragging using the given handle.
+   *
+   * The default implementation returns a deepcopy of the drag target.
+   */
+  protected getDragImage(handle: HTMLElement): HTMLElement {
+    return this.findDragTarget(handle).cloneNode(true) as HTMLElement;
+  }
+
+  /**
+   * Called when a widget should be moved as a consequence of an internal drag event.
+   *
+   * The default implementation moves the direct childer as indexed by the passed
+   * keys, then emits the `moved` signal.
+   */
+  protected move(from: any, to: any): void {
+    if (to !== from) {
+      let adjustedTo = to;
+      if (adjustedTo > from) {
+        adjustedTo -= 1;
+      }
+      this.insertWidget(adjustedTo, this.widgets.at(from));
+      this.moved.emit({from: from, to: to});
+    }
+  }
+
+  /**
+   * Determine whether node is equal to or a decendant of our panel, and that is does
+   * not belong to a nested drag panel.
+   */
+  protected belongsToUs(node: HTMLElement): boolean {
+    // Traverse DOM until drag panel encountered:
+    while (node && !node.classList.contains(PANEL_CLASS)) {
+      node = node.parentElement;
+    }
+    return node && node === this.node;
+  }
+
+  /**
+   * Returns the index of node in `layout.widgets`.
+   *
+   * Returns null if not found.
+   */
+  protected getIndexOfChildNode(parent: Widget, node: HTMLElement): number {
+    let layout = parent.layout as PanelLayout;
+    for (let i = 0; i < layout.widgets.length; i++) {
+      if (layout.widgets.at(i).node === node) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Handle `after_attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    let node = this.node;
+    node.addEventListener('click', this);
+    node.addEventListener('dblclick', this);
+    node.addEventListener('mousedown', this);
+    node.addEventListener('p-dragenter', this);
+    node.addEventListener('p-dragleave', this);
+    node.addEventListener('p-dragover', this);
+    node.addEventListener('p-drop', this);
+   }
+
+  /**
+   * Handle `before_detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    let node = this.node;
+    node.removeEventListener('click', this);
+    node.removeEventListener('dblclick', this);
+    node.removeEventListener('p-dragenter', this);
+    node.removeEventListener('p-dragleave', this);
+    node.removeEventListener('p-dragover', this);
+    node.removeEventListener('p-drop', this);
+    document.removeEventListener('mousemove', this, true);
+    document.removeEventListener('mouseup', this, true);
+  }
+
+  /**
+   * Start a drag event.
+   */
+  protected _startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
+    // Create the drag image.
+
+    let dragImage = this.getDragImage(handle);
+
+    // Set up the drag event.
+    this._drag = new Drag({
+      dragImage: dragImage,
+      mimeData: new MimeData(),
+      supportedActions: 'move',
+      proposedAction: 'move',
+      source: this
+    });
+    this.addMimeData(handle, this._drag.mimeData);
+
+    // Start the drag and remove the mousemove listener.
+    this._drag.start(clientX, clientY).then(action => {
+      // TODO: If some outside source accepted it, should we remove the widget?
+      // In principle an accepted move op should always delete the source...
+      this._drag = null;
+    });
+    document.removeEventListener('mousemove', this, true);
+  }
+
+  /**
+   * Handle the `'p-drop'` event for the widget.
+   */
+  protected _evtDrop(event: IDragEvent): void {
+    let target = event.target as HTMLElement;
+    while (target && target.parentElement) {
+      if (target.classList.contains(DROP_TARGET_CLASS)) {
+        target.classList.remove(DROP_TARGET_CLASS);
+        break;
+      }
+      target = target.parentElement;
+    }
+    if (!target || !this.belongsToUs(target)) {
+      // Ignore event
+      return;
+    }
+
+    // If configured to, only accept internal moves:
+    if (!this.acceptExternalDropSource && event.source !== this) {
+      event.dropAction = 'none';
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    this.processDrop(target, event);
+  }
+
+  /**
+   * Check if node, or any of nodes ancestors are a drag handle
+   *
+   * If it is a drag handle, it returns the handle, if not returns null.
+   */
+  private _findDragHandle(node: HTMLElement): HTMLElement {
+    let handle: HTMLElement = null;
+    if (this.childrenAreDragHandles) {
+      // Simple scenario, just look for node among children
+      handle = node;
+    } else {
+      // Otherwise, traverse up DOM to check if click is on a drag handle
+      while (node && node !== this.node) {
+        if (node.classList.contains(DRAG_HANDLE)) {
+          handle = node;
+          break;
+        }
+        node = node.parentElement;
+      }
+      // Finally, check that handle does not belong to a nested drag panel
+      if (handle !== null && !this.belongsToUs(handle)) {
+        // Handle belongs to a nested drag panel:
+        handle = null;
+      }
+    }
+    return handle;
+  }
+
+  /**
+   * Handle the `'mousedown'` event for the widget.
+   */
+  private _evtMousedown(event: MouseEvent): void {
+    let target = event.target as HTMLElement;
+    let handle = this._findDragHandle(target);
+    if (handle === null) {
+      return;
+    }
+
+    // Left mouse press for drag start.
+    if (event.button === 0) {
+      this._dragData = { pressX: event.clientX, pressY: event.clientY,
+                         handle: handle };
+      document.addEventListener('mouseup', this, true);
+      document.addEventListener('mousemove', this, true);
+    }
+  }
+
+
+  /**
+   * Handle the `'mouseup'` event for the widget.
+   */
+  private _evtMouseup(event: MouseEvent): void {
+    if (event.button !== 0 || !this._drag) {
+      document.removeEventListener('mousemove', this, true);
+      document.removeEventListener('mouseup', this, true);
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Handle the `'mousemove'` event for the widget.
+   */
+  private _evtMousemove(event: MouseEvent): void {
+    // Bail if we are already dragging.
+    if (this._drag) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Check for a drag initialization.
+    let data = this._dragData;
+    let dx = Math.abs(event.clientX - data.pressX);
+    let dy = Math.abs(event.clientY - data.pressY);
+    if (dx < DRAG_THRESHOLD && dy < DRAG_THRESHOLD) {
+      return;
+    }
+
+    this._startDrag(data.handle, event.clientX, event.clientY);
+  }
+
+  /**
+   * Handle the `'p-dragenter'` event for the widget.
+   */
+  private _evtDragEnter(event: IDragEvent): void {
+    let target = this.findDropTarget(event.target as HTMLElement, event.mimeData);
+    if (target === null) {
+      return;
+    }
+    this._clearDropTarget();
+    target.classList.add(DROP_TARGET_CLASS);
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Handle the `'p-dragleave'` event for the widget.
+   */
+  private _evtDragLeave(event: IDragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    // Clear drop target:
+    let elements = this.node.getElementsByClassName(DROP_TARGET_CLASS);
+    if (elements.length) {
+      (elements[0] as HTMLElement).classList.remove(DROP_TARGET_CLASS);
+    }
+  }
+
+  /**
+   * Handle the `'p-dragover'` event for the widget.
+   */
+  private _evtDragOver(event: IDragEvent): void {
+    let target = this.findDropTarget(event.target as HTMLElement, event.mimeData);
+    if (target === null) {
+      return;
+    }
+    this._clearDropTarget();
+    target.classList.add(DROP_TARGET_CLASS);
+    event.preventDefault();
+    event.stopPropagation();
+    event.dropAction = event.proposedAction;
+  }
+
+  /**
+   * Clear existing drop target from out children.
+   *
+   * #### Notes
+   * This function assumes there are only one active drop target
+   */
+  private _clearDropTarget(): void {
+    // Clear drop target:
+    let elements = this.node.getElementsByClassName(DROP_TARGET_CLASS);
+    if (elements.length) {
+      (elements[0] as HTMLElement).classList.remove(DROP_TARGET_CLASS);
+    }
+  }
+
+  private _drag: Drag = null;
+  private _dragData: { pressX: number, pressY: number, handle: HTMLElement } = null;
+}
+
+defineSignal(DragPanel.prototype, 'moved');
+
+
+/**
+ * The namespace for the `DragPanel` class statics.
+ */
+export
+namespace DragPanel {
+  /**
+   * An options object for initializing a drag panel widget.
+   */
+  export
+  interface IOptions {
+    /**
+     * Whether all direct children of the list are handles, or only those widgets
+     * designated as handles. Defaults to false.
+     */
+    childrenAreDragHandles: boolean,
+
+    /**
+     * Whether the lsit should accept drops from an external source.
+     * Defaults to false.
+     *
+     * This option only makes sense to set for subclasses that accept drops from
+     * external sources.
+     */
+    acceptExternalDropSource: boolean;
+  }
+
+  export
+  function isValidAction(supported: SupportedActions, action: DropAction): boolean {
+    switch (supported) {
+    case 'all':
+      return true;
+    case 'link-move':
+      return action === 'move' || action === 'link';
+    case 'copy-move':
+      return action === 'move' || action === 'copy';
+    case 'copy-link':
+      return action === 'link' || action === 'copy';
+    default:
+      return action === supported;
+    }
+  }
+
+  /**
+   * Mark a widget as a drag handle.
+   *
+   * Using this, any child-widget can be a drag handle, as long as mouse events
+   * are propagated from it to the DragPanel.
+   */
+  export
+  function makeHandle(handle: Widget) {
+    handle.addClass(DRAG_HANDLE);
+  }
+
+  /**
+   * Unmark a widget as a drag handle
+   */
+  export
+  function unmakeHandle(handle: Widget) {
+    handle.removeClass(DRAG_HANDLE);
+  }
+
+  /**
+   * Create a default handle widget for dragging (see styling in dragpanel.css)
+   */
+  export
+  function createDefaultHandle(): Widget {
+    let widget = new Widget();
+    widget.addClass(DEFAULT_DRAG_HANDLE_CLASS);
+    makeHandle(widget);
+    return widget;
+  }
+}
+
+
+namespace Private {
+  /**
+   * Find the direct child node of `parent`, which has `node` as a descendant.
+   *
+   * Returns null if not found. Also returns null if it detects an inner drag
+   * list.
+   */
+  export
+  function findChild(parent: HTMLElement, node: HTMLElement): HTMLElement {
+    // Work our way up the DOM to an element which has this node as parent
+    let child: HTMLElement = null;
+    while (node && node !== parent) {
+      if (node.classList.contains(PANEL_CLASS)) {
+        return null;
+      }
+      if (node.parentElement === parent) {
+        child = node;
+        break;
+      }
+      node = node.parentElement;
+    }
+    return child;
+  }
+}

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  Panel
+  Panel, PanelLayout
 } from 'phosphor/lib/ui/panel';
 
 import {
@@ -73,9 +73,10 @@ const MIME_INDEX = 'application/vnd.jupyter.dragindex';
 const DRAG_THRESHOLD = 5;
 
 
-// Turn Panel shape into interface
+// Turn Panel shape into interface, use for simulating mixins
 export
 interface IPanel extends Panel {}
+const PANEL_CLASS = 'p-Panel';
 
 /**
  * A widget class which allows the user to drop mime data onto it.
@@ -309,7 +310,8 @@ abstract class DropPanel extends DropWidget implements IPanel {
    */
   constructor(options: DropPanel.IOptions={}) {
     super(options);  // DropWidget ctor
-    Panel.apply(this, [options]);  // Panel constructor
+    this.addClass(PANEL_CLASS);
+    this.layout = Private.createLayout(options);
   }
 
   // Shims for applyMixins:
@@ -629,7 +631,8 @@ abstract class DragPanel extends DragWidget implements IPanel {
    */
   constructor(options: DragPanel.IOptions={}) {
     super(options);
-    Panel.apply(this, options);
+    this.addClass(PANEL_CLASS);
+    this.layout = Private.createLayout(options);
   }
 
   // Shims for applyMixins:
@@ -796,13 +799,15 @@ defineSignal(DragDropWidget.prototype, 'moved');
  *
  * For maximum control, `startDrag` and `evtDrop` can be overriden.
  */
+export
 class DragDropPanel extends DragDropWidget implements IPanel {
   /**
    * Construct a drag and drop panel.
    */
   constructor(options: DragDropPanel.IOptions={}) {
     super(options);
-    Panel.apply(this, options);
+    this.addClass(PANEL_CLASS);
+    this.layout = Private.createLayout(options);
   }
 
   // Shims for applyMixins:
@@ -881,7 +886,7 @@ function findChild(parent: HTMLElement | HTMLElement[], node: HTMLElement): HTML
     if (parentIsArray) {
       return (parent as HTMLElement[]).indexOf(child) > -1;
     } else {
-      return child.parentElement === node.parentElement;
+      return child.parentElement === parent;
     }
   };
   while (node && node !== parent) {
@@ -1027,5 +1032,12 @@ export
 namespace DragDropPanel {
   export
   interface IOptions extends DragDropWidget.IOptions, Panel.IOptions {
+  }
+}
+
+namespace Private {
+  export
+  function createLayout(options: Panel.IOptions) {
+    return options.layout || new PanelLayout();
   }
 }

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -195,7 +195,7 @@ abstract class DropWidget extends Widget {
    *
    * This function is called after checking:
    *  - That the `dropTarget` is a valid drop target
-   *  - The value of `event.source` if `acceptDropsFromExternalSource` is true
+   *  - The value of `event.source` if `acceptDropsFromExternalSource` is false
    *
    * The default implementation assumes calling `getIndexOfChildNode` with
    * `dropTarget` will be valid. It will call `move` with that index as `to`,
@@ -713,7 +713,7 @@ abstract class DragDropWidget extends DragDropWidgetBase {
    *
    * This function is called after checking:
    *  - That the `dropTarget` is a valid drop target
-   *  - The value of `event.source` if `acceptDropsFromExternalSource` is true
+   *  - The value of `event.source` if `acceptDropsFromExternalSource` is false
    *
    * The default implementation assumes calling `getIndexOfChildNode` with
    * `dropTarget` will be valid. It will call `move` with that index as `to`,

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -3,7 +3,7 @@
 'use strict';
 
 import {
-  Panel, PanelLayout
+  Panel
 } from 'phosphor/lib/ui/panel';
 
 import {
@@ -13,6 +13,10 @@ import {
 import {
   Message
 } from 'phosphor/lib/core/messaging';
+
+import {
+  ISequence
+} from 'phosphor/lib/algorithm/sequence';
 
 import {
   ISignal, defineSignal
@@ -26,10 +30,20 @@ import {
   Drag, IDragEvent, DropAction, SupportedActions
 } from 'phosphor/lib/dom/dragdrop';
 
+import {
+  applyMixins
+} from '../utils';
+
+
 /**
- * The class name added to the DragPanel
+ * The class name added to the DropWidget
  */
-const PANEL_CLASS = 'jp-DragPanel';
+const DROP_WIDGET_CLASS = 'jp-DropWidget';
+
+/**
+ * The class name added to the DragWidget
+ */
+const DRAG_WIDGET_CLASS = 'jp-DragWidget';
 
 /**
  * The class name added to something which can be used to drag a box
@@ -39,7 +53,7 @@ const DRAG_HANDLE = 'jp-mod-dragHandle';
 /**
  * The class name of the default drag handle
  */
-const DEFAULT_DRAG_HANDLE_CLASS = 'jp-DragPanel-dragHandle';
+const DEFAULT_DRAG_HANDLE_CLASS = 'jp-DragWidget-dragHandle';
 
 
 /**
@@ -50,6 +64,7 @@ const DROP_TARGET_CLASS = 'jp-mod-dropTarget';
 /**
  * MIME type representing drag data by index
  */
+export
 const MIME_INDEX = 'application/vnd.jupyter.dragindex';
 
 /**
@@ -58,68 +73,34 @@ const MIME_INDEX = 'application/vnd.jupyter.dragindex';
 const DRAG_THRESHOLD = 5;
 
 
+// Turn Panel shape into interface
+export
+interface IPanel extends Panel {}
 
 /**
- * A panel which allows the user to rearrange elements by drag and drop.
+ * A widget class which allows the user to drop mime data onto it.
  *
- * Any descendant element with the drag handle class `'jp-mod-dragHandle'`
- * will serve as a handle that can be used for dragging. If DragPanels are
- * nested, handles will only belong to the closest parent DragPanel. For
- * convenience, the functions `makeHandle`, `unmakeHandle` and
- * `createDefaultHandle` can be used to indicate which elements should be
- * made handles. `createDefaultHandle` will create a new element as a handle
- * with a default styling class applied. Optionally, `childrenAreDragHandles`
- * can be set to indicate that all direct children are themselve drag handles.
+ * To complete the class, the following functions need to be implemented:
+ *  - processDrop: Process pre-screened drop events
  *
  * The functionallity of the class can be extended by overriding the following
  * functions:
- *  - move(): Override to add custom processing of move command, for example
- *    by performing the move in a model instead of on widgets. A possible
- *    alternative to overriding `move` is to connect to the `moved` signal.
- *  - addMimeData: Override to add other drag data to the mime bundle.
- *    This is often a necessary step for allowing dragging to external
- *    drop targets.
- *  - processDrop: Override if you need to handle other mime data than the
- *    default. For allowing drops from external sources, the field
- *    `acceptDropsFromExternalSource` should be set as well.
- *  - getDragImage: Override to change the drag image (the default is a
- *    copy of the element being dragged).
+ *  - findDropTarget(): Override if anything other than the direct children
+ *    of the widget's node are to be the drop targets.
  *
- * To drag and drop other things than all direct children, the following functions
- * should be overriden: `findDragTarget`, `findDropTarget` and possibly
- * `getIndexOfChildNode` and `move` to allow for custom to/from keys.
- *
- * For maximum control, `_startDrag` and `_evtDrop` can be overriden.
+ * For maximum control, `evtDrop` can be overriden.
  */
 export
-class DragPanel extends Panel {
-
+abstract class DropWidget extends Widget {
   /**
-   * Construct a drag panel.
+   * Construct a drag widget.
    */
-  constructor(options: DragPanel.IOptions={}) {
+  constructor(options: DropWidget.IOptions={}) {
     super(options);
-    this.childrenAreDragHandles = options.childrenAreDragHandles === true;
-    this.acceptDropsFromExternalSource = options.acceptDropsFromExternalSource === true;
-    this.addClass(PANEL_CLASS);
+    this.acceptDropsFromExternalSource =
+      options.acceptDropsFromExternalSource === true;
+    this.addClass(DROP_WIDGET_CLASS);
   }
-
-  /**
-   * Signal that is emitted after a widget has been moved internally in the list.
-   *
-   * The first argument is the panel in which the move occurred.
-   * The second argument is the old and the new keys of the widget.
-   *
-   * In the default implementation the keys are indices to the widget positions
-   */
-  moved: ISignal<DragPanel, {from: any, to: any}>;
-
-
-  /**
-   * Whether all direct children of the list are handles, or only those widgets
-   * designated as handles. Defaults to false.
-   */
-  childrenAreDragHandles: boolean;
 
   /**
    * Whether the list should accept drops from an external source.
@@ -143,15 +124,6 @@ class DragPanel extends Panel {
    */
   handleEvent(event: Event): void {
     switch (event.type) {
-    case 'mousedown':
-      this._evtMousedown(event as MouseEvent);
-      break;
-    case 'mouseup':
-      this._evtMouseup(event as MouseEvent);
-      break;
-    case 'mousemove':
-      this._evtMousemove(event as MouseEvent);
-      break;
     case 'p-dragenter':
       this._evtDragEnter(event as IDragEvent);
       break;
@@ -170,47 +142,6 @@ class DragPanel extends Panel {
   }
 
   /**
-   * Called when a widget should be moved as a consequence of an internal drag event.
-   *
-   * The default implementation assumes the keys `from` and `to` are numbers
-   * indexing the drag panels direct children. It then moves the direct child as
-   * specified by these keys, then emits the `moved` signal.
-   */
-  protected move(from: any, to: any): void {
-    if (to !== from) {
-      // Adjust for the shifting of elements once 'from' is removed
-      if (to > from) {
-        to -= 1;
-      }
-      this.insertWidget(to, this.widgets.at(from));
-      this.moved.emit({from: from, to: to});
-    }
-  }
-
-  /**
-   * Adds mime data represeting the drag data to the drag event's MimeData bundle.
-   *
-   * The default implementation adds mime data indicating the index of the direct
-   * child being dragged (as indicated by findDragTarget).
-   *
-   * Override this method if you have data that cannot be communicated well by an
-   * index, for example if the data should be able to be dropped on an external
-   * target that only understands direct mime data.
-   *
-   * As the method simply adds mime data for a specific key, overriders can call
-   * this method before/after adding their own mime data to still support default
-   * dragging behavior.
-   */
-  protected addMimeData(handle: HTMLElement, mimeData: MimeData): void {
-    let target = this.findDragTarget(handle);
-    let key = this.getIndexOfChildNode(this, target);
-
-    if (key !== null) {
-      mimeData.setData(MIME_INDEX, key);
-    }
-  }
-
-  /**
    * Processes a drop event.
    *
    * This function is called after checking:
@@ -223,44 +154,7 @@ class DragPanel extends Panel {
    *
    * Override this if you need to handle other mime data than the default.
    */
-  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
-    if (!DragPanel.isValidAction(event.supportedActions, 'move') ||
-        event.proposedAction === 'none') {
-      // The default implementation only handles move action
-      // OR Accept proposed none action, and perform no-op
-      event.dropAction = 'none';
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
-    if (event.source !== this) {
-      // Source indicates external drop, incorrect use in subclass
-    }
-    let sourceKey = event.mimeData.getData(MIME_INDEX);
-    let targetKey = this.getIndexOfChildNode(this, dropTarget);
-    if (targetKey === null) {
-      // Invalid target somehow
-      return;
-    }
-
-    // We have an acceptable drop, handle:
-    this.move(sourceKey, targetKey);
-    event.preventDefault();
-    event.stopPropagation();
-    event.dropAction = 'link';
-  }
-
-  /**
-   * Finds the drag target (the widget to move) from a drag handle.
-   *
-   * Returns null if no valid drag target was found.
-   *
-   * The default implementation returns the direct child that is the ancestor of
-   * (or equal to) the handle.
-   */
-  protected findDragTarget(handle: HTMLElement): HTMLElement {
-    return this.findChild(this.node, handle);
-  }
+  protected abstract processDrop(dropTarget: HTMLElement, event: IDragEvent): void;
 
   /**
    * Find a drop target from a given drag event target.
@@ -275,120 +169,7 @@ class DragPanel extends Panel {
     if (!mimeData.hasData(MIME_INDEX)) {
       return null;
     }
-    return this.findChild(this.node, input);
-  }
-
-  /**
-   * Returns the drag image to use when dragging using the given handle.
-   *
-   * The default implementation returns a deepcopy of the drag target.
-   */
-  protected getDragImage(handle: HTMLElement): HTMLElement {
-    return this.findDragTarget(handle).cloneNode(true) as HTMLElement;
-  }
-
-  /**
-   * Determine whether node is equal to or a decendant of our panel, and that is does
-   * not belong to a nested drag panel.
-   */
-  protected belongsToUs(node: HTMLElement): boolean {
-    // Traverse DOM until drag panel encountered:
-    while (node && !node.classList.contains(PANEL_CLASS)) {
-      node = node.parentElement;
-    }
-    return node && node === this.node;
-  }
-
-  /**
-   * Returns the index of node in `layout.widgets`.
-   *
-   * Returns null if not found.
-   */
-  protected getIndexOfChildNode(parent: Widget, node: HTMLElement): any {
-    let layout = parent.layout as PanelLayout;
-    for (let i = 0; i < layout.widgets.length; i++) {
-      if (layout.widgets.at(i).node === node) {
-        return i;
-      }
-    }
-    return null;
-  }
-
-
-  /**
-   * Find the direct child node of `parent`, which has `node` as a descendant.
-   *
-   * Returns null if not found.
-   */
-  protected findChild(parent: HTMLElement, node: HTMLElement): HTMLElement {
-    // Work our way up the DOM to an element which has this node as parent
-    let child: HTMLElement = null;
-    while (node && node !== parent) {
-      if (node.parentElement === parent) {
-        child = node;
-        break;
-      }
-      node = node.parentElement;
-    }
-    return child;
-  }
-
-  /**
-   * Handle `after_attach` messages for the widget.
-   */
-  protected onAfterAttach(msg: Message): void {
-    let node = this.node;
-    node.addEventListener('click', this);
-    node.addEventListener('dblclick', this);
-    node.addEventListener('mousedown', this);
-    node.addEventListener('p-dragenter', this);
-    node.addEventListener('p-dragleave', this);
-    node.addEventListener('p-dragover', this);
-    node.addEventListener('p-drop', this);
-   }
-
-  /**
-   * Handle `before_detach` messages for the widget.
-   */
-  protected onBeforeDetach(msg: Message): void {
-    let node = this.node;
-    node.removeEventListener('click', this);
-    node.removeEventListener('dblclick', this);
-    node.removeEventListener('p-dragenter', this);
-    node.removeEventListener('p-dragleave', this);
-    node.removeEventListener('p-dragover', this);
-    node.removeEventListener('p-drop', this);
-    document.removeEventListener('mousemove', this, true);
-    document.removeEventListener('mouseup', this, true);
-  }
-
-  /**
-   * Start a drag event.
-   *
-   * Called when dragginging and DRAG_THRESHOLD is met.
-   *
-   * Should normally only be overriden if you cannot achive your goal by
-   * other overrides.
-   */
-  protected startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
-    // Create the drag image.
-    let dragImage = this.getDragImage(handle);
-
-    // Set up the drag event.
-    this.drag = new Drag({
-      dragImage: dragImage,
-      mimeData: new MimeData(),
-      supportedActions: 'all',
-      proposedAction: 'link',
-      source: this
-    });
-    this.addMimeData(handle, this.drag.mimeData);
-
-    // Start the drag and remove the mousemove listener.
-    this.drag.start(clientX, clientY).then(action => {
-      this.drag = null;
-    });
-    document.removeEventListener('mousemove', this, true);
+    return findChild(this.node, input);
   }
 
   /**
@@ -408,7 +189,7 @@ class DragPanel extends Panel {
       }
       target = target.parentElement;
     }
-    if (!target || !this.belongsToUs(target)) {
+    if (!target || !belongsToUs(target, DROP_WIDGET_CLASS, this.node)) {
       // Ignore event
       return;
     }
@@ -425,95 +206,27 @@ class DragPanel extends Panel {
   }
 
   /**
-   * Drag data stored in _startDrag
+   * Handle `after_attach` messages for the widget.
    */
-  protected drag: Drag = null;
-
-  /**
-   * Check if node, or any of nodes ancestors are a drag handle
-   *
-   * If it is a drag handle, it returns the handle, if not returns null.
-   */
-  private _findDragHandle(node: HTMLElement): HTMLElement {
-    let handle: HTMLElement = null;
-    if (this.childrenAreDragHandles) {
-      // Simple scenario, just look for node among children
-      handle = node;
-    } else {
-      // Otherwise, traverse up DOM to check if click is on a drag handle
-      while (node && node !== this.node) {
-        if (node.classList.contains(DRAG_HANDLE)) {
-          handle = node;
-          break;
-        }
-        node = node.parentElement;
-      }
-      // Finally, check that handle does not belong to a nested drag panel
-      if (handle !== null && !this.belongsToUs(handle)) {
-        // Handle belongs to a nested drag panel:
-        handle = null;
-      }
-    }
-    return handle;
+  protected onAfterAttach(msg: Message): void {
+    let node = this.node;
+    node.addEventListener('p-dragenter', this);
+    node.addEventListener('p-dragleave', this);
+    node.addEventListener('p-dragover', this);
+    node.addEventListener('p-drop', this);
   }
 
   /**
-   * Handle the `'mousedown'` event for the widget.
+   * Handle `before_detach` messages for the widget.
    */
-  private _evtMousedown(event: MouseEvent): void {
-    let target = event.target as HTMLElement;
-    let handle = this._findDragHandle(target);
-    if (handle === null) {
-      return;
-    }
-
-    // Left mouse press for drag start.
-    if (event.button === 0) {
-      this._clickData = { pressX: event.clientX, pressY: event.clientY,
-                         handle: handle };
-      document.addEventListener('mouseup', this, true);
-      document.addEventListener('mousemove', this, true);
-    }
+  protected onBeforeDetach(msg: Message): void {
+    let node = this.node;
+    node.removeEventListener('p-dragenter', this);
+    node.removeEventListener('p-dragleave', this);
+    node.removeEventListener('p-dragover', this);
+    node.removeEventListener('p-drop', this);
   }
 
-
-  /**
-   * Handle the `'mouseup'` event for the widget.
-   */
-  private _evtMouseup(event: MouseEvent): void {
-    if (event.button !== 0 || !this.drag) {
-      document.removeEventListener('mousemove', this, true);
-      document.removeEventListener('mouseup', this, true);
-      this.drag = null;
-      return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
-  /**
-   * Handle the `'mousemove'` event for the widget.
-   */
-  private _evtMousemove(event: MouseEvent): void {
-    // Bail if we are already dragging.
-    if (this.drag) {
-      return;
-    }
-
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Check for a drag initialization.
-    let data = this._clickData;
-    let dx = Math.abs(event.clientX - data.pressX);
-    let dy = Math.abs(event.clientY - data.pressY);
-    if (dx < DRAG_THRESHOLD && dy < DRAG_THRESHOLD) {
-      return;
-    }
-
-    this.startDrag(data.handle, event.clientX, event.clientY);
-    this._clickData = null;
-  }
 
   /**
    * Handle the `'p-dragenter'` event for the widget.
@@ -538,11 +251,7 @@ class DragPanel extends Panel {
   private _evtDragLeave(event: IDragEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    // Clear drop target:
-    let elements = this.node.getElementsByClassName(DROP_TARGET_CLASS);
-    if (elements.length) {
-      (elements[0] as HTMLElement).classList.remove(DROP_TARGET_CLASS);
-    }
+    this._clearDropTarget();
   }
 
   /**
@@ -552,11 +261,11 @@ class DragPanel extends Panel {
     if (!this.acceptDropsFromExternalSource && event.source !== this) {
       return;
     }
+    this._clearDropTarget();
     let target = this.findDropTarget(event.target as HTMLElement, event.mimeData);
     if (target === null) {
       return;
     }
-    this._clearDropTarget();
     target.classList.add(DROP_TARGET_CLASS);
     event.preventDefault();
     event.stopPropagation();
@@ -576,6 +285,287 @@ class DragPanel extends Panel {
       (elements[0] as HTMLElement).classList.remove(DROP_TARGET_CLASS);
     }
   }
+};
+
+
+
+/**
+ * A  panel class which allows the user to drop mime data onto it.
+ *
+ * To complete the class, the following functions need to be implemented:
+ *  - processDrop: Process pre-screened drop events
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - findDropTarget(): Override if anything other than the direct children
+ *    of the widget's node are to be the drop targets.
+ *
+ * For maximum control, `evtDrop` can be overriden.
+ */
+export
+abstract class DropPanel extends DropWidget implements IPanel {
+  /**
+   * Construct a drop panel.
+   */
+  constructor(options: DropPanel.IOptions={}) {
+    super(options);  // DropWidget ctor
+    Panel.apply(this, [options]);  // Panel constructor
+  }
+
+  // Shims for applyMixins:
+  widgets: ISequence<Widget>;
+  addWidget(widget: Widget): void;
+  insertWidget(index: number, widget: Widget): void;
+}
+applyMixins(DropPanel, [Panel]);
+
+
+/**
+ * An internal base class for implementing drag operations.
+ *
+ * To complete the class, the following functions need to be implemented:
+ * - processDrop: Process pre-screened drop events
+ * - addMimeData: Adds mime data to new drag events
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - findDropTarget(): Override if anything other than the direct children
+ *    of the widget's node are to be the drop targets.
+ *  - findDragTarget(): Override if anything other than the driect children
+ *    of the widget's node are to be drag targets.
+ */
+export
+abstract class DragDropWidgetBase extends DropWidget {
+
+  /**
+   * Construct a drag and drop base widget.
+   */
+  constructor(options: DragDropWidget.IOptions={}) {
+    super(options);
+    this.childrenAreDragHandles = options.childrenAreDragHandles === true;
+    this.addClass(DRAG_WIDGET_CLASS);
+  }
+
+
+  /**
+   * Whether all direct children of the widget are handles, or only those
+   * designated as handles. Defaults to false.
+   */
+  childrenAreDragHandles: boolean;
+
+  /**
+   * Dispose of the resources held by the directory listing.
+   */
+  dispose(): void {
+    this.drag = null;
+    this._clickData = null;
+    super.dispose();
+  }
+
+  /**
+   * Handle the DOM events for the widget.
+   *
+   * @param event - The DOM event sent to the widget.
+   *
+   * #### Notes
+   * This method implements the DOM `EventListener` interface and is
+   * called in response to events on the dock panel's node. It should
+   * not be called directly by user code.
+   */
+  handleEvent(event: Event): void {
+    switch (event.type) {
+    case 'mousedown':
+      this._evtDragMousedown(event as MouseEvent);
+      break;
+    case 'mouseup':
+      this._evtDragMouseup(event as MouseEvent);
+      break;
+    case 'mousemove':
+      this._evtDragMousemove(event as MouseEvent);
+      break;
+    default:
+      super.handleEvent(event);
+      break;
+    }
+  }
+
+  /**
+   * Adds mime data represeting the drag data to the drag event's MimeData bundle.
+   */
+  protected abstract addMimeData(handle: HTMLElement, mimeData: MimeData): void;
+
+  /**
+   * Finds the drag target (the node to move) from a drag handle.
+   *
+   * Returns null if no valid drag target was found.
+   *
+   * The default implementation returns the direct child that is the ancestor of
+   * (or equal to) the handle.
+   */
+  protected findDragTarget(handle: HTMLElement): HTMLElement {
+    return findChild(this.node, handle);
+  }
+
+  /**
+   * Returns the drag image to use when dragging using the given handle.
+   *
+   * The default implementation returns a clone of the drag target.
+   */
+  protected getDragImage(handle: HTMLElement): HTMLElement {
+    return this.findDragTarget(handle).cloneNode(true) as HTMLElement;
+  }
+
+  /**
+   * Called when a drag has completed with this panel as a source
+   */
+  protected onDragComplete(action: DropAction) {
+    this.drag = null;
+  }
+
+  /**
+   * Handle `after_attach` messages for the widget.
+   */
+  protected onAfterAttach(msg: Message): void {
+    let node = this.node;
+    node.addEventListener('mousedown', this);
+    super.onAfterAttach(msg);
+  }
+
+  /**
+   * Handle `before_detach` messages for the widget.
+   */
+  protected onBeforeDetach(msg: Message): void {
+    let node = this.node;
+    node.removeEventListener('click', this);
+    node.removeEventListener('dblclick', this);
+    document.removeEventListener('mousemove', this, true);
+    document.removeEventListener('mouseup', this, true);
+    super.onBeforeDetach(msg);
+  }
+
+  /**
+   * Start a drag event.
+   *
+   * Called when dragginging and DRAG_THRESHOLD is met.
+   *
+   * Should normally only be overriden if you cannot achive your goal by
+   * other overrides.
+   */
+  protected startDrag(handle: HTMLElement, clientX: number, clientY: number): void {
+    // Create the drag image.
+    let dragImage = this.getDragImage(handle);
+
+    // Set up the drag event.
+    this.drag = new Drag({
+      dragImage: dragImage,
+      mimeData: new MimeData(),
+      supportedActions: 'all',
+      proposedAction: 'copy',
+      source: this
+    });
+    this.addMimeData(handle, this.drag.mimeData);
+
+    // Start the drag and remove the mousemove listener.
+    this.drag.start(clientX, clientY).then(this.onDragComplete.bind(this));
+    document.removeEventListener('mousemove', this, true);
+    document.removeEventListener('mouseup', this, true);
+  }
+
+  /**
+   * Drag data stored in _startDrag
+   */
+  protected drag: Drag = null;
+
+  protected dragHandleClass = DRAG_HANDLE;
+
+  /**
+   * Check if node, or any of nodes ancestors are a drag handle
+   *
+   * If it is a drag handle, it returns the handle, if not returns null.
+   */
+  private _findDragHandle(node: HTMLElement): HTMLElement {
+    let handle: HTMLElement = null;
+    if (this.childrenAreDragHandles) {
+      // Simple scenario, just look for node among children
+      if (belongsToUs(node, DRAG_WIDGET_CLASS, this.node)) {
+        handle = node;
+      }
+    } else {
+      // Otherwise, traverse up DOM to check if click is on a drag handle
+      while (node && node !== this.node) {
+        if (node.classList.contains(this.dragHandleClass)) {
+          handle = node;
+          break;
+        }
+        node = node.parentElement;
+      }
+      // Finally, check that handle does not belong to a nested drag panel
+      if (handle !== null && !belongsToUs(
+          handle, DRAG_WIDGET_CLASS, this.node)) {
+        // Handle belongs to a nested drag panel:
+        handle = null;
+      }
+    }
+    return handle;
+  }
+
+  /**
+   * Handle the `'mousedown'` event for the widget.
+   */
+  private _evtDragMousedown(event: MouseEvent): void {
+    let target = event.target as HTMLElement;
+    let handle = this._findDragHandle(target);
+    if (handle === null) {
+      return;
+    }
+
+    // Left mouse press for drag start.
+    if (event.button === 0) {
+      this._clickData = { pressX: event.clientX, pressY: event.clientY,
+                        handle: handle };
+      document.addEventListener('mouseup', this, true);
+      document.addEventListener('mousemove', this, true);
+    }
+  }
+
+
+  /**
+   * Handle the `'mouseup'` event for the widget.
+   */
+  private _evtDragMouseup(event: MouseEvent): void {
+    if (event.button !== 0 || !this.drag) {
+      document.removeEventListener('mousemove', this, true);
+      document.removeEventListener('mouseup', this, true);
+      this.drag = null;
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  /**
+   * Handle the `'mousemove'` event for the widget.
+   */
+  private _evtDragMousemove(event: MouseEvent): void {
+    // Bail if we are already dragging.
+    if (this.drag) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Check for a drag initialization.
+    let data = this._clickData;
+    let dx = Math.abs(event.clientX - data.pressX);
+    let dy = Math.abs(event.clientY - data.pressY);
+    if (dx < DRAG_THRESHOLD && dy < DRAG_THRESHOLD) {
+      return;
+    }
+
+    this.startDrag(data.handle, event.clientX, event.clientY);
+    this._clickData = null;
+  }
 
   /**
    * Data stored on mouse down to determine if drag treshold has
@@ -584,25 +574,336 @@ class DragPanel extends Panel {
   private _clickData: { pressX: number, pressY: number, handle: HTMLElement } = null;
 }
 
-defineSignal(DragPanel.prototype, 'moved');
+/**
+ * A widget which allows the user to initiate drag operations.
+ *
+ * To complete the class, the following functions need to be implemented:
+ * - addMimeData: Adds mime data to new drag events
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - findDragTarget(): Override if anything other than the driect children
+ *    of the widget's node are to be drag targets.
+ */
+export
+abstract class DragWidget extends DragDropWidgetBase {
+  /**
+   * Construct a drag widget.
+   */
+  constructor(options: DragWidget.IOptions={}) {
+    // Implementation removes DropWidget options
+    super(options);
+  }
+
+  /**
+   * No-op on DragWidget, as it does not support dropping
+   */
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+    // Intentionally empty
+  }
+
+  /**
+   * Simply returns null for DragWidget, as it does not support dropping
+   */
+  protected findDropTarget(input: HTMLElement, mimeData: MimeData): HTMLElement {
+    return null;
+  }
+
+}
+
+/**
+ * A panel which allows the user to initiate drag operations.
+ *
+ * To complete the class, the following functions need to be implemented:
+ * - addMimeData: Adds mime data to new drag events
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - findDragTarget(): Override if anything other than the driect children
+ *    of the widget's node are to be drag targets.
+ */
+export
+abstract class DragPanel extends DragWidget implements IPanel {
+  /**
+   * Construct a drag panel.
+   */
+  constructor(options: DragPanel.IOptions={}) {
+    super(options);
+    Panel.apply(this, options);
+  }
+
+  // Shims for applyMixins:
+  widgets: ISequence<Widget>;
+  addWidget(widget: Widget): void;
+  insertWidget(index: number, widget: Widget): void;
+}
+applyMixins(DragPanel, [Panel]);
 
 
 /**
- * The namespace for the `DragPanel` class statics.
+ * A widget which allows the user to rearrange elements by drag and drop.
+ *
+ * Any descendant element with the drag handle class `'jp-mod-dragHandle'`
+ * will serve as a handle that can be used for dragging. If DragWidgets are
+ * nested, handles will only belong to the closest parent DragWidget. For
+ * convenience, the functions `makeHandle`, `unmakeHandle` and
+ * `createDefaultHandle` can be used to indicate which elements should be
+ * made handles. `createDefaultHandle` will create a new element as a handle
+ * with a default styling class applied. Optionally, `childrenAreDragHandles`
+ * can be set to indicate that all direct children are themselve drag handles.
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - move(): Override to add custom processing of move command, for example
+ *    by performing the move in a model instead of on widgets. A possible
+ *    alternative to overriding `move` is to connect to the `moved` signal.
+ *  - addMimeData: Override to add other drag data to the mime bundle.
+ *    This is often a necessary step for allowing dragging to external
+ *    drop targets.
+ *  - processDrop: Override if you need to handle other mime data than the
+ *    default. For allowing drops from external sources, the field
+ *    `acceptDropsFromExternalSource` should be set as well.
+ *  - getDragImage: Override to change the drag image (the default is a
+ *    copy of the element being dragged).
+ *
+ * To drag and drop other things than all direct children, the following functions
+ * should be overriden: `findDragTarget`, `findDropTarget` and possibly
+ * `getIndexOfChildNode` and `move` to allow for custom to/from keys.
+ *
+ * For maximum control, `startDrag` and `evtDrop` can be overriden.
  */
 export
-namespace DragPanel {
+abstract class DragDropWidget extends DragDropWidgetBase {
+
+  /**
+   * Signal that is emitted after a widget has been moved internally in the list.
+   *
+   * The first argument is the panel in which the move occurred.
+   * The second argument is the old and the new keys of the widget.
+   *
+   * In the default implementation the keys are indices to the widget positions
+   */
+  moved: ISignal<DragWidget, {from: any, to: any}>;
+
+  /**
+   * Called when a widget should be moved as a consequence of an internal drag event.
+   */
+  protected abstract move(from: any, to: any): void;
+
+  /**
+   * Returns a key used to represent the child node.
+   *
+   * Returns null if not found.
+   */
+  protected abstract getIndexOfChildNode(node: HTMLElement, parent?: Panel): any;
+
+  /**
+   * Adds mime data represeting the drag data to the drag event's MimeData bundle.
+   *
+   * The default implementation adds mime data indicating the index of the direct
+   * child being dragged (as indicated by findDragTarget).
+   *
+   * Override this method if you have data that cannot be communicated well by an
+   * index, for example if the data should be able to be dropped on an external
+   * target that only understands direct mime data.
+   *
+   * As the method simply adds mime data for a specific key, overriders can call
+   * this method before/after adding their own mime data to still support default
+   * dragging behavior.
+   */
+  protected addMimeData(handle: HTMLElement, mimeData: MimeData): void {
+    let target = this.findDragTarget(handle);
+    let key = this.getIndexOfChildNode(target);
+
+    if (key !== null) {
+      mimeData.setData(MIME_INDEX, key);
+    }
+  }
+
+  /**
+   * Processes a drop event.
+   *
+   * This function is called after checking:
+   *  - That the `dropTarget` is a valid drop target
+   *  - The value of `event.source` if `acceptDropsFromExternalSource` is true
+   *
+   * The default implementation assumes calling `getIndexOfChildNode` with
+   * `dropTarget` will be valid. It will call `move` with that index as `to`,
+   * and the index stored in the mime data as `from`.
+   *
+   * Override this if you need to handle other mime data than the default.
+   */
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+    if (!DropWidget.isValidAction(event.supportedActions, 'move') ||
+        event.proposedAction === 'none') {
+      // The default implementation only handles move action
+      // OR Accept proposed none action, and perform no-op
+      event.dropAction = 'none';
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (event.source !== this) {
+      // Source indicates external drop, incorrect use in subclass
+      throw 'Invalid source!';
+    }
+    let sourceKey = event.mimeData.getData(MIME_INDEX);
+    let targetKey = this.getIndexOfChildNode(dropTarget);
+    if (targetKey === null) {
+      // Invalid target somehow
+      return;
+    }
+
+    // We have an acceptable drop, handle:
+    this.move(sourceKey, targetKey);
+    event.preventDefault();
+    event.stopPropagation();
+    event.dropAction = 'move';
+  }
+}
+defineSignal(DragDropWidget.prototype, 'moved');
+
+
+/**
+ * A widget which allows the user to rearrange elements by drag and drop.
+ *
+ * Any descendant element with the drag handle class `'jp-mod-dragHandle'`
+ * will serve as a handle that can be used for dragging. If DragWidgets are
+ * nested, handles will only belong to the closest parent DragWidget. For
+ * convenience, the functions `makeHandle`, `unmakeHandle` and
+ * `createDefaultHandle` can be used to indicate which elements should be
+ * made handles. `createDefaultHandle` will create a new element as a handle
+ * with a default styling class applied. Optionally, `childrenAreDragHandles`
+ * can be set to indicate that all direct children are themselve drag handles.
+ *
+ * The functionallity of the class can be extended by overriding the following
+ * functions:
+ *  - move(): Override to add custom processing of move command, for example
+ *    by performing the move in a model instead of on widgets. A possible
+ *    alternative to overriding `move` is to connect to the `moved` signal.
+ *  - addMimeData: Override to add other drag data to the mime bundle.
+ *    This is often a necessary step for allowing dragging to external
+ *    drop targets.
+ *  - processDrop: Override if you need to handle other mime data than the
+ *    default. For allowing drops from external sources, the field
+ *    `acceptDropsFromExternalSource` should be set as well.
+ *  - getDragImage: Override to change the drag image (the default is a
+ *    copy of the element being dragged).
+ *
+ * To drag and drop other things than all direct children, the following functions
+ * should be overriden: `findDragTarget`, `findDropTarget` and possibly
+ * `getIndexOfChildNode` and `move` to allow for custom to/from keys.
+ *
+ * For maximum control, `startDrag` and `evtDrop` can be overriden.
+ */
+class DragDropPanel extends DragDropWidget implements IPanel {
+  /**
+   * Construct a drag and drop panel.
+   */
+  constructor(options: DragDropPanel.IOptions={}) {
+    super(options);
+    Panel.apply(this, options);
+  }
+
+  // Shims for applyMixins:
+  widgets: ISequence<Widget>;
+  addWidget(widget: Widget): void { /* shim */ };
+  insertWidget(index: number, widget: Widget): void { /* shim */ };
+
+  /**
+   * Called when a widget should be moved as a consequence of an internal drag event.
+   *
+   * The default implementation assumes the keys `from` and `to` are numbers
+   * indexing the drag panels direct children. It then moves the direct child as
+   * specified by these keys, then emits the `moved` signal.
+   */
+  protected move(from: any, to: any): void {
+    if (to !== from) {
+      // Adjust for the shifting of elements once 'from' is removed
+      if (to > from) {
+        to -= 1;
+      }
+      this.insertWidget(to, this.widgets.at(from));
+      this.moved.emit({from: from, to: to});
+    }
+  }
+
+  /**
+   * Returns a key used to represent the child node.
+   *
+   * The default implementation returns the index of node in `layout.widgets`.
+   *
+   * Returns null if not found.
+   */
+  protected getIndexOfChildNode(node: HTMLElement, parent?: Panel): any {
+    parent = parent || this;
+    for (let i = 0; i < parent.widgets.length; i++) {
+      if (parent.widgets.at(i).node === node) {
+        return i;
+      }
+    }
+    return null;
+  }
+}
+applyMixins(DragDropPanel, [Panel]);
+
+
+/**
+ * Determine whether node is equal to or a decendant of our panel, and that is does
+ * not belong to a nested drag panel.
+ */
+export
+function belongsToUs(node: HTMLElement, parentClass: string,
+                     parentNode: HTMLElement): boolean {
+  // Traverse DOM until drag panel encountered:
+  while (node && !node.classList.contains(parentClass)) {
+    node = node.parentElement;
+  }
+  return node && node === parentNode;
+}
+
+
+/**
+ * Find the direct child node of `parent`, which has `node` as a descendant.
+ * Alternatively, parent can be a collection of children.
+ *
+ * Returns null if not found.
+ *
+ * It is normally not recommended to overload this function, but to rather
+ * overload `findDragTarget`/`findDropTarget`.
+ */
+export
+function findChild(parent: HTMLElement | HTMLElement[], node: HTMLElement): HTMLElement {
+  // Work our way up the DOM to an element which has this node as parent
+  let child: HTMLElement = null;
+  let parentIsArray = Array.isArray(parent);
+  let isDirectChild = (child: HTMLElement): boolean => {
+    if (parentIsArray) {
+      return (parent as HTMLElement[]).indexOf(child) > -1;
+    } else {
+      return child.parentElement === node.parentElement;
+    }
+  };
+  while (node && node !== parent) {
+    if (isDirectChild(node)) {
+      child = node;
+      break;
+    }
+    node = node.parentElement;
+  }
+  return child;
+}
+
+/**
+ * The namespace for the `DropWidget` class statics.
+ */
+export
+namespace DropWidget {
   /**
    * An options object for initializing a drag panel widget.
    */
   export
-  interface IOptions extends Panel.IOptions {
-    /**
-     * Whether all direct children of the list are handles, or only those widgets
-     * designated as handles. Defaults to false.
-     */
-    childrenAreDragHandles?: boolean;
-
+  interface IOptions extends Widget.IOptions {
     /**
      * Whether the lsit should accept drops from an external source.
      * Defaults to false.
@@ -613,6 +914,9 @@ namespace DragPanel {
     acceptDropsFromExternalSource?: boolean;
   }
 
+  /**
+   * Validate a drop action against a SupportedActions type
+   */
   export
   function isValidAction(supported: SupportedActions, action: DropAction): boolean {
     switch (supported) {
@@ -628,12 +932,43 @@ namespace DragPanel {
       return action === supported;
     }
   }
+}
+
+/**
+ * The namespace for the `DropPanel` class statics.
+ */
+export
+namespace DropPanel {
+  /**
+   * An options object for initializing a drag panel widget.
+   */
+  export
+  interface IOptions extends DropWidget.IOptions, Panel.IOptions {
+  }
+}
+
+/**
+ * The namespace for the `DragWidget` class statics.
+ */
+export
+namespace DragWidget {
+  /**
+   * An options object for initializing a drag panel widget.
+   */
+  export
+  interface IOptions {
+    /**
+     * Whether all direct children of the list are handles, or only those widgets
+     * designated as handles. Defaults to false.
+     */
+    childrenAreDragHandles?: boolean;
+  }
 
   /**
    * Mark a widget as a drag handle.
    *
    * Using this, any child-widget can be a drag handle, as long as mouse events
-   * are propagated from it to the DragPanel.
+   * are propagated from it to the DragWidget.
    */
   export
   function makeHandle(handle: Widget) {
@@ -649,7 +984,7 @@ namespace DragPanel {
   }
 
   /**
-   * Create a default handle widget for dragging (see styling in dragpanel.css).
+   * Create a default handle widget for dragging (see styling in DragWidget.css).
    *
    * The handle will need to be styled to ensure a minimum size
    */
@@ -659,5 +994,38 @@ namespace DragPanel {
     widget.addClass(DEFAULT_DRAG_HANDLE_CLASS);
     makeHandle(widget);
     return widget;
+  }
+}
+
+/**
+ * The namespace for the `DragPanel` class statics.
+ */
+export
+namespace DragPanel {
+  /**
+   * An options object for initializing a drag panel widget.
+   */
+  export
+  interface IOptions extends DragWidget.IOptions, Panel.IOptions {
+  }
+}
+
+/**
+ * The namespace for the `DragDropWidget` class statics.
+ */
+export
+namespace DragDropWidget {
+  export
+  interface IOptions extends DragWidget.IOptions, DropWidget.IOptions {
+  }
+}
+
+/**
+ * The namespace for the `DragDropPanel` class statics.
+ */
+export
+namespace DragDropPanel {
+  export
+  interface IOptions extends DragDropWidget.IOptions, Panel.IOptions {
   }
 }

--- a/src/common/dragpanel.ts
+++ b/src/common/dragpanel.ts
@@ -624,7 +624,9 @@ namespace DragPanel {
   }
 
   /**
-   * Create a default handle widget for dragging (see styling in dragpanel.css)
+   * Create a default handle widget for dragging (see styling in dragpanel.css).
+   *
+   * The handle will need to be styled to ensure a minimum size
    */
   export
   function createDefaultHandle(): Widget {

--- a/src/common/index.css
+++ b/src/common/index.css
@@ -1,0 +1,8 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2016, Jupyter Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|----------------------------------------------------------------------------*/
+
+
+@import './dragpanel.css';

--- a/src/default-theme/index.css
+++ b/src/default-theme/index.css
@@ -17,6 +17,7 @@
 @import '../about/index.css';
 @import '../codemirror/index.css';
 @import '../commandpalette/index.css';
+@import '../common/index.css';
 @import '../console/index.css';
 @import '../csvwidget/index.css';
 @import '../dialog/index.css';

--- a/src/filebrowser/crumbs.ts
+++ b/src/filebrowser/crumbs.ts
@@ -10,8 +10,12 @@ import {
 } from 'phosphor/lib/core/messaging';
 
 import {
-  Widget
-} from 'phosphor/lib/ui/widget';
+  MimeData
+} from 'phosphor/lib/core/mimedata';
+
+import {
+  DropWidget, findChild
+} from '../common/dragpanel';
 
 import {
   FileBrowserModel
@@ -41,7 +45,7 @@ const BREAD_CRUMB_PATHS = ['/', '../../', '../', ''];
  * A class which hosts folder breadcrumbs.
  */
 export
-class BreadCrumbs extends Widget {
+class BreadCrumbs extends DropWidget {
 
   /**
    * Construct a new file browser crumb widget.
@@ -49,7 +53,9 @@ class BreadCrumbs extends Widget {
    * @param model - The file browser view model.
    */
   constructor(options: BreadCrumbs.IOptions) {
-    super();
+    super({
+      acceptDropsFromExternalSource: true
+    });
     this._model = options.model;
     this.addClass(BREADCRUMB_CLASS);
     this._crumbs = Private.createCrumbs();
@@ -73,19 +79,8 @@ class BreadCrumbs extends Widget {
     case 'click':
       this._evtClick(event as MouseEvent);
       break;
-    case 'p-dragenter':
-      this._evtDragEnter(event as IDragEvent);
-      break;
-    case 'p-dragleave':
-      this._evtDragLeave(event as IDragEvent);
-      break;
-    case 'p-dragover':
-      this._evtDragOver(event as IDragEvent);
-      break;
-    case 'p-drop':
-      this._evtDrop(event as IDragEvent);
-      break;
     default:
+      super.handleEvent(event);
       return;
     }
   }
@@ -97,10 +92,6 @@ class BreadCrumbs extends Widget {
     super.onAfterAttach(msg);
     let node = this.node;
     node.addEventListener('click', this);
-    node.addEventListener('p-dragenter', this);
-    node.addEventListener('p-dragleave', this);
-    node.addEventListener('p-dragover', this);
-    node.addEventListener('p-drop', this);
   }
 
   /**
@@ -110,11 +101,65 @@ class BreadCrumbs extends Widget {
     super.onBeforeDetach(msg);
     let node = this.node;
     node.removeEventListener('click', this);
-    node.removeEventListener('p-dragenter', this);
-    node.removeEventListener('p-dragleave', this);
-    node.removeEventListener('p-dragover', this);
-    node.removeEventListener('p-drop', this);
   }
+
+  /**
+   * Find a drop target from a given drag event target.
+   *
+   * Returns the crumb that is being dropped on, if not the
+   * current crumb, otherwise returns null.
+   *
+   * Overrides method from `DropPanel`.
+   */
+  protected findDropTarget(input: HTMLElement, mimeData: MimeData): HTMLElement {
+    if (mimeData.hasData(utils.CONTENTS_MIME)) {
+      let child = findChild(this._crumbs, input);
+      let index = this._crumbs.indexOf(child);
+      if (index !== -1 && index !== Private.Crumb.Current) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Processes a drop event.
+   *
+   * This function is called after checking:
+   *  - That the `dropTarget` is a valid drop target
+   *  - The value of `event.source` if `acceptDropsFromExternalSource` is true
+   *
+   * Overrides method from `DropPanel`.
+   */
+  protected processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+    // Get the path based on the target node.
+    let index = this._crumbs.indexOf(dropTarget);
+    if (index === -1) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    if (!DropWidget.isValidAction(event.supportedActions, 'move') ||
+        event.proposedAction === 'none') {
+      // The default implementation only handles move action
+      // OR Accept proposed none action, and perform no-op
+      event.dropAction = 'none';
+      return;
+    }
+    event.dropAction = 'move';
+    let path = BREAD_CRUMB_PATHS[index];
+
+    // Move all of the items.
+    let names = event.mimeData.getData(utils.CONTENTS_MIME) as string[];
+    let promises = utils.moveConditionalOverwrite(
+      path, names, this._model
+    );
+    Promise.all(promises).then(
+      () => this._model.refresh(),
+      err => utils.showErrorMessage(this, 'Move Error', err)
+    );
+  }
+
 
   /**
    * A handler invoked on an `'update-request'` message.
@@ -149,91 +194,6 @@ class BreadCrumbs extends Widget {
       }
       node = node.parentElement;
     }
-  }
-
-  /**
-   * Handle the `'p-dragenter'` event for the widget.
-   */
-  private _evtDragEnter(event: IDragEvent): void {
-    if (event.mimeData.hasData(utils.CONTENTS_MIME)) {
-      let index = utils.hitTestNodes(this._crumbs, event.clientX, event.clientY);
-      if (index !== -1) {
-        if (index !== Private.Crumb.Current) {
-          this._crumbs[index].classList.add(utils.DROP_TARGET_CLASS);
-          event.preventDefault();
-          event.stopPropagation();
-        }
-      }
-    }
-  }
-
-  /**
-   * Handle the `'p-dragleave'` event for the widget.
-   */
-  private _evtDragLeave(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    let dropTarget = utils.findElement(this.node, utils.DROP_TARGET_CLASS);
-    if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
-    }
-  }
-
-  /**
-   * Handle the `'p-dragover'` event for the widget.
-   */
-  private _evtDragOver(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    event.dropAction = event.proposedAction;
-    let dropTarget = utils.findElement(this.node, utils.DROP_TARGET_CLASS);
-    if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
-    }
-    let index = utils.hitTestNodes(this._crumbs, event.clientX, event.clientY);
-    if (index !== -1) {
-      this._crumbs[index].classList.add(utils.DROP_TARGET_CLASS);
-    }
-  }
-
-  /**
-   * Handle the `'p-drop'` event for the widget.
-   */
-  private _evtDrop(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    if (event.proposedAction === 'none') {
-      event.dropAction = 'none';
-      return;
-    }
-    if (!event.mimeData.hasData(utils.CONTENTS_MIME)) {
-      return;
-    }
-    event.dropAction = event.proposedAction;
-
-    let target = event.target as HTMLElement;
-    while (target && target.parentElement) {
-      if (target.classList.contains(utils.DROP_TARGET_CLASS)) {
-        target.classList.remove(utils.DROP_TARGET_CLASS);
-        break;
-      }
-      target = target.parentElement;
-    }
-
-    // Get the path based on the target node.
-    let index = this._crumbs.indexOf(target);
-    if (index === -1) {
-      return;
-    }
-    let path = BREAD_CRUMB_PATHS[index];
-
-    // Move all of the items.
-    let names = event.mimeData.getData(utils.CONTENTS_MIME) as string[];
-    let promises = utils.moveConditionalOverwrite(path, names, this._model);
-    Promise.all(promises).then(
-      () => this._model.refresh(),
-      err => utils.showErrorMessage(this, 'Move Error', err)
-    );
   }
 
   private _model: FileBrowserModel = null;

--- a/src/filebrowser/crumbs.ts
+++ b/src/filebrowser/crumbs.ts
@@ -127,7 +127,7 @@ class BreadCrumbs extends DropWidget {
    *
    * This function is called after checking:
    *  - That the `dropTarget` is a valid drop target
-   *  - The value of `event.source` if `acceptDropsFromExternalSource` is true
+   *  - The value of `event.source` if `acceptDropsFromExternalSource` is false
    *
    * Overrides method from `DropPanel`.
    */

--- a/src/filebrowser/listing.ts
+++ b/src/filebrowser/listing.ts
@@ -18,16 +18,12 @@ import {
 } from 'phosphor/lib/core/mimedata';
 
 import {
-  Drag, IDragEvent
+  DropAction
 } from 'phosphor/lib/dom/dragdrop';
 
 import {
   scrollIntoViewIfNeeded
 } from 'phosphor/lib/dom/query';
-
-import {
-  Widget
-} from 'phosphor/lib/ui/widget';
 
 import {
   humanTime, dateTime
@@ -53,8 +49,12 @@ import * as utils
   from './utils';
 
 import {
-  SELECTED_CLASS, showErrorMessage, moveConditionalOverwrite
+  SELECTED_CLASS, showErrorMessage
 } from './utils';
+
+import {
+  DragDropWidget, MIME_INDEX, findChild
+} from '../common/dragpanel';
 
 
 /**
@@ -168,11 +168,6 @@ const DESCENDING_CLASS = 'jp-mod-descending';
 const RENAME_DURATION = 500;
 
 /**
- * The threshold in pixels to start a drag event.
- */
-const DRAG_THRESHOLD = 5;
-
-/**
  * A boolean indicating whether the platform is Mac.
  */
 const IS_MAC = !!navigator.platform.match(/Mac/i);
@@ -187,7 +182,7 @@ const FACTORY_MIME = 'application/vnd.phosphor.widget-factory';
  * A widget which hosts a file list area.
  */
 export
-class DirListing extends Widget {
+class DirListing extends DragDropWidget {
   /**
    * Construct a new file browser directory listing widget.
    *
@@ -195,8 +190,10 @@ class DirListing extends Widget {
    */
   constructor(options: DirListing.IOptions) {
     super({
-      node: (options.renderer || DirListing.defaultRenderer).createNode()
+      node: (options.renderer || DirListing.defaultRenderer).createNode(),
+      acceptDropsFromExternalSource: false
     });
+    this.dragHandleClass = ITEM_CLASS;
     this.addClass(DIR_LISTING_CLASS);
     this._model = options.model;
     this._model.refreshed.connect(this._onModelRefreshed, this);
@@ -217,8 +214,6 @@ class DirListing extends Widget {
     this._model = null;
     this._items = null;
     this._editNode = null;
-    this._drag = null;
-    this._dragData = null;
     this._manager = null;
     this._opener = null;
     super.dispose();
@@ -522,9 +517,6 @@ class DirListing extends Widget {
     case 'mouseup':
       this._evtMouseup(event as MouseEvent);
       break;
-    case 'mousemove':
-      this._evtMousemove(event as MouseEvent);
-      break;
     case 'keydown':
       this._evtKeydown(event as KeyboardEvent);
       break;
@@ -540,19 +532,8 @@ class DirListing extends Widget {
     case 'scroll':
       this._evtScroll(event as MouseEvent);
       break;
-    case 'p-dragenter':
-      this._evtDragEnter(event as IDragEvent);
-      break;
-    case 'p-dragleave':
-      this._evtDragLeave(event as IDragEvent);
-      break;
-    case 'p-dragover':
-      this._evtDragOver(event as IDragEvent);
-      break;
-    case 'p-drop':
-      this._evtDrop(event as IDragEvent);
-      break;
     default:
+      super.handleEvent(event);
       break;
     }
   }
@@ -564,16 +545,11 @@ class DirListing extends Widget {
     super.onAfterAttach(msg);
     let node = this.node;
     let content = utils.findElement(node, CONTENT_CLASS);
-    node.addEventListener('mousedown', this);
     node.addEventListener('keydown', this);
     node.addEventListener('click', this);
     node.addEventListener('dblclick', this);
     node.addEventListener('contextmenu', this);
     content.addEventListener('scroll', this);
-    content.addEventListener('p-dragenter', this);
-    content.addEventListener('p-dragleave', this);
-    content.addEventListener('p-dragover', this);
-    content.addEventListener('p-drop', this);
   }
 
   /**
@@ -583,16 +559,11 @@ class DirListing extends Widget {
     super.onBeforeDetach(msg);
     let node = this.node;
     let content = utils.findElement(node, CONTENT_CLASS);
-    node.removeEventListener('mousedown', this);
     node.removeEventListener('keydown', this);
     node.removeEventListener('click', this);
     node.removeEventListener('dblclick', this);
     node.removeEventListener('contextmenu', this);
     content.removeEventListener('scroll', this);
-    content.removeEventListener('p-dragenter', this);
-    content.removeEventListener('p-dragleave', this);
-    content.removeEventListener('p-dragover', this);
-    content.removeEventListener('p-drop', this);
     document.removeEventListener('mousemove', this, true);
     document.removeEventListener('mouseup', this, true);
   }
@@ -665,6 +636,134 @@ class DirListing extends Widget {
   }
 
   /**
+   * Finds the drag target (the item to move) from a drag handle.
+   *
+   * Returns null if no valid drag target was found.
+   *
+   * Overrides method from `DragPanel`.
+   */
+  protected findDragTarget(handle: HTMLElement): HTMLElement {
+    return findChild(this._items, handle);
+  }
+
+  /**
+   * Find a drop target from a given drag event target.
+   *
+   * Returns null if no valid drop target was found.
+   *
+   * The default implementation returns the node that is the parent of
+   * `input`, if that node represents a directory item, that is currently
+   * not selected.
+   *
+   * Overrides method from `DragPanel`.
+   */
+  protected findDropTarget(input: HTMLElement, mimeData: MimeData): HTMLElement {
+    // Currently rely on disallowing external drops to assure correct mime data
+    let child = findChild(this._items, input);
+    let index = this.getIndexOfChildNode(child);
+    if (index !== null) {
+      let item = this.sortedItems[index];
+      if (item.type === 'directory' && !this._selection[item.name]) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the index of node in `_items`.
+   *
+   * Returns null if not found.
+   */
+  protected getIndexOfChildNode(node: HTMLElement): number {
+    let index = this._items.indexOf(node);
+    return index > -1 ? index : null;
+  }
+
+  /**
+   * Called when a widget should be moved as a consequence of an internal drag event.
+   *
+   * Moves the files and directories specified to the directory that index
+   * points to.
+   */
+  protected move(names: string[], index: number) {
+    // Move all of the items.
+    let path = this.sortedItems[index].name + '/';
+    let promises = utils.moveConditionalOverwrite(
+      path, names, this._model
+    );
+    Promise.all(promises).then(
+      () => {
+        this.moved.emit({to: index, from: names});
+        this._model.refresh();
+      },
+      error => utils.showErrorMessage(this, 'Move Error', error)
+    );
+  }
+
+  /**
+   * Add mime data for drag and drop opertaion
+   */
+  protected addMimeData(handle: HTMLElement, mimeData: MimeData): void {
+    let source = this.findDragTarget(handle);
+    let index = this.getIndexOfChildNode(source);
+    let selectedNames = Object.keys(this._selection);
+    let model = this._model;
+    let items = this.sortedItems;
+    let item: IContents.IModel = null;
+
+    // If the source node is not selected, use just that node.
+    if (!source.classList.contains(SELECTED_CLASS)) {
+      item = items[index];
+      selectedNames = [item.name];
+    } else if (selectedNames.length === 1) {
+      let name = selectedNames[0];
+      item = find(items, value => value.name === name);
+    }
+
+    mimeData.setData(utils.CONTENTS_MIME, selectedNames);
+    // Piggy-back on DragPanel processDrop by adding this:
+    mimeData.setData(MIME_INDEX, selectedNames);
+    if (item && item.type !== 'directory') {
+      mimeData.setData(FACTORY_MIME, () => {
+        let path = item.path;
+        let widget = this._manager.findWidget(path);
+        if (!widget) {
+          widget = this._manager.open(item.path);
+          let context = this._manager.contextForWidget(widget);
+          context.populated.connect(() => model.refresh() );
+          context.kernelChanged.connect(() => model.refresh() );
+        }
+        return widget;
+      });
+    }
+  }
+
+  /**
+   *
+   */
+  protected onDragComplete(action: DropAction) {
+    super.onDragComplete(action);
+    clearTimeout(this._selectTimer);
+  }
+
+  /**
+   * Returns the drag image to use when dragging using the given handle.
+   */
+  protected getDragImage(handle: HTMLElement) : HTMLElement {
+    let source = this.findDragTarget(handle);
+    let selectedNames = Object.keys(this._selection);
+
+    // If the source node is not selected, use just that node.
+    if (!source.classList.contains(SELECTED_CLASS)) {
+      let index = this.getIndexOfChildNode(source);
+      selectedNames = [this.sortedItems[index].name];
+    }
+    clearTimeout(this._selectTimer);
+    return this.renderer.createDragImage(handle, selectedNames.length);
+  }
+
+  /**
    * Handle the `'click'` event for the widget.
    */
   private _evtClick(event: MouseEvent) {
@@ -730,13 +829,9 @@ class DirListing extends Widget {
 
     // Left mouse press for drag start.
     if (event.button === 0) {
-      this._dragData = { pressX: event.clientX, pressY: event.clientY,
-                         index: index };
-      document.addEventListener('mouseup', this, true);
-      document.addEventListener('mousemove', this, true);
-    }
-
-    if (event.button !== 0) {
+      // Send event to drag panel:
+      super.handleEvent(event);
+    } else {
       clearTimeout(this._selectTimer);
     }
   }
@@ -756,37 +851,7 @@ class DirListing extends Widget {
       }
       this._softSelection = '';
     }
-    // Remove the drag listeners if necessary.
-    if (event.button !== 0 || !this._drag) {
-      document.removeEventListener('mousemove', this, true);
-      document.removeEventListener('mouseup', this, true);
-      return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
-  /**
-   * Handle the `'mousemove'` event for the widget.
-   */
-  private _evtMousemove(event: MouseEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Bail if we are the one dragging.
-    if (this._drag) {
-      return;
-    }
-
-    // Check for a drag initialization.
-    let data = this._dragData;
-    let dx = Math.abs(event.clientX - data.pressX);
-    let dy = Math.abs(event.clientY - data.pressY);
-    if (dx < DRAG_THRESHOLD && dy < DRAG_THRESHOLD) {
-      return;
-    }
-
-    this._startDrag(data.index, event.clientX, event.clientY);
+    super.handleEvent(event);  // Also send event to drag panel
   }
 
   /**
@@ -858,147 +923,6 @@ class DirListing extends Widget {
       }
       this._opener.open(widget);
     }
-  }
-
-
-  /**
-   * Handle the `'p-dragenter'` event for the widget.
-   */
-  private _evtDragEnter(event: IDragEvent): void {
-    if (event.mimeData.hasData(utils.CONTENTS_MIME)) {
-      let index = utils.hitTestNodes(this._items, event.clientX, event.clientY);
-      if (index === -1) {
-        return;
-      }
-      let item = this.sortedItems[index];
-      if (item.type !== 'directory' || this._selection[item.name]) {
-        return;
-      }
-      let target = event.target as HTMLElement;
-      target.classList.add(utils.DROP_TARGET_CLASS);
-      event.preventDefault();
-      event.stopPropagation();
-    }
-  }
-
-  /**
-   * Handle the `'p-dragleave'` event for the widget.
-   */
-  private _evtDragLeave(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    let dropTarget = utils.findElement(this.node, utils.DROP_TARGET_CLASS);
-    if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
-    }
-  }
-
-  /**
-   * Handle the `'p-dragover'` event for the widget.
-   */
-  private _evtDragOver(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    event.dropAction = event.proposedAction;
-    let dropTarget = utils.findElement(this.node, utils.DROP_TARGET_CLASS);
-    if (dropTarget) {
-      dropTarget.classList.remove(utils.DROP_TARGET_CLASS);
-    }
-    let index = utils.hitTestNodes(this._items, event.clientX, event.clientY);
-    this._items[index].classList.add(utils.DROP_TARGET_CLASS);
-  }
-
-  /**
-   * Handle the `'p-drop'` event for the widget.
-   */
-  private _evtDrop(event: IDragEvent): void {
-    event.preventDefault();
-    event.stopPropagation();
-    clearTimeout(this._selectTimer);
-    if (event.proposedAction === 'none') {
-      event.dropAction = 'none';
-      return;
-    }
-    if (!event.mimeData.hasData(utils.CONTENTS_MIME)) {
-      return;
-    }
-    event.dropAction = event.proposedAction;
-
-    let target = event.target as HTMLElement;
-    while (target && target.parentElement) {
-      if (target.classList.contains(utils.DROP_TARGET_CLASS)) {
-        target.classList.remove(utils.DROP_TARGET_CLASS);
-        break;
-      }
-      target = target.parentElement;
-    }
-
-    // Get the path based on the target node.
-    let index = this._items.indexOf(target);
-    let items = this.sortedItems;
-    let path = items[index].name + '/';
-
-    // Move all of the items.
-    let names = event.mimeData.getData(utils.CONTENTS_MIME) as string[];
-    let promises = moveConditionalOverwrite(path, names, this._model);
-    Promise.all(promises).then(
-      () => this._model.refresh(),
-      error => utils.showErrorMessage(this, 'Move Error', error)
-    );
-  }
-
-  /**
-   * Start a drag event.
-   */
-  private _startDrag(index: number, clientX: number, clientY: number): void {
-    let selectedNames = Object.keys(this._selection);
-    let source = this._items[index];
-    let model = this._model;
-    let items = this.sortedItems;
-    let item: IContents.IModel = null;
-
-    // If the source node is not selected, use just that node.
-    if (!source.classList.contains(SELECTED_CLASS)) {
-      item = items[index];
-      selectedNames = [item.name];
-    } else if (selectedNames.length === 1) {
-      let name = selectedNames[0];
-      item = find(items, value => value.name === name);
-    }
-
-    // Create the drag image.
-    let dragImage = this.renderer.createDragImage(source, selectedNames.length);
-
-    // Set up the drag event.
-    this._drag = new Drag({
-      dragImage,
-      mimeData: new MimeData(),
-      supportedActions: 'move',
-      proposedAction: 'move'
-    });
-    this._drag.mimeData.setData(utils.CONTENTS_MIME, selectedNames);
-    if (item && item.type !== 'directory') {
-      this._drag.mimeData.setData(FACTORY_MIME, () => {
-        let path = item.path;
-        let widget = this._manager.findWidget(path);
-        if (!widget) {
-          widget = this._manager.open(item.path);
-          let context = this._manager.contextForWidget(widget);
-          context.populated.connect(() => model.refresh() );
-          context.kernelChanged.connect(() => model.refresh() );
-        }
-        return widget;
-      });
-    }
-
-    // Start the drag and remove the mousemove and mouseup listeners.
-    document.removeEventListener('mousemove', this, true);
-    document.removeEventListener('mouseup', this, true);
-    clearTimeout(this._selectTimer);
-    this._drag.start(clientX, clientY).then(action => {
-      this._drag = null;
-      clearTimeout(this._selectTimer);
-    });
   }
 
   /**
@@ -1223,8 +1147,6 @@ class DirListing extends Widget {
   private _items: HTMLElement[] = [];
   private _sortedModels: IContents.IModel[] = null;
   private _sortState: DirListing.ISortState = { direction: 'ascending', key: 'name' };
-  private _drag: Drag = null;
-  private _dragData: { pressX: number, pressY: number, index: number } = null;
   private _selectTimer = -1;
   private _noSelectTimer = -1;
   private _isCut = false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,3 +30,16 @@ function findElement(parent: HTMLElement, className: string): HTMLElement {
     return elements[0] as HTMLElement;
   }
 }
+
+/**
+ * Apply a mixin
+ */
+export
+function applyMixins(derivedCtor: any, baseCtors: any[]) {
+    baseCtors.forEach(baseCtor => {
+        Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
+            let desc = Object.getOwnPropertyDescriptor(baseCtor.prototype, name);
+            Object.defineProperty(derivedCtor.prototype, name, desc);
+        });
+    });
+}

--- a/test/src/common/dragpanel.spec.ts
+++ b/test/src/common/dragpanel.spec.ts
@@ -31,24 +31,24 @@ describe('common/dragpanel', () => {
       it('should handle empty args', () => {
         let widget = new DragPanel();
         expect(widget).to.be.an(DragPanel);
-        expect(widget.acceptExternalDropSource).to.be(false);
+        expect(widget.acceptDropsFromExternalSource).to.be(false);
         expect(widget.childrenAreDragHandles).to.be(false);
       });
 
       it('should take an empty options object', () => {
         let widget = new DragPanel({});
         expect(widget).to.be.an(DragPanel);
-        expect(widget.acceptExternalDropSource).to.be(false);
+        expect(widget.acceptDropsFromExternalSource).to.be(false);
         expect(widget.childrenAreDragHandles).to.be(false);
       });
 
       it('should take an options object with optional arguments', () => {
         let widget = new DragPanel({
           childrenAreDragHandles: true,
-          acceptExternalDropSource: true
+          acceptDropsFromExternalSource: true
          });
         expect(widget).to.be.an(DragPanel);
-        expect(widget.acceptExternalDropSource).to.be(true);
+        expect(widget.acceptDropsFromExternalSource).to.be(true);
         expect(widget.childrenAreDragHandles).to.be(true);
       });
 

--- a/test/src/common/dragpanel.spec.ts
+++ b/test/src/common/dragpanel.spec.ts
@@ -16,7 +16,7 @@ import {
 } from 'phosphor/lib/dom/dragdrop';
 
 import {
-  DragPanel
+  DragDropPanel
 } from '../../../lib/common/dragpanel';
 
 const MIME_INDEX = 'application/vnd.jupyter.dragindex';
@@ -29,32 +29,37 @@ describe('common/dragpanel', () => {
     describe('#constructor', () => {
 
       it('should handle empty args', () => {
-        let widget = new DragPanel();
-        expect(widget).to.be.an(DragPanel);
+        let widget = new DragDropPanel();
+        expect(widget).to.be.an(DragDropPanel);
         expect(widget.acceptDropsFromExternalSource).to.be(false);
         expect(widget.childrenAreDragHandles).to.be(false);
       });
 
       it('should take an empty options object', () => {
-        let widget = new DragPanel({});
-        expect(widget).to.be.an(DragPanel);
+        let widget = new DragDropPanel({});
+        expect(widget).to.be.an(DragDropPanel);
         expect(widget.acceptDropsFromExternalSource).to.be(false);
         expect(widget.childrenAreDragHandles).to.be(false);
       });
 
       it('should take an options object with optional arguments', () => {
-        let widget = new DragPanel({
+        let widget = new DragDropPanel({
           childrenAreDragHandles: true,
           acceptDropsFromExternalSource: true
          });
-        expect(widget).to.be.an(DragPanel);
+        expect(widget).to.be.an(DragDropPanel);
         expect(widget.acceptDropsFromExternalSource).to.be(true);
         expect(widget.childrenAreDragHandles).to.be(true);
       });
 
-      it('should add the `jp-DragPanel` class', () => {
-        let widget = new DragPanel();
-        expect(widget.hasClass('jp-DragPanel')).to.be(true);
+      it('should add the `jp-DragWidget` class', () => {
+        let widget = new DragDropPanel();
+        expect(widget.hasClass('jp-DragWidget')).to.be(true);
+      });
+
+      it('should add the `jp-DropWidget` class', () => {
+        let widget = new DragDropPanel();
+        expect(widget.hasClass('jp-DropWidget')).to.be(true);
       });
 
     });
@@ -64,7 +69,7 @@ describe('common/dragpanel', () => {
       // Testing UI-based thing like drag and drop is tricky at best,
       // so we instead just test using protected API of code
 
-      class Override extends DragPanel {
+      class Override extends DragDropPanel {
         addMimeData(handle: HTMLElement, mimeData: MimeData): void {
           return super.addMimeData(handle, mimeData);
         }
@@ -260,7 +265,7 @@ describe('common/dragpanel', () => {
         });
 
         it('should return null when passed a handle that belongs to a different, non-nested drag panel', () => {
-          let otherDrag = new DragPanel();
+          let otherDrag = new DragDropPanel();
           otherDrag.addWidget(other);
           let target = simple.findDragTarget(other.node);
           expect(target).to.be(null);
@@ -292,14 +297,14 @@ describe('common/dragpanel', () => {
         });
 
         it('should return null when passed a handle that belongs to a different, non-nested drag panel', () => {
-          let otherDrag = new DragPanel();
+          let otherDrag = new DragDropPanel();
           otherDrag.addWidget(other);
           let target = simple.findDropTarget(other.node, mimeData);
           expect(target).to.be(null);
         });
 
         it('should return null when passed a mime bundle without needed mime type', () => {
-          let otherDrag = new DragPanel();
+          let otherDrag = new DragDropPanel();
           otherDrag.addWidget(other);
           let mimeData = new MimeData();
           mimeData.setData('text/plain', 'abc');

--- a/test/src/common/dragpanel.spec.ts
+++ b/test/src/common/dragpanel.spec.ts
@@ -1,0 +1,316 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  Panel
+} from 'phosphor/lib/ui/panel';
+
+import {
+  MimeData
+} from 'phosphor/lib/core/mimedata';
+
+import {
+  IDragEvent
+} from 'phosphor/lib/dom/dragdrop';
+
+import {
+  DragPanel
+} from '../../../lib/common/dragpanel';
+
+const MIME_INDEX = 'application/vnd.jupyter.dragindex';
+
+
+describe('common/dragpanel', () => {
+
+  describe('DragPanel()', () => {
+
+    describe('#constructor', () => {
+
+      it('should handle empty args', () => {
+        let widget = new DragPanel();
+        expect(widget).to.be.an(DragPanel);
+        expect(widget.acceptExternalDropSource).to.be(false);
+        expect(widget.childrenAreDragHandles).to.be(false);
+      });
+
+      it('should take an empty options object', () => {
+        let widget = new DragPanel({});
+        expect(widget).to.be.an(DragPanel);
+        expect(widget.acceptExternalDropSource).to.be(false);
+        expect(widget.childrenAreDragHandles).to.be(false);
+      });
+
+      it('should take an options object with optional arguments', () => {
+        let widget = new DragPanel({
+          childrenAreDragHandles: true,
+          acceptExternalDropSource: true
+         });
+        expect(widget).to.be.an(DragPanel);
+        expect(widget.acceptExternalDropSource).to.be(true);
+        expect(widget.childrenAreDragHandles).to.be(true);
+      });
+
+      it('should add the `jp-DragPanel` class', () => {
+        let widget = new DragPanel();
+        expect(widget.hasClass('jp-DragPanel')).to.be(true);
+      });
+
+    });
+
+    describe('Protected API', () => {
+
+      // Testing UI-based thing like drag and drop is tricky at best,
+      // so we instead just test using protected API of code
+
+      class Override extends DragPanel {
+        addMimeData(handle: HTMLElement, mimeData: MimeData): void {
+          return super.addMimeData(handle, mimeData);
+        }
+
+        processDrop(dropTarget: HTMLElement, event: IDragEvent): void {
+          return super.processDrop(dropTarget, event);
+        }
+
+        findDragTarget(handle: HTMLElement): HTMLElement {
+          return super.findDragTarget(handle);
+        }
+
+        findDropTarget(input: HTMLElement, mimeData: MimeData): HTMLElement {
+          return super.findDropTarget(input, mimeData);
+        }
+
+        getDragImage(handle: HTMLElement): HTMLElement {
+          return super.getDragImage(handle);
+        }
+      }
+
+      let simple: Override;
+      let child1: Panel;
+      let child2: Panel;
+      let child3: Panel;
+      let other: Panel;
+      let dragEvent: IDragEvent;
+      let stopped: boolean;
+
+      beforeEach(function() {
+        // runs before each test in this block
+        simple = new Override();
+        child1 = new Panel();
+        child2 = new Panel();
+        child3 = new Panel();
+        simple.addWidget(child1);
+        simple.addWidget(child2);
+        simple.addWidget(child3);
+        other = new Panel();
+
+        // Partly created drag event
+        dragEvent = document.createEvent('MouseEvent') as IDragEvent;
+        dragEvent.initEvent('dummy', true, true);
+        dragEvent.dropAction = 'none';
+        dragEvent.proposedAction = 'move';
+        dragEvent.supportedActions = 'move';
+        dragEvent.dropAction = 'none';
+        dragEvent.source = simple;
+        stopped = false;
+        let oldStop = dragEvent.stopPropagation;
+        dragEvent.stopPropagation = () => {
+          stopped = true;
+          oldStop.apply(dragEvent);
+        };
+      });
+
+
+      describe('#addMimeData', () => {
+
+        it('should add index from handle', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          simple.addMimeData(child1.node, mimeData);
+          expect(mimeData.hasData(MIME_INDEX)).to.be(true);
+          expect(mimeData.getData(MIME_INDEX)).to.be(0);
+        });
+
+        it('should not add anything for invalid handle', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          simple.addMimeData(other.node, mimeData);
+          expect(mimeData.hasData(MIME_INDEX)).to.be(false);
+        });
+
+      });
+
+      describe('#processDrop()', () => {
+
+        it('should move child widget down', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          mimeData.setData(MIME_INDEX, 0);
+          dragEvent.mimeData = mimeData;
+
+          simple.processDrop(child3.node, dragEvent);
+          expect(simple.widgets.length).to.be(3);
+          // Drops insert the item *above* target
+          expect(simple.widgets.at(0)).to.be(child2);
+          expect(simple.widgets.at(1)).to.be(child1);
+          expect(simple.widgets.at(2)).to.be(child3);
+        });
+
+        it('should stop propagation of event', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          mimeData.setData(MIME_INDEX, 0);
+          dragEvent.mimeData = mimeData;
+
+          simple.processDrop(child3.node, dragEvent);
+          // Check that event was processed and won't propagate:
+          expect(dragEvent.defaultPrevented).to.be(true);
+          expect(stopped).to.be(true);
+        });
+
+        it('should emit moved signal', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          mimeData.setData(MIME_INDEX, 0);
+          dragEvent.mimeData = mimeData;
+
+          let called = false;
+          simple.moved.connect((sender, args) => {
+            expect(sender).to.be(simple);
+            // Drops insert the item *above* target
+            expect(args).to.eql({from: 0, to: 1});
+            called = true;
+          });
+          simple.processDrop(child3.node, dragEvent);
+          expect(called).to.be(true);
+        });
+
+        it('should move child widget up', () => {
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          mimeData.setData(MIME_INDEX, 2);
+          dragEvent.mimeData = mimeData;
+
+          let called = false;
+          simple.moved.connect((sender, args) => {
+            expect(sender).to.be(simple);
+            // Drops insert the item *above* target
+            expect(args).to.eql({from: 2, to: 0});
+            called = true;
+          });
+          simple.processDrop(child1.node, dragEvent);
+          // Check widget moved:
+          expect(simple.widgets.length).to.be(3);
+          // Drops insert the item *above* target
+          expect(simple.widgets.at(0)).to.be(child3);
+          expect(simple.widgets.at(1)).to.be(child1);
+          expect(simple.widgets.at(2)).to.be(child2);
+          expect(called).to.be(true);
+        });
+
+        it('should do no-op for proposed action `\'none\'`', () => {
+          // Setup
+          simple.childrenAreDragHandles = true;
+          let mimeData = new MimeData();
+          mimeData.setData(MIME_INDEX, 2);
+          dragEvent.mimeData = mimeData;
+          dragEvent.proposedAction = 'none';
+
+          let called = false;
+          simple.moved.connect((sender, args) => {
+            called = true;
+          });
+
+          // Call:
+          simple.processDrop(child1.node, dragEvent);
+
+          // Check that event was processed and won't propagate:
+          expect(dragEvent.defaultPrevented).to.be(true);
+          expect(stopped).to.be(true);
+          // Check that moved was not emitted
+          expect(called).to.be(false);
+          // Check that order is unchanged
+          expect(simple.widgets.length).to.be(3);
+          expect(simple.widgets.at(0)).to.be(child1);
+          expect(simple.widgets.at(1)).to.be(child2);
+          expect(simple.widgets.at(2)).to.be(child3);
+        });
+
+      });
+
+      describe('#findDragTarget', () => {
+
+        it('should return the input when passed a valid drag target', () => {
+          for (let child of [child1, child2, child3]) {
+            let target = simple.findDragTarget(child.node);
+            expect(target).to.be(child.node);
+          }
+        });
+
+        it('should return the direct child when passed a buried handle', () => {
+          child1.addWidget(other);
+          let target = simple.findDragTarget(other.node);
+          expect(target).to.be(child1.node);
+        });
+
+        it('should return null when passed a handle that is not a descendant', () => {
+          let target = simple.findDragTarget(other.node);
+          expect(target).to.be(null);
+        });
+
+        it('should return null when passed a handle that belongs to a different, non-nested drag panel', () => {
+          let otherDrag = new DragPanel();
+          otherDrag.addWidget(other);
+          let target = simple.findDragTarget(other.node);
+          expect(target).to.be(null);
+        });
+
+      });
+
+      describe('#findDropTarget', () => {
+
+        let mimeData = new MimeData();
+        mimeData.setData(MIME_INDEX, 0);
+
+        it('should return the input when passed a valid drop target', () => {
+          for (let child of [child1, child2, child3]) {
+            let target = simple.findDropTarget(child.node, mimeData);
+            expect(target).to.be(child.node);
+          }
+        });
+
+        it('should return the direct child when passed a buried handle', () => {
+          child1.addWidget(other);
+          let target = simple.findDropTarget(other.node, mimeData);
+          expect(target).to.be(child1.node);
+        });
+
+        it('should return null when passed a handle that is not a descendant', () => {
+          let target = simple.findDropTarget(other.node, mimeData);
+          expect(target).to.be(null);
+        });
+
+        it('should return null when passed a handle that belongs to a different, non-nested drag panel', () => {
+          let otherDrag = new DragPanel();
+          otherDrag.addWidget(other);
+          let target = simple.findDropTarget(other.node, mimeData);
+          expect(target).to.be(null);
+        });
+
+        it('should return null when passed a mime bundle without needed mime type', () => {
+          let otherDrag = new DragPanel();
+          otherDrag.addWidget(other);
+          let mimeData = new MimeData();
+          mimeData.setData('text/plain', 'abc');
+          let target = simple.findDropTarget(other.node, mimeData);
+          expect(target).to.be(null);
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -3,6 +3,7 @@
 
 import './common/activitymonitor.spec';
 import './common/observablelist.spec';
+import './common/dragpanel.spec';
 
 import './console/history.spec';
 


### PR DESCRIPTION
This is a general purpose panel for using drag and drop to reorder widgets. The base implementation only allows for reordering widgets that are directly under the panel, but is implemented in such a way to be easily extensible in subclasses for more advanced behavior.

Example extension for allowing drag and drop reordering of cells (ref #641) would:
 - Override `move()` to change the order in the model instead of the order of the widgets.

OR:
 - Override `addMimeData()` to add `nbformat.ICell` to metadata bundle
 - Override `processDrop()` to move/copy the dropped cell.
 - Optionally set `allowDropsFromExternalSource` to true to allow copy/move of cells between panels.

The code is based on initial suggestion by @blink1073 in jupyter-attic/jupyter-js-notebook#189