### PR TITLE
Issue 490: Rename console to Code Console

### DIFF
--- a/src/default-theme/images.css
+++ b/src/default-theme/images.css
@@ -4,8 +4,9 @@
 |----------------------------------------------------------------------------*/
 
 
-.jp-ImageConsole {
+.jp-ImageCodeConsole {
   background-image: url(images/console.svg);
+  margin-left: 12px;
 }
 
 

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -71,7 +71,7 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
   body.className = 'jp-Landing-body';
   dialog.appendChild(body);
 
-  for (let name of ['Notebook', 'Console', 'Terminal', 'Text Editor']) {
+  for (let name of ['Notebook', 'Code Console', 'Terminal', 'Text Editor']) {
     let column = document.createElement('div');
     body.appendChild(column);
     column.className = 'jp-Landing-column';
@@ -93,7 +93,7 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
     app.commands.execute('file-operations:new-notebook', void 0);
   });
 
-  img = body.getElementsByClassName('jp-ImageConsole')[0];
+  img = body.getElementsByClassName('jp-ImageCodeConsole')[0];
   img.addEventListener('click', () => {
     app.commands.execute(`console:create-${services.kernelspecs.default}`, void 0);
   });


### PR DESCRIPTION
Fixes https://github.com/jupyter/jupyterlab/issues/490

<img width="1001" alt="screen shot 2016-09-28 at 10 34 26 pm" src="https://cloud.githubusercontent.com/assets/3866405/18923903/bf6ce2a8-85cb-11e6-9e7c-6341b8cf0c80.png">

The alignment seems to have gone a little awry with the new longer name. What do you think?