### PR TITLE
blend menu with menu bar when open

### DIFF
--- a/src/application/menus.css
+++ b/src/application/menus.css
@@ -28,7 +28,7 @@
 
 
 .p-MenuBar-menu {
-  transform: translateY(calc(-1*var(--jp-border-width)));
+  transform: translateY(calc(-2*var(--jp-border-width)));
 }
 
 
@@ -47,6 +47,7 @@
 
 .p-MenuBar.p-mod-active .p-MenuBar-item.p-mod-active {
   z-index: 10001;
+  background: var(--jp-layout-color1);
   border-left: var(--jp-border-width) solid var(--jp-border-color1);
   border-right: var(--jp-border-width) solid var(--jp-border-color1);
   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
This adjusts the alignment of the open menu bar menu so that its background blends with the active menu bar item. It also updates the bgcolor of the active menu bar item to blend with the menu.

Before:

![capture1](https://cloud.githubusercontent.com/assets/137289/18893767/d892f92c-84d4-11e6-8a95-a14fc8e43735.PNG)

After:

![capture2](https://cloud.githubusercontent.com/assets/137289/18893772/dd4817a4-84d4-11e6-97b2-a4b279918834.PNG)


cc @ellisonbg 