### PR TITLE
Use an acitivity monitor to throttle the rendering of the markdown widget.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,7 +27,7 @@ Create the release
 ------------------
 
 We publish an npm package, a Python source package, and a Python universal binary wheel.  We also publish a conda package on conda-forge (see below).
-See the Python docs on [package uploading](https://packaging.python.org/distributing/#uploading-your-project-to-pypi) 
+See the Python docs on [package uploading](https://packaging.python.org/distributing/#uploading-your-project-to-pypi)
 for twine setup instructions and for why twine is the recommended method.
 
 ```bash

--- a/test/src/common/activitymonitor.spec.ts
+++ b/test/src/common/activitymonitor.spec.ts
@@ -106,7 +106,6 @@ describe('common/activitymonitor', () => {
           let now = (new Date()).getTime();
           let delta = now - start;
           if (delta > timeout) {
-            console.log('delta', delta);
             expect(called).to.be(true);
             expect(emission).to.be(secondEmission);
             done();


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyterlab/issues/965