### PR TITLE
Create classes to encode VDOM best practices

### DIFF
--- a/src/common/vdom.ts
+++ b/src/common/vdom.ts
@@ -2,12 +2,12 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Message
-} from 'phosphor/lib/core/messaging';
-
-import {
   IDisposable
 } from 'phosphor/lib/core/disposable';
+
+import {
+  Message
+} from 'phosphor/lib/core/messaging';
 
 import {
   clearSignalData, defineSignal, ISignal
@@ -23,28 +23,25 @@ import {
 
 
 /**
- * An interface for a model to be used with vdom rendering
+ * An interface for a model to be used with vdom rendering.
  */
 export
 interface IVDomModel extends IDisposable {
-
   /**
-   * A signal emmited when any model state changes.
+   * A signal emited when any model state changes.
    */
   stateChanged: ISignal<IVDomModel, void>;
-
 }
 
 
 /**
- * Concrete implementation of IVDomModel
+ * Concrete implementation of IVDomModel.
  */
 export class VDomModel implements IVDomModel {
-
   /**
-   * Create a VDomModel
+   * Construct a new VDomModel.
    */
-  contructor() {}
+  constructor() {}
 
   /**
    * A signal emitted when any model state changes.
@@ -63,14 +60,13 @@ export class VDomModel implements IVDomModel {
   }
 
   /**
-   * Is the model disposed?
+   * Test whether the model is disposed.
    */
   get isDisposed(): boolean {
     return this._isDisposed;
   }
 
   _isDisposed = false;
-
 }
 
 // Define the signals for the VDomModel class.
@@ -78,26 +74,24 @@ defineSignal(VDomModel.prototype, 'stateChanged');
 
 
 /** 
- * Phosphor widget that encodes best practices for VDOM based rendering
+ * Phosphor widget that encodes best practices for VDOM based rendering.
  */
 export
 abstract class VDomWidget<T extends IVDomModel> extends Widget {
-
   /**
-   * Create a VDomWidget.
+   * Construct a var name = new type(arguments);VDomWidget.
    */
   constructor() {
     super();
   }
 
   /**
-   * A signal emmited when the model changes.
+   * A signal emited when the model changes.
    */
   modelChanged: ISignal<VDomWidget<T>, void>;
 
   /** 
    * Set the model and fire changed signals.
-   * 
    */
   set model(newValue: T) {
     if (!newValue && !this._model || newValue === this._model) {
@@ -141,10 +135,10 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
    * in this.model and return a phosphor VNode or VNode[] using the phosphor
    * VDOM API.
    */
-  protected abstract render(): VNode | VNode[]
+  protected abstract render(): VNode | VNode[];
 
   /**
-   * Is this widget disposed?
+   * Test whether the widget is disposed.
    */
   get isDisposed(): boolean {
     return this._model === null;
@@ -162,8 +156,7 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
   }
 
   _model: T
-
 }
 
-// Define the signal for the VDomWidget class
+// Define the signal for the VDomWidget class.
 defineSignal(VDomWidget.prototype, 'modelChanged');

--- a/src/common/vdom.ts
+++ b/src/common/vdom.ts
@@ -22,20 +22,38 @@ import {
 } from 'phosphor/lib/ui/vdom';
 
 
+/**
+ * An interface for a model to be used with vdom rendering
+ */
 export
 interface IVDomModel extends IDisposable {
 
+  /**
+   * A signal emmited when any model state changes.
+   */
   stateChanged: ISignal<IVDomModel, void>;
 
 }
 
 
+/**
+ * Concrete implementation of IVDomModel
+ */
 export class VDomModel implements IVDomModel {
 
+  /**
+   * Create a VDomModel
+   */
   contructor() {}
 
+  /**
+   * A signal emitted when any model state changes.
+   */
   stateChanged: ISignal<IVDomModel, void>;
 
+  /**
+   * Dispose the model.
+   */
   dispose(): void {
     if (this.isDisposed) {
       return
@@ -44,6 +62,9 @@ export class VDomModel implements IVDomModel {
     clearSignalData(this);
   }
 
+  /**
+   * Is the model disposed?
+   */
   get isDisposed(): boolean {
     return this._isDisposed;
   }
@@ -52,19 +73,32 @@ export class VDomModel implements IVDomModel {
 
 }
 
+// Define the signals for the VDomModel class.
 defineSignal(VDomModel.prototype, 'stateChanged');
 
 
+/** 
+ * Phosphor widget that encodes best practices for VDOM based rendering
+ */
 export
 abstract class VDomWidget<T extends IVDomModel> extends Widget {
 
+  /**
+   * Create a VDomWidget.
+   */
   constructor() {
     super();
   }
 
+  /**
+   * A signal emmited when the model changes.
+   */
   modelChanged: ISignal<VDomWidget<T>, void>;
 
-
+  /** 
+   * Set the model and fire changed signals.
+   * 
+   */
   set model(newValue: T) {
     if (!newValue && !this._model || newValue === this._model) {
       return;
@@ -79,24 +113,46 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
     this.modelChanged.emit(void 0);
   }
 
-
+  /**
+   * Get the current model.
+   */
   get model(): T {
     return this._model;
   }
 
+  /**
+   * Called to update the state of the widget.
+   * 
+   * In this class, this triggers VDOM based rendering by calling
+   * the this.render() method.
+   */
   protected onUpdateRequest(msg: Message): void {
     let vnode = this.render();
     render(vnode, this.node);
   }
 
+  /**
+   * Render the content of this widget using the virtial DOM.
+   * 
+   * This method will be called anytime the widget needs to be rendered,
+   * which includes layout triggered rendering and all model changes.
+   * 
+   * Subclasses should define this method and use the current model state
+   * in this.model and return a phosphor VNode or VNode[] using the phosphor
+   * VDOM API.
+   */
   protected abstract render(): VNode | VNode[]
 
-
+  /**
+   * Is this widget disposed?
+   */
   get isDisposed(): boolean {
     return this._model === null;
   }
 
-
+  /**
+   * Dispose this widget.
+   */
   dispose() {
     if (this.isDisposed) {
       return;
@@ -109,4 +165,5 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
 
 }
 
+// Define the signal for the VDomWidget class
 defineSignal(VDomWidget.prototype, 'modelChanged');

--- a/src/common/vdom.ts
+++ b/src/common/vdom.ts
@@ -46,7 +46,7 @@ export class VDomModel implements IVDomModel {
   /**
    * A signal emitted when any model state changes.
    */
-  stateChanged: ISignal<IVDomModel, void>;
+  stateChanged: ISignal<this, void>;
 
   /**
    * Dispose the model.
@@ -66,7 +66,7 @@ export class VDomModel implements IVDomModel {
     return this._isDisposed;
   }
 
-  _isDisposed = false;
+  private _isDisposed = false;
 }
 
 // Define the signals for the VDomModel class.
@@ -79,7 +79,7 @@ defineSignal(VDomModel.prototype, 'stateChanged');
 export
 abstract class VDomWidget<T extends IVDomModel> extends Widget {
   /**
-   * Construct a var name = new type(arguments);VDomWidget.
+   * Construct a new VDomWidget.
    */
   constructor() {
     super();
@@ -88,13 +88,14 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
   /**
    * A signal emited when the model changes.
    */
-  modelChanged: ISignal<VDomWidget<T>, void>;
+  modelChanged: ISignal<this, void>;
 
   /** 
    * Set the model and fire changed signals.
    */
   set model(newValue: T) {
-    if (!newValue && !this._model || newValue === this._model) {
+    newValue = newValue || null;
+    if (this._model === newValue) {
       return;
     }
 
@@ -115,10 +116,28 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
   }
 
   /**
+   * Test whether the widget is disposed.
+   */
+  get isDisposed(): boolean {
+    return this._model === null;
+  }
+
+  /**
+   * Dispose this widget.
+   */
+  dispose() {
+    if (this.isDisposed) {
+      return;
+    }
+    this._model = null;
+    super.dispose();
+  }
+
+  /**
    * Called to update the state of the widget.
    * 
-   * In this class, this triggers VDOM based rendering by calling
-   * the this.render() method.
+   * The default implementation of this method triggers
+   * VDOM based rendering by calling the this.render() method.
    */
   protected onUpdateRequest(msg: Message): void {
     let vnode = this.render();
@@ -137,25 +156,7 @@ abstract class VDomWidget<T extends IVDomModel> extends Widget {
    */
   protected abstract render(): VNode | VNode[];
 
-  /**
-   * Test whether the widget is disposed.
-   */
-  get isDisposed(): boolean {
-    return this._model === null;
-  }
-
-  /**
-   * Dispose this widget.
-   */
-  dispose() {
-    if (this.isDisposed) {
-      return;
-    }
-    this._model = null;
-    super.dispose();
-  }
-
-  _model: T
+  private _model: T
 }
 
 // Define the signal for the VDomWidget class.

--- a/src/common/vdom.ts
+++ b/src/common/vdom.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Message
+} from 'phosphor/lib/core/messaging';
+
+import {
+  IDisposable
+} from 'phosphor/lib/core/disposable';
+
+import {
+  clearSignalData, defineSignal, ISignal
+} from 'phosphor/lib/core/signaling';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
+
+import {
+  render, VNode
+} from 'phosphor/lib/ui/vdom';
+
+
+export
+interface IVDomModel extends IDisposable {
+
+  stateChanged: ISignal<IVDomModel, void>;
+
+}
+
+
+export class VDomModel implements IVDomModel {
+
+  contructor() {}
+
+  stateChanged: ISignal<IVDomModel, void>;
+
+  dispose(): void {
+    if (this.isDisposed) {
+      return
+    };
+    this._isDisposed = true;
+    clearSignalData(this);
+  }
+
+  get isDisposed(): boolean {
+    return this._isDisposed;
+  }
+
+  _isDisposed = false;
+
+}
+
+defineSignal(VDomModel.prototype, 'stateChanged');
+
+
+export
+abstract class VDomWidget<T extends IVDomModel> extends Widget {
+
+  constructor() {
+    super();
+  }
+
+  modelChanged: ISignal<VDomWidget<T>, void>;
+
+
+  set model(newValue: T) {
+    if (!newValue && !this._model || newValue === this._model) {
+      return;
+    }
+
+    if (this._model) {
+      this._model.stateChanged.disconnect(this.update, this);
+    }
+    this._model = newValue;
+    this._model.stateChanged.connect(this.update, this);
+    this.update();
+    this.modelChanged.emit(void 0);
+  }
+
+
+  get model(): T {
+    return this._model;
+  }
+
+  protected onUpdateRequest(msg: Message): void {
+    let vnode = this.render();
+    render(vnode, this.node);
+  }
+
+  protected abstract render(): VNode | VNode[]
+
+
+  get isDisposed(): boolean {
+    return this._model === null;
+  }
+
+
+  dispose() {
+    if (this.isDisposed) {
+      return;
+    }
+    this._model = null;
+    super.dispose();
+  }
+
+  _model: T
+
+}
+
+defineSignal(VDomWidget.prototype, 'modelChanged');

--- a/test/src/common/vdom.spec.ts
+++ b/test/src/common/vdom.spec.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  h, VNode
+} from 'phosphor/lib/ui/vdom';
+
+import {
+  VDomModel, VDomWidget
+} from '../../../lib/common/vdom';
+
+
+class TestModel extends VDomModel {
+  get value(): string {
+    return this._value;
+  }
+
+  set value(newValue: string) {
+    this._value = newValue;
+    this.stateChanged.emit(void 0);
+  }
+
+  _value = '';
+}
+
+class TestWidget extends VDomWidget<TestModel> {
+  protected render(): VNode | VNode[] {
+    return h.span(this.model.value);
+  } 
+}
+
+
+describe('common/vdom', () => {
+
+  describe('VDomModel', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a VDomModel', () => {
+        let model = new VDomModel();
+        expect(model).to.be.a(VDomModel);
+      });
+
+      it('should create a TestModel', () => {
+        let model = new TestModel();
+        expect(model).to.be.a(TestModel);
+      });
+
+      it('should be properly disposed', () => {
+        let model = new TestModel();
+        model.dispose();
+        expect(model.isDisposed).to.be.equal(true);
+      });
+    });
+
+    describe('#stateChanged()', () => {
+
+      it('should fire the stateChanged signal on a change', () => {
+        let model = new TestModel();
+        let changed = false;
+        model.stateChanged.connect(() => {changed = true});
+        model.value = 'newvalue';
+        expect(changed).to.be(true);
+      });
+
+    });
+
+  });
+
+  describe('VDomWidget', () => {
+
+    describe('#constructor()', () => {
+
+      it('should create a TestWidget', () => {
+        let widget = new TestWidget();
+        expect(widget).to.be.a(TestWidget);
+      });
+
+      it('should be properly disposed', () => {
+        let widget = new TestWidget();
+        widget.dispose();
+        expect(widget.isDisposed).to.be(true);
+      });
+    });
+
+    describe('#modelChanged()', () => {
+
+      it('should fire the stateChanged signal on a change', () => {
+        let widget = new TestWidget();
+        let model = new TestModel();
+        let changed = false;
+        widget.modelChanged.connect(() => {changed = true});
+        widget.model = model;
+        expect(changed).to.be(true);
+      });
+
+    });
+
+    describe('#render()', () => {
+
+      it('should render the contents after a model change', (done) => {
+        let widget = new TestWidget();
+        let model = new TestModel();
+        widget.model = model;
+        model.value = 'foo';
+        requestAnimationFrame(() => {
+          let span = widget.node.firstChild as HTMLElement;
+          expect(span.textContent).to.be('foo');
+          done();
+        })
+      })
+
+    })
+
+  });
+
+});

--- a/test/src/common/vdom.spec.ts
+++ b/test/src/common/vdom.spec.ts
@@ -22,7 +22,7 @@ class TestModel extends VDomModel {
     this.stateChanged.emit(void 0);
   }
 
-  _value = '';
+  private _value = '';
 }
 
 class TestWidget extends VDomWidget<TestModel> {

--- a/tutorial/index.rst
+++ b/tutorial/index.rst
@@ -25,6 +25,7 @@ Contents:
    notebook.md
    patterns.md
    css.md
+   virtualdom.md
    adding_content.md
    examples.md
    terminology.md

--- a/tutorial/virtualdom.md
+++ b/tutorial/virtualdom.md
@@ -1,0 +1,71 @@
+# Virtual DOM
+
+JupyterLab is based on [PhosphorJS](http://phosphorjs.github.io/), which
+provides a flexible `Widget` class that handles the following:
+
+* Resize events that propagate down the Widget heirarchy.
+* Lifecycle events (`onBeforeDetach`, `onAfterAttach`, etc.).
+* Both CSS-based and absolutely postioned layouts.
+
+The idea of virtual DOM rendering, which became popular in the
+[ReactJS](https://facebook.github.io/react/) community, is a very elegant
+and efficient way of rendering and updating DOM content in response to
+model/state changes. The base `Widget` class in PhosphorJS does not use virtual
+DOM rendering, however Phosphor provides a lightweight virtual DOM API that can
+be used to render leaf content inside a `Widget`. However, the virtual DOM
+API in PhosphorJS is implemented in a manner that is unopinionated about how
+it is used.
+
+In JupyterLab, we provide a more opinionated API for using virtual DOM
+rendering following best practices. This API can be found in `common/vdom.ts`
+and offers two classes:
+
+* `VDomModel`
+* `VDomWidget`
+
+To use these classes, we recommend the following approach.
+
+First, import the virtual DOM API from PhosphorJS and JupyterLab:
+
+```typescriptimport {
+  h, VNode
+} from 'phosphor/lib/ui/vdom';
+
+import {
+  VDomModel, VDomWidget
+} from '../../../lib/common/vdom';
+```
+
+Second, create a subclass of `VDomModel` that contains all of the state needed
+to render the content:
+
+```typescript
+class TestModel extends VDomModel {
+  get value(): string {
+    return this._value;
+  }
+
+  set value(newValue: string) {
+    this._value = newValue;
+    this.stateChanged.emit(void 0);
+  }
+
+  _value = '';
+}
+```
+
+Third, create a subclass of `VDomWidget` that has a `render()` method that uses Phosphor's
+virtual DOM API and returns a PhosphorJS `VNode` or an array of them:
+
+```typescript
+class TestWidget extends VDomWidget<TestModel> {
+  protected render(): VNode | VNode[] {
+    return h.span(this.model.value);
+  } 
+}
+```
+
+Now anytime the model is changed, the content will be rendered on the page efficiently using the virtual
+DOM approach.
+
+

--- a/tutorial/virtualdom.md
+++ b/tutorial/virtualdom.md
@@ -34,7 +34,7 @@ import {
 
 import {
   VDomModel, VDomWidget
-} from '../../../lib/common/vdom';
+} from '../common/vdom'; // From another JupyterLab plugin
 ```
 
 Second, create a subclass of `VDomModel` that contains all of the state needed

--- a/tutorial/virtualdom.md
+++ b/tutorial/virtualdom.md
@@ -42,18 +42,22 @@ to render the content:
 
 ```typescript
 class TestModel extends VDomModel {
-  get value(): string {
-    return this._value;
+  get myvalue(): string {
+    return this._myvalue;
   }
 
-  set value(newValue: string) {
-    this._value = newValue;
+  set myvalue(newValue: string) {
+    this._myvalue = newValue;
     this.stateChanged.emit(void 0);
   }
 
-  _value = '';
+  _myvalue = '';
 }
 ```
+
+For each attribute that is part of your model, you will implement a `get` and `set`
+method as we have done here for the `myvalue` attribute. All of the `set` methods
+in your model should end by calling `this.stateChanged.emit(void 0)`.
 
 Third, create a subclass of `VDomWidget` that has a `render()` method that uses Phosphor's
 virtual DOM API and returns a PhosphorJS `VNode` or an array of them:
@@ -61,7 +65,7 @@ virtual DOM API and returns a PhosphorJS `VNode` or an array of them:
 ```typescript
 class TestWidget extends VDomWidget<TestModel> {
   protected render(): VNode | VNode[] {
-    return h.span(this.model.value);
+    return h.span(this.model.myvalue);
   } 
 }
 ```

--- a/tutorial/virtualdom.md
+++ b/tutorial/virtualdom.md
@@ -51,7 +51,7 @@ class TestModel extends VDomModel {
     this.stateChanged.emit(void 0);
   }
 
-  _myvalue = '';
+  private _myvalue = '';
 }
 ```
 

--- a/tutorial/virtualdom.md
+++ b/tutorial/virtualdom.md
@@ -27,7 +27,8 @@ To use these classes, we recommend the following approach.
 
 First, import the virtual DOM API from PhosphorJS and JupyterLab:
 
-```typescriptimport {
+```typescript
+import {
   h, VNode
 } from 'phosphor/lib/ui/vdom';
 


### PR DESCRIPTION
Phosphor has a very general virtual DOM API, but it is very un-opinionated about how it is used. This PR adds a `VDomModel` and `VDomWidget` class that encodes some best practices for how the underlying VDOM API is used. 

@blink1073 @charnpreetsingh185 @jasongrout @afshin 

Will attempt to add tests and docs now ;-)