### PR TITLE
Make IRenderOptions a parameterized type.

### DIFF
--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -43,7 +43,7 @@ class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedHTML(options);
   }
 }
@@ -76,7 +76,7 @@ class ImageRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedImage(options);
   }
 }
@@ -109,7 +109,7 @@ class TextRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedText(options);
   }
 }
@@ -142,7 +142,7 @@ class JavascriptRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedJavascript(options);
   }
 }
@@ -175,7 +175,7 @@ class SVGRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedSVG(options);
   }
 }
@@ -208,7 +208,7 @@ class PDFRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedPDF(options);
   }
 }
@@ -241,7 +241,7 @@ class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * Render the mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedLatex(options);
   }
 }
@@ -274,7 +274,7 @@ class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * Render the mime bundle.
    */
-  render(options: RenderMime.IRenderOptions): Widget {
+  render(options: RenderMime.IRenderOptions<string>): Widget {
     return new RenderedMarkdown(options);
   }
 }

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -131,7 +131,7 @@ marked.setOptions({
 export
 class RenderedHTMLCommon extends Widget {
   /* Construct a new rendered HTML common widget.*/
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
     this.addClass(HTML_COMMON_CLASS);
   }
@@ -146,10 +146,10 @@ class RenderedHTML extends RenderedHTMLCommon {
   /**
    * Construct a new html widget.
    */
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super(options);
     this.addClass(HTML_CLASS);
-    let source = options.source as string;
+    let source = options.source;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }
@@ -176,10 +176,10 @@ class RenderedMarkdown extends RenderedHTMLCommon {
   /**
    * Construct a new markdown widget.
    */
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super(options);
     this.addClass(MARKDOWN_CLASS);
-    let parts = removeMath(options.source as string);
+    let parts = removeMath(options.source);
     // Add the markdown content asynchronously.
     marked(parts['text'], (err, content) => {
       if (err) {
@@ -223,9 +223,9 @@ class RenderedLatex extends Widget {
   /**
    * Construct a new latex widget.
    */
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
-    this.node.textContent = options.source as string;
+    this.node.textContent = options.source;
     this.addClass(LATEX_CLASS);
   }
 
@@ -241,7 +241,7 @@ class RenderedLatex extends Widget {
 export
 class RenderedImage extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
     let img = document.createElement('img');
     img.src = `data:${options.mimetype};base64,${options.source}`;
@@ -254,7 +254,7 @@ class RenderedImage extends Widget {
 export
 class RenderedText extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
     let data = escape_for_html(options.source as string);
     let pre = document.createElement('pre');
@@ -268,11 +268,11 @@ class RenderedText extends Widget {
 export
 class RenderedJavascript extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
     let s = document.createElement('script');
     s.type = options.mimetype;
-    s.textContent = options.source as string;
+    s.textContent = options.source;
     this.node.appendChild(s);
     this.addClass(JAVASCRIPT_CLASS);
   }
@@ -282,9 +282,9 @@ class RenderedJavascript extends Widget {
 export
 class RenderedSVG extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
-    let source = options.source as string;
+    let source = options.source;
     if (options.sanitizer) {
       source = options.sanitizer.sanitize(source);
     }
@@ -304,7 +304,7 @@ class RenderedSVG extends Widget {
 export
 class RenderedPDF extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions) {
+  constructor(options: RenderMime.IRenderOptions<string>) {
     super();
     let a = document.createElement('a');
     a.target = '_blank';

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -264,14 +264,14 @@ namespace RenderMime {
      *
      * @param options - The options used for rendering.
      */
-    render(options: IRenderOptions): Widget;
+    render(options: IRenderOptions<string | JSONObject>): Widget;
   }
 
   /**
    * The options used to transform or render mime data.
    */
   export
-  interface IRenderOptions {
+  interface IRenderOptions<T extends string | JSONObject> {
     /**
      * The mimetype.
      */
@@ -280,7 +280,7 @@ namespace RenderMime {
     /**
      * The source data.
      */
-    source: string | JSONObject;
+    source: T;
 
     /**
      * An optional url resolver.


### PR DESCRIPTION
It’s not clear this is better than having separate subtypes for IRenderOptions (like IRenderOptionsString, IRenderOptionsObject), perhaps with a differentiating field like sourceFormat.

See also https://github.com/jupyter/jupyterlab/pull/874, CC @sccolbert, @rgbkrk.