### PR TITLE
Add favicon to JupyterLab.

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -21,6 +21,8 @@ Distributed under the terms of the Modified BSD License.
   "notebookPath": "{{notebook_path | urlencode}}"
   }</script>
 
+  <link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">
+
   {% for bundle_file in jupyterlab_bundles %}
   <script src="{{ bundle_file }}" type="text/javascript" charset="utf-8"></script>
   {% endfor %}


### PR DESCRIPTION
In the future, instead of using a `<link>` tag in Jupyter Lab (and also one in the classic notebook), the base notebook server should explicitly handle the route:

```
GET /favicon.ico
```

It should serve the static `favicon.ico` file. For now, however, the `<link>` tag will suffice.

Fixes https://github.com/jupyter/jupyterlab/issues/845