### PR TITLE
Fix switching to rendered markdown cell in edit mode

### DIFF
--- a/src/notebook/notebook/widget.ts
+++ b/src/notebook/notebook/widget.ts
@@ -661,6 +661,9 @@ class Notebook extends StaticNotebook {
     if (newValue === oldValue) {
       return;
     }
+    if (this.mode === 'edit' && cell instanceof MarkdownCellWidget) {
+      cell.rendered = false;
+    }
     this.stateChanged.emit({ name: 'activeCellIndex', oldValue, newValue });
   }
 


### PR DESCRIPTION
Fixes #981 

![markdown-unrender-edit](https://cloud.githubusercontent.com/assets/2096628/18896487/d048ec96-84e7-11e6-8e9d-223d727bd943.gif)
