### PR TITLE
HTML table redesign

### DIFF
--- a/src/csvwidget/widget.ts
+++ b/src/csvwidget/widget.ts
@@ -64,6 +64,7 @@ class CSVWidget extends Widget {
     this._toolbar.addClass(CSV_TOOLBAR_CLASS);
     this._table = new Widget();
     this._table.addClass(CSV_TABLE_CLASS);
+    this._table.addClass('jp-RenderedHTMLCommon');
 
     let layout = this.layout as PanelLayout;
     layout.addWidget(this._toolbar);

--- a/src/csvwidget/widget.ts
+++ b/src/csvwidget/widget.ts
@@ -64,7 +64,6 @@ class CSVWidget extends Widget {
     this._toolbar.addClass(CSV_TOOLBAR_CLASS);
     this._table = new Widget();
     this._table.addClass(CSV_TABLE_CLASS);
-    this._table.addClass('jp-RenderedHTMLCommon');
 
     let layout = this.layout as PanelLayout;
     layout.addWidget(this._toolbar);

--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -202,25 +202,25 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon table {
-  margin-left: auto;
-  margin-right: auto;
   border: none;
   border-collapse: collapse;
   border-spacing: 0;
   color: var(--jp-ui-font-color1);
-  font-size: var(--jp-ui-font-size1);
+  font-size: 12px;
   table-layout: fixed;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 
 .jp-RenderedHTMLCommon thead {
-  border-bottom: 1px solid var(--jp-border-color1);
+  border-bottom: 2px solid var(--jp-border-color1);
   vertical-align: bottom;
 }
 
 
 .jp-RenderedHTMLCommon tr {
-  /*border-bottom: var(--jp-border-width) solid var(--jp-border-color2);*/
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
 }
 
 
@@ -238,22 +238,10 @@ margin-top = 14, 14, 14, 14, 8, 8
 }
 
 
-.jp-RenderedHTMLCommon tr,
-.jp-RenderedHTMLCommon th,
-.jp-RenderedHTMLCommon td {
-
-}
-
-
-.jp-RenderedHTMLCommon tbody tr:nth-child(odd) {
-  background: var(--md-grey-100);
-}
-
-
-
 .jp-RenderedHTMLCommon th {
-  font-weight: normal;
+  font-weight: bold;
 }
+
 
 .jp-RenderedHTMLCommon * + table {
   margin-top: 1em;

--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -219,11 +219,6 @@ margin-top = 14, 14, 14, 14, 8, 8
 }
 
 
-.jp-RenderedHTMLCommon tr {
-  /*border-bottom: var(--jp-border-width) solid var(--jp-border-color2);*/
-}
-
-
 .jp-RenderedHTMLCommon td,
 .jp-RenderedHTMLCommon th {
   text-align: right;

--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -204,26 +204,48 @@ margin-top = 14, 14, 14, 14, 8, 8
 .jp-RenderedHTMLCommon table {
   margin-left: auto;
   margin-right: auto;
-  border: var(--jp-border-width) solid black;
+  border: none;
   border-collapse: collapse;
+  border-spacing: 0;
+  color: var(--jp-ui-font-color1);
+  font-size: var(--jp-ui-font-size1);
+  table-layout: fixed;
+}
+
+
+.jp-RenderedHTMLCommon thead {
+  border-bottom: 2px solid var(--jp-border-color1);
+  vertical-align: bottom;
+}
+
+
+.jp-RenderedHTMLCommon tr {
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+}
+
+
+.jp-RenderedHTMLCommon td,
+.jp-RenderedHTMLCommon th {
+  text-align: right;
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: 1.0;
+  white-space: nowrap;
+  max-width: 100px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  border: none;
 }
 
 
 .jp-RenderedHTMLCommon tr,
 .jp-RenderedHTMLCommon th,
 .jp-RenderedHTMLCommon td {
-  border: var(--jp-border-width) solid black;
-  border-collapse: collapse;
-  margin: 1em 2em;
+
 }
 
 
-.jp-RenderedHTMLCommon td,
-.jp-RenderedHTMLCommon th {
-  text-align: left;
-  vertical-align: middle;
-  padding: 4px;
-}
+
 
 
 .jp-RenderedHTMLCommon th {

--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -214,13 +214,13 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon thead {
-  border-bottom: 2px solid var(--jp-border-color1);
+  border-bottom: 1px solid var(--jp-border-color1);
   vertical-align: bottom;
 }
 
 
 .jp-RenderedHTMLCommon tr {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+  /*border-bottom: var(--jp-border-width) solid var(--jp-border-color2);*/
 }
 
 
@@ -245,11 +245,14 @@ margin-top = 14, 14, 14, 14, 8, 8
 }
 
 
+.jp-RenderedHTMLCommon tbody tr:nth-child(odd) {
+  background: var(--md-grey-100);
+}
 
 
 
 .jp-RenderedHTMLCommon th {
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .jp-RenderedHTMLCommon * + table {

--- a/src/renderers/index.css
+++ b/src/renderers/index.css
@@ -214,13 +214,13 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 
 .jp-RenderedHTMLCommon thead {
-  border-bottom: 2px solid var(--jp-border-color1);
+  border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
   vertical-align: bottom;
 }
 
 
 .jp-RenderedHTMLCommon tr {
-  border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
+  /*border-bottom: var(--jp-border-width) solid var(--jp-border-color2);*/
 }
 
 
@@ -240,6 +240,11 @@ margin-top = 14, 14, 14, 14, 8, 8
 
 .jp-RenderedHTMLCommon th {
   font-weight: bold;
+}
+
+
+.jp-RenderedHTMLCommon tbody tr:nth-child(odd) {
+  background: var(--md-grey-100);
 }
 
 


### PR DESCRIPTION
Here is an initial attempt to clean up the HTML table design.

* Better colors and font size
* Minimal borders
* Right align everything (can't distinguish text/numbers in pure CSS)
* Better padding
* Prevent wrapping text in cells and show ellipses in long cells

We may want to do zebra striping and get rid of the bold heading style? I can do variations with those options...

<img width="882" alt="screen shot 2016-09-19 at 11 34 11 pm" src="https://cloud.githubusercontent.com/assets/27600/18656737/d8716dca-7ec1-11e6-8901-ed62339724ee.png">

<img width="884" alt="screen shot 2016-09-19 at 11 34 27 pm" src="https://cloud.githubusercontent.com/assets/27600/18656738/dc75cdf8-7ec1-11e6-89d6-554aba0e1ca3.png">

<img width="881" alt="screen shot 2016-09-19 at 11 34 40 pm" src="https://cloud.githubusercontent.com/assets/27600/18656741/df3e668a-7ec1-11e6-8cda-cc01e974cb5b.png">



