### PR TITLE
Add output mimetypes

### DIFF
--- a/src/inspector/handler.ts
+++ b/src/inspector/handler.ts
@@ -136,7 +136,8 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
     let details = content.payload.filter(i => (i as any).source === 'page')[0];
     if (details) {
       let bundle = (details as any).data as RenderMime.MimeMap<string>;
-      let widget = this._rendermime.render(bundle, true);
+      let trusted = true;
+      let widget = this._rendermime.render({ bundle, trusted });
       update.content = widget;
       this.inspected.emit(update);
       return;
@@ -192,7 +193,8 @@ class InspectionHandler implements IDisposable, Inspector.IInspectable {
       }
 
       let bundle = value.data as RenderMime.MimeMap<string>;
-      let widget = this._rendermime.render(bundle, true);
+      let trusted = true;
+      let widget = this._rendermime.render({ bundle, trusted });
       update.content = widget;
       this.inspected.emit(update);
     });

--- a/src/markdownwidget/widget.ts
+++ b/src/markdownwidget/widget.ts
@@ -92,7 +92,8 @@ class MarkdownWidget extends Widget {
     let context = this._context;
     let model = context.model;
     let layout = this.layout as PanelLayout;
-    let widget = this._rendermime.render({ 'text/markdown': model.toString() });
+    let bundle = { 'text/markdown': model.toString() };
+    let widget = this._rendermime.render({ bundle });
     if (layout.widgets.length) {
       layout.widgets.at(0).dispose();
     }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -638,7 +638,8 @@ class MarkdownCellWidget extends BaseCellWidget {
       // Do not re-render if the text has not changed.
       if (text !== this._prev) {
         let bundle: RenderMime.MimeMap<string> = { 'text/markdown': text };
-        let widget = this._rendermime.render(bundle, this.trusted);
+        let trusted = this.trusted;
+        let widget = this._rendermime.render({ bundle, trusted });
         this._output.content = widget || new Widget();
         this.update();
       } else {

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -154,6 +154,28 @@ class OutputAreaModel implements IDisposable {
   }
 
   /**
+   * Add a mime type to an output data bundle.
+   *
+   * @param output - The output to augment.
+   *
+   * @param mimetype - The mimetype to add.
+   *
+   * @param value - The value to add.
+   */
+  addMimeData(output: nbformat.IDisplayData | nbformat.IExecuteResult, mimetype: string, value: string): void {
+    let index = this.list.indexOf(output);
+    if (index === -1) {
+      throw new Error(`Cannot add data to non-tracked bundle`);
+    }
+    if (mimetype in output) {
+      console.warn(`Cannot add existing key '${mimetype}' to bundle`);
+      return;
+    }
+    output.data[mimetype] = value;
+    this.list.set(index, output);
+  }
+
+  /**
    * Execute code on a kernel and send outputs to the model.
    */
   execute(code: string, kernel: IKernel): Promise<KernelMessage.IExecuteReplyMsg> {

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -729,9 +729,7 @@ class OutputWidget extends Widget {
    * @param options - The options used to render the output.
    */
   render(options: OutputWidget.IRenderOptions): void {
-    let output = options.output;
-    let trusted = options.trusted === true;
-    let injector = options.injector;
+    let { output, trusted, injector } = options;
 
     // Handle an input request.
     if (output.output_type === 'input_request') {

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -740,7 +740,7 @@ class OutputWidget extends Widget {
     }
 
     // Create the output result area.
-    let child = rendermime.render(data, trusted);
+    let child = rendermime.render({ bundle: data, trusted });
     if (!child) {
       console.log(msg);
       console.log(data);

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -6,6 +6,10 @@ import {
 } from 'jupyter-js-services';
 
 import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+import {
   Message
 } from 'phosphor/lib/core/messaging';
 
@@ -339,7 +343,17 @@ class OutputAreaWidget extends Widget {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets.at(index) as OutputWidget;
     let output = this._model.get(index);
-    widget.render(output, this._trusted);
+    let injector: (mimetype: string, value: string) => void;
+    if (output.output_type === 'display_data' ||
+        output.output_type === 'execute_result') {
+      injector = (mimetype: string, value: string) => {
+        this._model.addMimeData(
+          output as nbformat.IDisplayData, mimetype, value
+        );
+      };
+    }
+    let trusted = this._trusted;
+    widget.render({ output, trusted, injector });
   }
 
   /**
@@ -712,11 +726,13 @@ class OutputWidget extends Widget {
   /**
    * Render an output.
    *
-   * @param output - The kernel output message payload.
-   *
-   * @param trusted - Whether the output is trusted.
+   * @param options - The options used to render the output.
    */
-  render(output: OutputAreaModel.Output, trusted=false): void {
+  render(options: OutputWidget.IRenderOptions): void {
+    let output = options.output;
+    let trusted = options.trusted === true;
+    let injector = options.injector;
+
     // Handle an input request.
     if (output.output_type === 'input_request') {
       let child = new InputWidget(output as OutputAreaModel.IInputRequest);
@@ -740,7 +756,7 @@ class OutputWidget extends Widget {
     }
 
     // Create the output result area.
-    let child = rendermime.render({ bundle: data, trusted });
+    let child = rendermime.render({ bundle: data, trusted, injector });
     if (!child) {
       console.log(msg);
       console.log(data);
@@ -849,6 +865,34 @@ class OutputWidget extends Widget {
   private _placeholder: Widget = null;
 }
 
+
+/**
+ * The namespace for `OutputWidget` statics.
+ */
+export
+namespace OutputWidget {
+  /**
+   * The options for rendering the output.
+   */
+   export
+   interface IRenderOptions {
+    /**
+     * The kernel output message payload.
+     */
+    output: OutputAreaModel.Output;
+
+    /**
+     * Whether the output is trusted.
+     */
+    trusted: boolean;
+
+    /**
+     * A callback that can be used to add a mimetype to the original bundle.
+     */
+    injector?: (mimetype: string, value: string) => void;
+   }
+
+}
 
 /**
  * A widget that handles stdin requests from the kernel.

--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -43,7 +43,7 @@ class HTMLRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedHTML(options);
   }
 }
@@ -76,7 +76,7 @@ class ImageRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedImage(options);
   }
 }
@@ -109,7 +109,7 @@ class TextRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedText(options);
   }
 }
@@ -142,7 +142,7 @@ class JavascriptRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedJavascript(options);
   }
 }
@@ -175,7 +175,7 @@ class SVGRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedSVG(options);
   }
 }
@@ -208,7 +208,7 @@ class PDFRenderer implements RenderMime.IRenderer {
   /**
    * Render the transformed mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedPDF(options);
   }
 }
@@ -241,7 +241,7 @@ class LatexRenderer implements RenderMime.IRenderer  {
   /**
    * Render the mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedLatex(options);
   }
 }
@@ -274,7 +274,7 @@ class MarkdownRenderer implements RenderMime.IRenderer {
   /**
    * Render the mime bundle.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRendererOptions<string>): Widget {
     return new RenderedMarkdown(options);
   }
 }

--- a/src/renderers/widget.ts
+++ b/src/renderers/widget.ts
@@ -131,7 +131,7 @@ marked.setOptions({
 export
 class RenderedHTMLCommon extends Widget {
   /* Construct a new rendered HTML common widget.*/
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     this.addClass(HTML_COMMON_CLASS);
   }
@@ -146,7 +146,7 @@ class RenderedHTML extends RenderedHTMLCommon {
   /**
    * Construct a new html widget.
    */
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super(options);
     this.addClass(HTML_CLASS);
     let source = options.source;
@@ -176,7 +176,7 @@ class RenderedMarkdown extends RenderedHTMLCommon {
   /**
    * Construct a new markdown widget.
    */
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super(options);
     this.addClass(MARKDOWN_CLASS);
     let parts = removeMath(options.source);
@@ -223,7 +223,7 @@ class RenderedLatex extends Widget {
   /**
    * Construct a new latex widget.
    */
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     this.node.textContent = options.source;
     this.addClass(LATEX_CLASS);
@@ -241,7 +241,7 @@ class RenderedLatex extends Widget {
 export
 class RenderedImage extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     let img = document.createElement('img');
     img.src = `data:${options.mimetype};base64,${options.source}`;
@@ -254,7 +254,7 @@ class RenderedImage extends Widget {
 export
 class RenderedText extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     let data = escape_for_html(options.source as string);
     let pre = document.createElement('pre');
@@ -268,7 +268,7 @@ class RenderedText extends Widget {
 export
 class RenderedJavascript extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     let s = document.createElement('script');
     s.type = options.mimetype;
@@ -282,7 +282,7 @@ class RenderedJavascript extends Widget {
 export
 class RenderedSVG extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     let source = options.source;
     if (options.sanitizer) {
@@ -304,7 +304,7 @@ class RenderedSVG extends Widget {
 export
 class RenderedPDF extends Widget {
 
-  constructor(options: RenderMime.IRenderOptions<string>) {
+  constructor(options: RenderMime.IRendererOptions<string>) {
     super();
     let a = document.createElement('a');
     a.target = '_blank';

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -100,18 +100,20 @@ class RenderMime {
    * trusted (see [[preferredMimetype]]), and then pass a sanitizer to the
    * renderer if the output should be sanitized.
    */
-  render(bundle: RenderMime.MimeMap<string>, trusted=false): Widget {
-    let mimetype = this.preferredMimetype(bundle, trusted);
+  render(options: RenderMime.IRenderOptions<string>): Widget {
+    let trusted = options.trusted === true;
+    let mimetype = this.preferredMimetype(options.bundle, trusted);
     if (!mimetype) {
       return void 0;
     }
-    let options = {
+    let rendererOptions = {
       mimetype,
-      source: bundle[mimetype],
+      source: options.bundle[mimetype],
+      injector: options.injector,
       resolver: this._resolver,
       sanitizer: trusted ? null : this._sanitizer
     };
-    return this._renderers[mimetype].render(options);
+    return this._renderers[mimetype].render(rendererOptions);
   }
 
   /**
@@ -264,14 +266,35 @@ namespace RenderMime {
      *
      * @param options - The options used for rendering.
      */
-    render(options: IRenderOptions<string | JSONObject>): Widget;
+    render(options: IRendererOptions<string | JSONObject>): Widget;
+  }
+
+  /**
+   * The options used to render a mime map.
+   */
+  export
+  interface IRenderOptions<T extends string | JSONObject> {
+    /**
+     * The mime bundle to render.
+     */
+    bundle: MimeMap<T>;
+
+    /**
+     * A callback that can be used to add a mimetype to the original bundle.
+     */
+    injector?: (mimetype: string, value: string | JSONObject) => void;
+
+    /**
+     * Whether the mime bundle is trusted (the default is False).
+     */
+    trusted?: boolean;
   }
 
   /**
    * The options used to transform or render mime data.
    */
   export
-  interface IRenderOptions<T extends string | JSONObject> {
+  interface IRendererOptions<T extends string | JSONObject> {
     /**
      * The mimetype.
      */
@@ -281,6 +304,11 @@ namespace RenderMime {
      * The source data.
      */
     source: T;
+
+    /**
+     * A callback that can be used to add a mimetype to the original bundle.
+     */
+    injector?: (mimetype: string, value: string | JSONObject) => void;
 
     /**
      * An optional url resolver.

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -101,15 +101,15 @@ class RenderMime {
    * renderer if the output should be sanitized.
    */
   render(options: RenderMime.IRenderOptions<string>): Widget {
-    let trusted = options.trusted === true;
-    let mimetype = this.preferredMimetype(options.bundle, trusted);
+    let { trusted, bundle, injector } = options;
+    let mimetype = this.preferredMimetype(bundle, trusted);
     if (!mimetype) {
       return void 0;
     }
     let rendererOptions = {
       mimetype,
-      source: options.bundle[mimetype],
-      injector: options.injector,
+      source: bundle[mimetype],
+      injector,
       resolver: this._resolver,
       sanitizer: trusted ? null : this._sanitizer
     };

--- a/test/src/notebook/output-area/widget.spec.ts
+++ b/test/src/notebook/output-area/widget.spec.ts
@@ -398,7 +398,7 @@ describe('notebook/output-area/widget', () => {
 
       it('should clear the current output', () => {
         let widget = new OutputWidget({ rendermime });
-        widget.render(DEFAULT_OUTPUTS[0], true);
+        widget.render({ output: DEFAULT_OUTPUTS[0], trusted: true });
         let output = widget.output;
         widget.clear();
         expect(widget.output).to.not.be(output);
@@ -413,7 +413,7 @@ describe('notebook/output-area/widget', () => {
         let widget = new OutputWidget({ rendermime });
         for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
           let output = DEFAULT_OUTPUTS[i];
-          widget.render(output, true);
+          widget.render({ output, trusted: true });
         }
       });
 
@@ -421,7 +421,7 @@ describe('notebook/output-area/widget', () => {
         let widget = new OutputWidget({ rendermime });
         for (let i = 0; i < DEFAULT_OUTPUTS.length; i++) {
           let output = DEFAULT_OUTPUTS[i];
-          widget.render(output, false);
+          widget.render({ output, trusted: false });
         }
       });
 

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -65,13 +65,13 @@ describe('rendermime/index', () => {
 
       it('should render a mimebundle', () => {
         let r = defaultRenderMime();
-        let w = r.render({ 'text/plain': 'foo' });
+        let w = r.render({ bundle: { 'text/plain': 'foo' } });
         expect(w instanceof Widget).to.be(true);
       });
 
       it('should return `undefined` for an unregistered mime type', () => {
         let r = defaultRenderMime();
-        let value = r.render({ 'text/fizz': 'buzz' });
+        let value = r.render({ bundle: { 'text/fizz': 'buzz' } });
         expect(value).to.be(void 0);
       });
 
@@ -81,7 +81,7 @@ describe('rendermime/index', () => {
           'text/html': '<h1>foo</h1>'
         };
         let r = defaultRenderMime();
-        let w = r.render(bundle, true);
+        let w = r.render({ bundle, trusted: true });
         let el = w.node.firstChild as HTMLElement;
         expect(el.localName).to.be('h1');
       });
@@ -93,7 +93,7 @@ describe('rendermime/index', () => {
           'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
         };
         let r = defaultRenderMime();
-        let w = r.render(bundle, false);
+        let w = r.render({ bundle, trusted: false });
         let el = w.node.firstChild as HTMLElement;
         expect(el.localName).to.be('img');
       });
@@ -104,7 +104,7 @@ describe('rendermime/index', () => {
           'text/html': '<h1>foo</h1>'
         };
         let r = defaultRenderMime();
-        let w = r.render(bundle, false);
+        let w = r.render({ bundle, trusted: false });
         let el = w.node.firstChild as HTMLElement;
         expect(el.localName).to.be('h1');
       });
@@ -114,7 +114,7 @@ describe('rendermime/index', () => {
           'text/html': '<h1>foo <script>window.x=1></scrip></h1>'
         };
         let r = defaultRenderMime();
-        let widget = r.render(bundle);
+        let widget = r.render({ bundle });
         expect(widget.node.innerHTML).to.be('<h1>foo </h1>');
       });
 
@@ -123,7 +123,7 @@ describe('rendermime/index', () => {
           'image/svg+xml': '<svg><script>windox.x=1</script></svg>'
         };
         let r = defaultRenderMime();
-        let widget = r.render(bundle);
+        let widget = r.render({ bundle });
         expect(widget.node.innerHTML.indexOf('svg')).to.not.be(-1);
         expect(widget.node.innerHTML.indexOf('script')).to.be(-1);
       });
@@ -153,7 +153,7 @@ describe('rendermime/index', () => {
           'image/png': 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
         };
         let r = defaultRenderMime();
-        expect(r.preferredMimetype(bundle, false)).to.be('image/png');
+        expect(r.preferredMimetype(bundle)).to.be('image/png');
       });
 
       it('should render the mimetype that is sanitizable', () => {
@@ -162,7 +162,7 @@ describe('rendermime/index', () => {
           'text/html': '<h1>foo</h1>'
         };
         let r = defaultRenderMime();
-        expect(r.preferredMimetype(bundle, false)).to.be('text/html');
+        expect(r.preferredMimetype(bundle)).to.be('text/html');
       });
     });
 


### PR DESCRIPTION
Fixes #467.

cc @ellisonbg.

Adds the ability to explicitly add mimetypes to the `data` of an output bundle from a renderer.