### PR TITLE
Foreign console cell tweaks.

### DIFF
--- a/src/console/content.ts
+++ b/src/console/content.ts
@@ -459,6 +459,7 @@ class ConsoleContent extends Widget {
    */
   protected newForeignCell(parentMsgId: string): CodeCellWidget {
     let cell = this._renderer.createForeignCell(this._rendermime);
+    cell.readOnly = true;
     cell.mimetype = this._mimetype;
     cell.addClass(FOREIGN_CELL_CLASS);
     this._content.addWidget(cell);
@@ -597,7 +598,6 @@ namespace ConsoleContent {
 
     /**
      * Create a code cell whose input originated from a foreign session.
-     * The implementor is expected to make this read-only.
      */
     createForeignCell(rendermine: IRenderMime): CodeCellWidget;
   }

--- a/src/console/index.css
+++ b/src/console/index.css
@@ -32,11 +32,13 @@
   overflow: auto;
 }
 
-.jp-ConsoleContent-foreignCell {
+
+.jp-ConsoleContent-content .jp-Cell.jp-ConsoleContent-foreignCell {
   background-color: var(--jp-layout-color3);
   flex: 1 1 auto;
   overflow: auto;
 }
+
 
 .jp-ConsoleContent-content .jp-Cell.jp-CodeCell.jp-mod-collapsed.jp-mod-readOnly {
   padding-left: calc(2*var(--jp-private-console-cell-padding))


### PR DESCRIPTION
This PR:

- [x]  moves responsibility for setting foreign cells to read-only into the `ConsoleContent` class, (cc @akosyakov)
- [x] fixes a rendering bug where foreign cell styles were not visible because of CSS specificity

cc: @danielballan 