### PR TITLE
Fix padding for csv widget

### DIFF
--- a/src/csvwidget/index.css
+++ b/src/csvwidget/index.css
@@ -54,7 +54,6 @@
 
 .jp-CSVWidget-table {
   flex: 1 1 auto;
-  padding: 4px;
   overflow: auto;
 }
 


### PR DESCRIPTION
The csv padding of 4px causes
 - the header of the csv table to look taller than other headers
 - the table to appear to have some left padding but not right padding when there are many columns.