### PR TITLE
Consolidate file creation process

### DIFF
--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -202,6 +202,13 @@ function showDialog(options?: IDialogOptions): Promise<IButtonItem> {
         resolve(cancelButton);
       }
     }, true);
+    dialog.addEventListener('keydown', evt => {
+      // Check for enter key
+      if (evt.keyCode === 13) {
+        host.removeChild(dialog);
+        resolve(okButton);
+      }
+    }, true);
     dialog.addEventListener('contextmenu', evt => {
       evt.preventDefault();
       evt.stopPropagation();

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -202,13 +202,6 @@ function showDialog(options?: IDialogOptions): Promise<IButtonItem> {
         resolve(cancelButton);
       }
     }, true);
-    dialog.addEventListener('keydown', evt => {
-      // Check for enter key
-      if (evt.keyCode === 13) {
-        host.removeChild(dialog);
-        resolve(okButton);
-      }
-    }, true);
     dialog.addEventListener('contextmenu', evt => {
       evt.preventDefault();
       evt.stopPropagation();

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -52,10 +52,10 @@ interface IKernelSelection {
 
 
 /**
- * An interface for populated a kernel selector.
+ * An interface for populating a kernel selector.
  */
 export
-interface IPopulateKernels {
+interface IPopulateOptions {
    /**
     * The Kernel specs.
     */
@@ -195,7 +195,7 @@ function findKernel(kernelName: string, language: string, specs: IKernel.ISpecMo
  * the explicit session information.
  */
 export
-function populateKernels(node: HTMLSelectElement, options: IPopulateKernels): void {
+function populateKernels(node: HTMLSelectElement, options: IPopulateOptions): void {
   // Clear any existing options.
   while (node.firstChild) {
     node.removeChild(node.firstChild);

--- a/src/docregistry/kernelselector.ts
+++ b/src/docregistry/kernelselector.ts
@@ -52,12 +52,38 @@ interface IKernelSelection {
 
 
 /**
+ * An interface for populated a kernel selector.
+ */
+export
+interface IPopulateKernels {
+   /**
+    * The Kernel specs.
+    */
+  specs: IKernel.ISpecModels;
+
+  /**
+   * The current running sessions.
+   */
+  sessions: ISession.IModel[];
+
+  /**
+   * The preferred kernel name.
+   */
+  preferredKernel?: string;
+
+  /**
+   * The preferred kernel language.
+   */
+  preferredLanguage?: string;
+}
+
+
+/**
  * Bring up a dialog to select a kernel.
  */
 export
 function selectKernel(options: IKernelSelection): Promise<IKernel.IModel> {
-  let specs = options.specs;
-  let kernel = options.kernel;
+  let { specs, kernel, sessions, preferredLanguage } = options;
 
   // Create the dialog body.
   let body = document.createElement('div');
@@ -74,8 +100,7 @@ function selectKernel(options: IKernelSelection): Promise<IKernel.IModel> {
   body.appendChild(selector);
 
   // Get the current sessions, populate the kernels, and show the dialog.
-  let lang = options.preferredLanguage;
-  populateKernels(selector, specs, options.sessions, lang);
+  populateKernels(selector, { specs, sessions, preferredLanguage });
   return showDialog({
     title: 'Select Kernel',
     body,
@@ -152,13 +177,9 @@ function findKernel(kernelName: string, language: string, specs: IKernel.ISpecMo
 /**
  * Populate a kernel dropdown list.
  *
- * @param node - The host html element.
+ * @param node - The host node.
  *
- * @param specs - The available kernel spec information.
- *
- * @param running - The list of running session ids.
- *
- * @param preferredLanguage - The preferred language for the kernel.
+ * @param options - The options used to populate the kernels.
  *
  * #### Notes
  * Populates the list with separated sections:
@@ -174,12 +195,15 @@ function findKernel(kernelName: string, language: string, specs: IKernel.ISpecMo
  * the explicit session information.
  */
 export
-function populateKernels(node: HTMLSelectElement, specs: IKernel.ISpecModels, running: ISession.IModel[], preferredLanguage?: string): void {
+function populateKernels(node: HTMLSelectElement, options: IPopulateKernels): void {
   // Clear any existing options.
   while (node.firstChild) {
     node.removeChild(node.firstChild);
   }
   let maxLength = 10;
+
+  let { preferredKernel, preferredLanguage, sessions, specs } = options;
+
   // Create mappings of display names and languages for kernel name.
   let displayNames: { [key: string]: string } = Object.create(null);
   let languages: { [key: string]: string } = Object.create(null);
@@ -191,11 +215,18 @@ function populateKernels(node: HTMLSelectElement, specs: IKernel.ISpecModels, ru
     languages[name] = spec.language;
     modes[name] = spec.codemirror_mode;
   }
-  // Handle a preferred kernel language in order of display name.
+
+  // Handle a kernel by name.
   let names: string[] = [];
+  if (preferredKernel && preferredKernel in specs.kernelspecs) {
+    names.push(name);
+  }
+
+  // Handle a preferred kernel language in order of display name.
   if (preferredLanguage) {
     for (let name in specs.kernelspecs) {
-      if (languages[name] === preferredLanguage || modes[name] === preferredLanguage) {
+      if (languages[name] === preferredLanguage ||
+          modes[name] === preferredLanguage) {
         names.push(name);
       }
     }
@@ -236,7 +267,7 @@ function populateKernels(node: HTMLSelectElement, specs: IKernel.ISpecModels, ru
   // Add the sessions using the preferred language first.
   let matchingSessions: ISession.IModel[] = [];
   if (preferredLanguage) {
-    for (let session of running) {
+    for (let session of sessions) {
       if (languages[session.kernel.name] === preferredLanguage) {
         matchingSessions.push(session);
       }
@@ -254,7 +285,7 @@ function populateKernels(node: HTMLSelectElement, specs: IKernel.ISpecModels, ru
   }
   // Add the other remaining sessions.
   let otherSessions: ISession.IModel[] = [];
-  for (let session of running) {
+  for (let session of sessions) {
     if (matchingSessions.indexOf(session) === -1) {
       otherSessions.push(session);
     }

--- a/src/docregistry/plugin.ts
+++ b/src/docregistry/plugin.ts
@@ -21,6 +21,16 @@ const docRegistryProvider: JupyterLabPlugin<IDocumentRegistry> = {
     let registry = new DocumentRegistry();
     registry.addModelFactory(new TextModelFactory());
     registry.addModelFactory(new Base64ModelFactory());
+    registry.addFileType({
+      name: 'Text',
+      extension: '.txt',
+      fileType: 'file',
+      fileFormat: 'text'
+    });
+    registry.addCreator({
+      name: 'Text File',
+      fileType: 'Text',
+    });
     return registry;
   }
 };

--- a/src/docregistry/plugin.ts
+++ b/src/docregistry/plugin.ts
@@ -29,7 +29,7 @@ const docRegistryProvider: JupyterLabPlugin<IDocumentRegistry> = {
     });
     registry.addCreator({
       name: 'Text File',
-      fileType: 'file',
+      fileType: 'Text',
     });
     return registry;
   }

--- a/src/docregistry/plugin.ts
+++ b/src/docregistry/plugin.ts
@@ -29,7 +29,7 @@ const docRegistryProvider: JupyterLabPlugin<IDocumentRegistry> = {
     });
     registry.addCreator({
       name: 'Text File',
-      fileType: 'Text',
+      fileType: 'file',
     });
     return registry;
   }

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -41,7 +41,7 @@ interface IDocumentRegistry extends IDisposable {
   /**
    * A signal emmitted when the registry has changed.
    */
-  readonly changed: ISignal<IDocumentRegistry, DocumentRegistry.IChangedArgs>;
+  readonly changed: ISignal<this, DocumentRegistry.IChangedArgs>;
 
   /**
    * Add a widget factory to the registry.
@@ -229,7 +229,7 @@ class DocumentRegistry implements IDocumentRegistry {
   /**
    * A signal emmitted when the registry has changed.
    */
-  readonly changed: ISignal<IDocumentRegistry, DocumentRegistry.IChangedArgs>;
+  readonly changed: ISignal<this, DocumentRegistry.IChangedArgs>;
 
   /**
    * Get whether the document registry has been disposed.

--- a/src/docregistry/registry.ts
+++ b/src/docregistry/registry.ts
@@ -39,7 +39,7 @@ const IDocumentRegistry = new Token<IDocumentRegistry>('jupyter.services.documen
 export
 interface IDocumentRegistry extends IDisposable {
   /**
-   * A signal emmitted when the registry has changed.
+   * A signal emitted when the registry has changed.
    */
   readonly changed: ISignal<this, DocumentRegistry.IChangedArgs>;
 
@@ -227,7 +227,7 @@ interface IDocumentRegistry extends IDisposable {
 export
 class DocumentRegistry implements IDocumentRegistry {
   /**
-   * A signal emmitted when the registry has changed.
+   * A signal emitted when the registry has changed.
    */
   readonly changed: ISignal<this, DocumentRegistry.IChangedArgs>;
 

--- a/src/editorwidget/plugin.ts
+++ b/src/editorwidget/plugin.ts
@@ -291,8 +291,6 @@ function createMenu(app: JupyterLab, tracker: IEditorTracker): Menu {
     args: { theme: name }
   }));
 
-  menu.addItem({ command: 'file-operations:new-text-file' });
-  menu.addItem({ command: 'file-operations:save' });
   menu.addItem({ command: cmdIds.closeAll });
   menu.addItem({ type: 'separator' });
   menu.addItem({ type: 'submenu', menu: settings });

--- a/src/filebrowser/browser.ts
+++ b/src/filebrowser/browser.ts
@@ -227,7 +227,7 @@ class FileBrowserWidget extends Widget {
   createNew(options: IContents.ICreateOptions): Promise<Widget> {
     let model = this.model;
     return model.newUntitled(options).then(contents => {
-      this._buttons.createNew(contents.path);
+      return this._buttons.createNew(contents.path);
     });
   }
 

--- a/src/filebrowser/browser.ts
+++ b/src/filebrowser/browser.ts
@@ -211,16 +211,14 @@ class FileBrowserWidget extends Widget {
    * Open a file by path.
    */
   openPath(path: string, widgetName='default'): Widget {
-    let model = this.model;
-    let widget = this._manager.findWidget(path, widgetName);
-    if (!widget) {
-      widget = this._manager.open(path, widgetName);
-      let context = this._manager.contextForWidget(widget);
-      context.populated.connect(() => model.refresh() );
-      context.kernelChanged.connect(() => model.refresh() );
-    }
-    this._opener.open(widget);
-    return widget;
+    return this._buttons.open(path, widgetName);
+  }
+
+  /**
+   * Create a file from a creator.
+   */
+  createFrom(creatorName: string): Promise<Widget> {
+    return this._buttons.createFrom(creatorName);
   }
 
   /**
@@ -229,12 +227,7 @@ class FileBrowserWidget extends Widget {
   createNew(options: IContents.ICreateOptions): Promise<Widget> {
     let model = this.model;
     return model.newUntitled(options).then(contents => {
-      let widget = this._manager.createNew(contents.path);
-      let context = this._manager.contextForWidget(widget);
-      context.populated.connect(() => model.refresh() );
-      context.kernelChanged.connect(() => model.refresh() );
-      this._opener.open(widget);
-      return widget;
+      this._buttons.createNew(contents.path);
     });
   }
 

--- a/src/filebrowser/buttons.ts
+++ b/src/filebrowser/buttons.ts
@@ -162,9 +162,7 @@ class FileButtons extends Widget {
    */
   createFrom(creatorName: string): Promise<Widget> {
     return createFromDialog(this.model, this.manager, creatorName).then(widget => {
-      if (widget) {
-        return this._open(widget);
-      }
+      return widget ? this._open(widget) : null;
     });
   }
 
@@ -191,8 +189,7 @@ class FileButtons extends Widget {
    * Open a widget and attach listeners.
    */
   private _open(widget: Widget): Widget {
-    let opener = this._opener;
-    opener.open(widget);
+    this._opener.open(widget);
     let context = this._manager.contextForWidget(widget);
     context.populated.connect(() => this.model.refresh() );
     context.kernelChanged.connect(() => this.model.refresh() );

--- a/src/filebrowser/buttons.ts
+++ b/src/filebrowser/buttons.ts
@@ -42,6 +42,10 @@ import {
 } from './browser';
 
 import {
+  createFromDialog
+} from './dialogs';
+
+import {
   FileBrowserModel
 } from './model';
 
@@ -158,27 +162,45 @@ class FileButtons extends Widget {
   }
 
   /**
+   * Create a file from a creator.
+   */
+  createFrom(creatorName: string): Promise<Widget> {
+    return createFromDialog(this.model, this.manager, creatorName).then(widget => {
+      if (widget) {
+        return this._open(widget);
+      }
+    });
+  }
+
+  /**
    * Open a file by path.
    */
-  open(path: string, widgetName='default', kernel?: IKernel.IModel): void {
-    let widget = this._manager.open(path, widgetName, kernel);
-    let opener = this._opener;
-    opener.open(widget);
-    let context = this._manager.contextForWidget(widget);
-    context.populated.connect(() => this.model.refresh() );
-    context.kernelChanged.connect(() => this.model.refresh() );
+  open(path: string, widgetName='default', kernel?: IKernel.IModel): Widget {
+    let widget = this._manager.findWidget(path, widgetName);
+    if (!widget) {
+      widget = this._manager.open(path, widgetName, kernel);
+    }
+    return this._open(widget);
   }
 
   /**
    * Create a new file by path.
    */
-  createNew(path: string, widgetName='default', kernel?: IKernel.IModel): void {
+  createNew(path: string, widgetName='default', kernel?: IKernel.IModel): Widget {
     let widget = this._manager.createNew(path, widgetName, kernel);
+    return this._open(widget);
+  }
+
+  /**
+   * Open a widget and attach listeners.
+   */
+  private _open(widget: Widget): Widget {
     let opener = this._opener;
     opener.open(widget);
     let context = this._manager.contextForWidget(widget);
     context.populated.connect(() => this.model.refresh() );
     context.kernelChanged.connect(() => this.model.refresh() );
+    return widget;
   }
 
   /**
@@ -390,18 +412,6 @@ namespace Private {
   }
 
   /**
-   * Create a new source file.
-   */
-  export
-  function createNewFile(widget: FileButtons): void {
-    widget.model.newUntitled({ type: 'file' }).then(contents => {
-      return widget.open(contents.path);
-    }).catch(error => {
-      utils.showErrorMessage(widget, 'New File Error', error);
-    });
-  }
-
-  /**
    * Create a new folder.
    */
   export
@@ -410,21 +420,6 @@ namespace Private {
       widget.model.refresh();
     }).catch(error => {
       utils.showErrorMessage(widget, 'New Folder Error', error);
-    });
-  }
-
-  /**
-   * Create a new item using a file creator.
-   */
-  function createNewItem(widget: FileButtons, fileType: IFileType, widgetName: string, kernelName?: string): void {
-    let kernel: IKernel.IModel;
-    if (kernelName) {
-      kernel = { name: kernelName };
-    }
-    widget.model.newUntitled(
-      { type: fileType.fileType, ext: fileType.extension })
-    .then(contents => {
-      widget.createNew(contents.path, widgetName, kernel);
     });
   }
 
@@ -443,13 +438,6 @@ namespace Private {
     // Remove all the commands associated with this menu upon disposal.
     menu.disposed.connect(() => disposables.dispose());
 
-    command = `${prefix}:new-text-file`;
-    disposables.add(commands.addCommand(command, {
-      execute: () => { createNewFile(widget); },
-      label: 'Text File'
-    }));
-    menu.addItem({ command });
-
     command = `${prefix}:new-text-folder`;
     disposables.add(commands.addCommand(command, {
       execute: () => { createNewFolder(widget); },
@@ -457,19 +445,11 @@ namespace Private {
     }));
     menu.addItem({ command });
 
-
-    if (creators) {
-      menu.addItem({ type: 'separator' });
-    }
     for (let creator of creators) {
-      let fileType = registry.getFileType(creator.fileType);
-
       command = `${prefix}:new-${creator.name}`;
       disposables.add(commands.addCommand(command, {
         execute: () => {
-          let widgetName = creator.widgetName || 'default';
-          let kernelName = creator.kernelName;
-          createNewItem(widget, fileType, widgetName, kernelName);
+          widget.createFrom(creator.name);
         },
         label: creator.name
       }));

--- a/src/filebrowser/buttons.ts
+++ b/src/filebrowser/buttons.ts
@@ -34,10 +34,6 @@ import {
 } from '../docmanager';
 
 import {
-  IFileType
-} from '../docregistry';
-
-import {
   IWidgetOpener
 } from './browser';
 

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -208,7 +208,11 @@ class OpenWithHandler extends Widget {
     let preference = this._manager.registry.getKernelPreference(
       this._ext, widgetName
     );
-    Private.updateKernels(preference, this.kernelDropdownNode, this._manager.kernelspecs, this._sessions);
+    let specs = this._manager.kernelspecs;
+    let sessions = this._sessions;
+    Private.updateKernels(this.kernelDropdownNode,
+      { preference, specs, sessions }
+    );
   }
 
   private _ext = '';
@@ -287,6 +291,7 @@ class CreateFromHandler extends Widget {
           return widget;
         });
       }
+      return null;
     });
   }
 
@@ -313,7 +318,12 @@ class CreateFromHandler extends Widget {
     // Handle the kernel preferences.
     let preference = registry.getKernelPreference(ext, widgetName);
     if (preference.canStartKernel) {
-      Private.updateKernels(preference, this.kernelDropdownNode, this._manager.kernelspecs, this._sessions, kernelName);
+      let specs = this._manager.kernelspecs;
+      let sessions = this._sessions;
+      let preferredKernel = kernelName;
+      Private.updateKernels(this.kernelDropdownNode,
+        { specs, sessions, preferredKernel, preference }
+      );
     } else {
       this.node.removeChild(this.kernelDropdownNode);
     }
@@ -340,7 +350,7 @@ class CreateFromHandler extends Widget {
     if (path !== this._orig) {
       return renameFile(this._model, this._orig, path).then(value => {
         if (!value) {
-          return;
+          return null;
         }
         return this._manager.createNew(path, widgetName, kernelId);
       });
@@ -538,7 +548,11 @@ class CreateNewHandler extends Widget {
     let ext = this.ext;
     let widgetName = this.widgetDropdown.value;
     let preference = this._manager.registry.getKernelPreference(ext, widgetName);
-    Private.updateKernels(preference, this.kernelDropdownNode, this._manager.kernelspecs, this._sessions);
+    let specs = this._manager.kernelspecs;
+    let sessions = this._sessions;
+    Private.updateKernels(this.kernelDropdownNode,
+      { preference, sessions, specs }
+    );
   }
 
   private _model: FileBrowserModel = null;
@@ -603,7 +617,8 @@ namespace Private {
    * Update a kernel listing based on a kernel preference.
    */
   export
-  function updateKernels(preference: IKernelPreference, node: HTMLSelectElement, specs: IKernel.ISpecModels, sessions: ISession.IModel[], preferredKernel?: string): void {
+  function updateKernels(node: HTMLSelectElement, options: IKernelOptions): void {
+    let { preference, specs, sessions, preferredKernel } = options;
     if (!preference.canStartKernel) {
       while (node.firstChild) {
         node.removeChild(node.firstChild);
@@ -620,5 +635,31 @@ namespace Private {
     if (!preference.preferKernel) {
       node.value = 'null';
     }
+  }
+
+  /**
+   * The options for updating kernels.
+   */
+  export
+  interface IKernelOptions {
+    /**
+     * The kernel preference.
+     */
+    preference: IKernelPreference;
+
+    /**
+     * The kernel specs.
+     */
+    specs: IKernel.ISpecModels;
+
+    /**
+     * The running sessions.
+     */
+    sessions: ISession.IModel[];
+
+    /**
+     * The preferred kernel name.
+     */
+    preferredKernel?: string;
   }
 }

--- a/src/filebrowser/index.css
+++ b/src/filebrowser/index.css
@@ -263,3 +263,8 @@
   min-height: 120px;
   outline: none;
 }
+
+
+.jp-FileDialog.jp-mod-conflict input {
+  color: red;
+}

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -115,7 +115,7 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
 
   let addCreator = (name: string) => {
     let disposables = creatorCmds[name] = new DisposableSet();
-    let command = `file-operations:new-${name}`;
+    let command = Private.commandForName(name);
     disposables.add(commands.addCommand(command, {
       execute: () => {
         fbWidget.createFrom(name);
@@ -293,7 +293,7 @@ function createMenu(app: JupyterLab, creatorCmds: string[]): Menu {
   let menu = new Menu({ commands, keymap });
   menu.title.label = 'File';
   creatorCmds.forEach(name => {
-    menu.addItem({ command: `file-operations:new-${name}` });
+    menu.addItem({ command: Private.commandForName(name) });
   });
   [
     cmdIds.save,
@@ -421,4 +421,13 @@ namespace Private {
    */
   export
   let id = 0;
+
+  /**
+   * Get the command for a name.
+   */
+  export
+  function commandForName(name: string): string {
+    name = name.split(' ').join('-').toLocaleLowerCase();
+    return `file-operations:new-${name}`;
+  }
 }

--- a/src/filebrowser/plugin.ts
+++ b/src/filebrowser/plugin.ts
@@ -173,6 +173,7 @@ function activateFileBrowser(app: JupyterLab, manager: IServiceManager, registry
   app.shell.addToLeftArea(fbWidget, { rank: 40 });
   app.commands.execute(cmdIds.showBrowser, void 0);
 
+  // Handle fileCreator items as they are added.
   registry.changed.connect((sender, args) => {
     if (args.type === 'fileCreator' && args.change === 'added') {
       menu.dispose();

--- a/src/mainmenu/index.ts
+++ b/src/mainmenu/index.ts
@@ -72,8 +72,11 @@ class MainMenu extends MenuBar implements IMainMenu {
     let rankItem = { menu, rank };
     let index = upperBound(this._items, rankItem, Private.itemCmp);
 
-    // Upon disposal, remove the menu reference from the rank list.
-    menu.disposed.connect(() => this._items.remove(rankItem));
+    // Upon disposal, remove the menu and its rank reference.
+    menu.disposed.connect(() => {
+      this.removeMenu(menu);
+      this._items.remove(rankItem);
+    });
 
     this._items.insert(index, rankItem);
     this.insertMenu(index, menu);

--- a/src/notebook/plugin.ts
+++ b/src/notebook/plugin.ts
@@ -145,30 +145,17 @@ function activateNotebookHandler(app: JupyterLab, registry: IDocumentRegistry, s
   registry.addModelFactory(new NotebookModelFactory());
   registry.addWidgetFactory(widgetFactory, options);
 
-  // Add the ability to launch notebooks for each kernel type.
-  let displayNameMap: { [key: string]: string } = Object.create(null);
-  let specs = services.kernelspecs;
-  for (let kernelName in specs.kernelspecs) {
-    let displayName = specs.kernelspecs[kernelName].spec.display_name;
-    displayNameMap[displayName] = kernelName;
-  }
-  let displayNames = Object.keys(displayNameMap).sort((a, b) => {
-    return a.localeCompare(b);
-  });
   registry.addFileType({
     name: 'Notebook',
     extension: '.ipynb',
     fileType: 'notebook',
     fileFormat: 'json'
   });
-  for (let displayName of displayNames) {
-    registry.addCreator({
-      name: `${displayName} Notebook`,
-      fileType: 'Notebook',
-      widgetName: 'Notebook',
-      kernelName: displayNameMap[displayName]
-    });
-  }
+  registry.addCreator({
+    name: 'Notebook',
+    fileType: 'Notebook',
+    widgetName: 'Notebook'
+  });
 
   addCommands(app, tracker);
   populatePalette(palette);
@@ -622,7 +609,6 @@ function createMenu(app: JupyterLab): Menu {
   settings.title.label = 'Settings';
   settings.addItem({ command: cmdIds.toggleAllLines });
 
-  menu.addItem({ command: 'file-operations:new-notebook' });
   menu.addItem({ command: cmdIds.undo });
   menu.addItem({ command: cmdIds.redo });
   menu.addItem({ command: cmdIds.split });


### PR DESCRIPTION
Fixes #917.

We use the information in the `IFileCreator` interface to create a file, choosing the appropriate file extension and type, and kernel information.

The only feature not added is the "Create New Default Notebook" command since that workflow is not supported by the `IFileCreator` as it stands and would require adding a method to the creator.  I am in favor of trying this as it is.


![doc-open](https://cloud.githubusercontent.com/assets/2096628/18876312/c2b83996-848e-11e6-97a1-5fe45208647f.gif)
