### PR TITLE
issue 1003: Fix search placeholder text

### DIFF
--- a/src/commandpalette/index.css
+++ b/src/commandpalette/index.css
@@ -33,7 +33,6 @@
 }
 
 .p-CommandPalette-wrapper {
-  background: var(--jp-brand-color1);
   overflow: overlay;
   padding: 0px 8px;
 }
@@ -54,25 +53,25 @@
   border: none;
   outline: none;
   font-size: var(--jp-ui-font-size1);
-  color: var(--jp-inverse-ui-font-color0);
+  color: var(--jp-ui-font-color0);
   line-height: var(--jp-private-commandpalette-search-height);
 }
 
 
 .p-CommandPalette-input::-webkit-input-placeholder {
-  color: var(--jp-inverse-ui-font-color0);
+  color: var(--jp-ui-font-color3);
   font-size: var(--jp-ui-font-size1);
 }
 
 
 .p-CommandPalette-input::-moz-placeholder {
-  color: var(--jp-inverse-ui-font-color0);
+  color: var(--jp-ui-font-color3);
   font-size: var(--jp-ui-font-size1);
 }
 
 
 .p-CommandPalette-input:-ms-input-placeholder {
-  color: var(--jp-inverse-ui-font-color0);
+  color: var(--jp-ui-font-color3);
   font-size: var(--jp-ui-font-size1);
 }
 


### PR DESCRIPTION
I've removed the blue background for the search box and made the placeholder text grey in color.

Fixes https://github.com/jupyter/jupyterlab/issues/1003

<img width="635" alt="screen shot 2016-10-02 at 8 39 24 pm" src="https://cloud.githubusercontent.com/assets/3866405/19022514/c5917908-88f7-11e6-9ebd-b998394c11f4.png">
<img width="662" alt="screen shot 2016-10-02 at 8 39 39 pm" src="https://cloud.githubusercontent.com/assets/3866405/19022515/c5c07c76-88f7-11e6-8230-6ab85fb09a42.png">
