### PR TITLE
Promote output area model/widget members to protected

### DIFF
--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -31,8 +31,8 @@ class OutputAreaModel implements IDisposable {
    * Construct a new observable outputs instance.
    */
   constructor() {
-    this._list = new ObservableList<OutputAreaModel.Output>();
-    this._list.changed.connect(this._onListChanged, this);
+    this.list = new ObservableList<OutputAreaModel.Output>();
+    this.list.changed.connect(this._onListChanged, this);
   }
 
   /**
@@ -52,7 +52,7 @@ class OutputAreaModel implements IDisposable {
    * This is a read-only property.
    */
   get length(): number {
-    return this._list ? this._list.length : 0;
+    return this.list ? this.list.length : 0;
   }
 
   /**
@@ -62,7 +62,7 @@ class OutputAreaModel implements IDisposable {
    * This is a read-only property.
    */
   get isDisposed(): boolean {
-    return this._list === null;
+    return this.list === null;
   }
 
   /**
@@ -73,8 +73,8 @@ class OutputAreaModel implements IDisposable {
       return;
     }
     this.disposed.emit(void 0);
-    this._list.clear();
-    this._list = null;
+    this.list.clear();
+    this.list = null;
     clearSignalData(this);
   }
 
@@ -82,7 +82,7 @@ class OutputAreaModel implements IDisposable {
    * Get an item at the specified index.
    */
   get(index: number): OutputAreaModel.Output {
-    return this._list.get(index);
+    return this.list.get(index);
   }
 
   /**
@@ -94,13 +94,13 @@ class OutputAreaModel implements IDisposable {
    */
   add(output: OutputAreaModel.Output): number {
     // If we received a delayed clear message, then clear now.
-    if (this._clearNext) {
+    if (this.clearNext) {
       this.clear();
-      this._clearNext = false;
+      this.clearNext = false;
     }
 
     if (output.output_type === 'input_request') {
-      this._list.add(output);
+      this.list.add(output);
     }
 
     // Make a copy of the output bundle.
@@ -124,7 +124,7 @@ class OutputAreaModel implements IDisposable {
       // This also replaces the metadata of the last item.
       let text = value.text as string;
       value.text = lastOutput.text as string + text;
-      this._list.set(index, value);
+      this.list.set(index, value);
       return index;
     } else {
       switch (value.output_type) {
@@ -132,7 +132,7 @@ class OutputAreaModel implements IDisposable {
       case 'execute_result':
       case 'display_data':
       case 'error':
-        return this._list.add(value);
+        return this.list.add(value);
       default:
         break;
       }
@@ -147,10 +147,10 @@ class OutputAreaModel implements IDisposable {
    */
   clear(wait: boolean = false): OutputAreaModel.Output[] {
     if (wait) {
-      this._clearNext = true;
+      this.clearNext = true;
       return [];
     }
-    return this._list.clear();
+    return this.list.clear();
   }
 
   /**
@@ -202,8 +202,8 @@ class OutputAreaModel implements IDisposable {
     });
   }
 
-  protected _clearNext = false;
-  protected _list: IObservableList<OutputAreaModel.Output> = null;
+  protected clearNext = false;
+  protected list: IObservableList<OutputAreaModel.Output> = null;
 
   /**
    * Handle a change to the list.

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -202,15 +202,15 @@ class OutputAreaModel implements IDisposable {
     });
   }
 
+  protected _clearNext = false;
+  protected _list: IObservableList<OutputAreaModel.Output> = null;
+
   /**
    * Handle a change to the list.
    */
   private _onListChanged(sender: IObservableList<OutputAreaModel.Output>, args: IListChangedArgs<OutputAreaModel.Output>) {
     this.changed.emit(args);
   }
-
-  private _clearNext = false;
-  private _list: IObservableList<OutputAreaModel.Output> = null;
 }
 
 

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -236,7 +236,7 @@ class OutputAreaWidget extends Widget {
     // Trigger a update of the child widgets.
     let layout = this.layout as PanelLayout;
     for (let i = 0; i < layout.widgets.length; i++) {
-      this._updateChild(i);
+      this.updateChild(i);
     }
   }
 
@@ -317,17 +317,17 @@ class OutputAreaWidget extends Widget {
   /**
    * Add a child to the layout.
    */
-  protected _addChild(): void {
+  protected addChild(): void {
     let widget = this._renderer.createOutput({ rendermime: this.rendermime });
     let layout = this.layout as PanelLayout;
     layout.addWidget(widget);
-    this._updateChild(layout.widgets.length - 1);
+    this.updateChild(layout.widgets.length - 1);
   }
 
   /**
    * Remove a child from the layout.
    */
-  protected _removeChild(index: number): void {
+  protected removeChild(index: number): void {
     let layout = this.layout as PanelLayout;
     layout.widgets.at(index).dispose();
   }
@@ -335,7 +335,7 @@ class OutputAreaWidget extends Widget {
   /**
    * Update a child in the layout.
    */
-  protected _updateChild(index: number): void {
+  protected updateChild(index: number): void {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets.at(index) as OutputWidget;
     let output = this._model.get(index);
@@ -345,11 +345,11 @@ class OutputAreaWidget extends Widget {
   /**
    * Follow changes on the model state.
    */
-  protected _onModelStateChanged(sender: OutputAreaModel, args: IListChangedArgs<nbformat.IOutput>) {
+  protected onModelStateChanged(sender: OutputAreaModel, args: IListChangedArgs<nbformat.IOutput>) {
     switch (args.type) {
     case 'add':
       // Children are always added at the end.
-      this._addChild();
+      this.addChild();
       break;
     case 'replace':
       // Only "clear" is supported by the model.
@@ -370,11 +370,11 @@ class OutputAreaWidget extends Widget {
 
       let oldValues = args.oldValue as nbformat.IOutput[];
       for (let i = args.oldIndex; i < oldValues.length; i++) {
-        this._removeChild(args.oldIndex);
+        this.removeChild(args.oldIndex);
       }
       break;
     case 'set':
-      this._updateChild(args.newIndex);
+      this.updateChild(args.newIndex);
       break;
     default:
       break;
@@ -400,29 +400,29 @@ class OutputAreaWidget extends Widget {
   private _onModelChanged(oldValue: OutputAreaModel, newValue: OutputAreaModel): void {
     let layout = this.layout as PanelLayout;
     if (oldValue) {
-      oldValue.changed.disconnect(this._onModelStateChanged, this);
+      oldValue.changed.disconnect(this.onModelStateChanged, this);
       oldValue.disposed.disconnect(this._onModelDisposed, this);
     }
 
     let start = newValue ? newValue.length : 0;
     // Clear unnecessary child widgets.
     for (let i = start; i < layout.widgets.length; i++) {
-      this._removeChild(i);
+      this.removeChild(i);
     }
     if (!newValue) {
       return;
     }
 
-    newValue.changed.connect(this._onModelStateChanged, this);
+    newValue.changed.connect(this.onModelStateChanged, this);
     newValue.disposed.connect(this._onModelDisposed, this);
 
     // Reuse existing child widgets.
     for (let i = 0; i < layout.widgets.length; i++) {
-      this._updateChild(i);
+      this.updateChild(i);
     }
     // Add new widgets as necessary.
     for (let i = layout.widgets.length; i < newValue.length; i++) {
-      this._addChild();
+      this.addChild();
     }
   }
 


### PR DESCRIPTION
I currently have a use case (for [nbdime](https://github.com/jupyter/nbdime)) where I want to allow the user to add/remove/re-order outputs in a merge. The easiest way to ensure compatibility of the output view with that of the rest of Jupyter is of course to just reuse `OutputAreaModel`/`OutputAreaWidget`. However, the standard implementations does not allow reordering/removal of outputs, so I would like to subclass these two classes to add those features (while leaving the JL implementation untouched).

To successfully override these classes, the functions in question would need to be promoted to protected, as suggested in this PR.

Note that code has been moved to conform to the styling guide's ordering of protected/private, so the diff looks a bit aggressive, but this should simply correspond to a cut and paste op.