### PR TITLE
Allow build scripts to work without internet connection

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "clean": "rimraf build",
-    "update": "rimraf node_modules/jupyterlab && npm install",
+    "update": "rimraf node_modules/jupyterlab && npm install jupyterlab",
     "build": "npm run update && npm run build:extension",
     "build:extension": "webpack",
     "webpack:devtool": "devtool node_modules/webpack/bin/webpack.js",


### PR DESCRIPTION
Fixes #907.  We can now run the build scripts with no internet connection if there is no install.   The initial `npm install` of the root and `jupyterlab` folders is taken care of by the `NPM` command in `setup.py`.