### PR TITLE
Relax type of mimebundle data to allow for Object

### DIFF
--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -149,7 +149,7 @@ class RenderedHTML extends RenderedHTMLCommon {
   constructor(options: RenderMime.IRenderOptions) {
     super(options);
     this.addClass(HTML_CLASS);
-    let source = <string>options.source;
+    let source = options.source as string;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }
@@ -179,7 +179,7 @@ class RenderedMarkdown extends RenderedHTMLCommon {
   constructor(options: RenderMime.IRenderOptions) {
     super(options);
     this.addClass(MARKDOWN_CLASS);
-    let parts = removeMath(<string>options.source);
+    let parts = removeMath(options.source as string);
     // Add the markdown content asynchronously.
     marked(parts['text'], (err, content) => {
       if (err) {
@@ -225,7 +225,7 @@ class RenderedLatex extends Widget {
    */
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    this.node.textContent = <string>options.source;
+    this.node.textContent = options.source as string;
     this.addClass(LATEX_CLASS);
   }
 
@@ -256,7 +256,7 @@ class RenderedText extends Widget {
 
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    let data = escape_for_html(<string>options.source);
+    let data = escape_for_html(options.source as string);
     let pre = document.createElement('pre');
     pre.innerHTML = ansi_to_html(data);
     this.node.appendChild(pre);
@@ -272,7 +272,7 @@ class RenderedJavascript extends Widget {
     super();
     let s = document.createElement('script');
     s.type = options.mimetype;
-    s.textContent = <string>options.source;
+    s.textContent = options.source as string;
     this.node.appendChild(s);
     this.addClass(JAVASCRIPT_CLASS);
   }
@@ -284,7 +284,7 @@ class RenderedSVG extends Widget {
 
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    let source = <string>options.source;
+    let source = options.source as string;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -149,7 +149,7 @@ class RenderedHTML extends RenderedHTMLCommon {
   constructor(options: RenderMime.IRenderOptions) {
     super(options);
     this.addClass(HTML_CLASS);
-    let source = options.source;
+    let source = <string>options.source;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }
@@ -179,7 +179,7 @@ class RenderedMarkdown extends RenderedHTMLCommon {
   constructor(options: RenderMime.IRenderOptions) {
     super(options);
     this.addClass(MARKDOWN_CLASS);
-    let parts = removeMath(options.source);
+    let parts = removeMath(<string>options.source);
     // Add the markdown content asynchronously.
     marked(parts['text'], (err, content) => {
       if (err) {
@@ -225,7 +225,7 @@ class RenderedLatex extends Widget {
    */
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    this.node.textContent = options.source;
+    this.node.textContent = <string>options.source;
     this.addClass(LATEX_CLASS);
   }
 
@@ -256,7 +256,7 @@ class RenderedText extends Widget {
 
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    let data = escape_for_html(options.source);
+    let data = escape_for_html(<string>options.source);
     let pre = document.createElement('pre');
     pre.innerHTML = ansi_to_html(data);
     this.node.appendChild(pre);
@@ -272,7 +272,7 @@ class RenderedJavascript extends Widget {
     super();
     let s = document.createElement('script');
     s.type = options.mimetype;
-    s.textContent = options.source;
+    s.textContent = <string>options.source;
     this.node.appendChild(s);
     this.addClass(JAVASCRIPT_CLASS);
   }
@@ -284,7 +284,7 @@ class RenderedSVG extends Widget {
 
   constructor(options: RenderMime.IRenderOptions) {
     super();
-    let source = options.source;
+    let source = <string>options.source;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -2,12 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Token
-} from 'phosphor/lib/core/token';
-
-import {
   JSONObject
 } from 'phosphor/lib/algorithm/json';
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
 
 import {
   Widget

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -276,7 +276,7 @@ namespace RenderMime {
     /**
      * The source data.
      */
-    source: string;
+    source: string | Object;
 
     /**
      * An optional url resolver.

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -6,6 +6,10 @@ import {
 } from 'phosphor/lib/core/token';
 
 import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+import {
   Widget
 } from 'phosphor/lib/ui/widget';
 
@@ -276,7 +280,7 @@ namespace RenderMime {
     /**
      * The source data.
      */
-    source: string | Object;
+    source: string | JSONObject;
 
     /**
      * An optional url resolver.


### PR DESCRIPTION
This allows the data from a mimebundle to be an `Object`. Note that message spec v5 states that

> application/json data should be unpacked JSON data, not double-serialized as a JSON string.

Which was broadened in https://github.com/jupyter/nbformat/issues/42 and  https://github.com/jupyter/nbformat/pull/43 to allow `application/(.+\+)?json` to use raw JSON rather than double encoded payloads. This PR allows for the handling of both.

I'll follow this up with a custom mimetype for GeoJSON.