### PR TITLE
Active tab blue top border is too long with narrower tabs

### DIFF
--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -259,7 +259,7 @@
   left: calc(-1 * var(--jp-border-width));
   content: '';
   height: var(--jp-private-horizontal-tab-active-top-border);
-  width: var(--jp-private-horizontal-tab-width);
+  width: calc(100% + 2*var(--jp-border-width));
   background: var(--jp-brand-color1);
   z-index: 3;
 }

--- a/src/application/tabs.css
+++ b/src/application/tabs.css
@@ -261,5 +261,4 @@
   height: var(--jp-private-horizontal-tab-active-top-border);
   width: calc(100% + 2*var(--jp-border-width));
   background: var(--jp-brand-color1);
-  z-index: 3;
 }


### PR DESCRIPTION
Before:

<img width="555" alt="screen shot 2016-09-29 at 10 40 25 am" src="https://cloud.githubusercontent.com/assets/27600/18958644/4e59cb92-8631-11e6-83c9-22d703d2dbf3.png">

After:

<img width="412" alt="screen shot 2016-09-29 at 10 39 04 am" src="https://cloud.githubusercontent.com/assets/27600/18958652/537ef502-8631-11e6-9db0-277ccf45f68f.png">
