### PR TITLE
Issue 861: Small wording issue with JupyterLab preview

### DIFF
--- a/src/about/html.ts
+++ b/src/about/html.ts
@@ -14,7 +14,7 @@ const html = `
                     <span class="jp-img jp-About-logo"></span>
                     <p class="header">Welcome to the JupyterLab Alpha preview</p>
                     <div class="desc-one">
-                        <p>Click on the JupyterLab tab for the initial JupyterLab screen.</p>
+                        <p>Click on the Launcher tab for the initial JupyterLab screen.</p>
                         <p>This demo gives an Alpha-level developer preview of the JupyterLab environment. <b>It is not ready for general usage yet.</b> We are developing JupyterLab at <a href="https://github.com/jupyter/jupyterlab">https://github.com/jupyter/jupyterlab</a>. Pull requests are welcome!</p>
                         <p>Here is a brief description of some of the things you'll find in this demo.</p>
                     </div>


### PR DESCRIPTION
Fixes: https://github.com/jupyter/jupyterlab/issues/861

Preview:
<img width="1016" alt="screen shot 2016-09-28 at 8 30 08 pm" src="https://cloud.githubusercontent.com/assets/3866405/18919185/d21ee556-85ba-11e6-8aac-9c38aacb86c8.png">
