### PR TITLE
Add some template blocks

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -9,11 +9,13 @@ Distributed under the terms of the Modified BSD License.
 <head>
   <meta charset="utf-8">
 
-  <title>{{page_title}}</title>
+  <title>{% block title %}{{page_title}}{% endblock %}</title>
 
-  {% for css_file in jupyterlab_css %}
-  <link href="{{ css_file }}" rel="stylesheet">
-  {% endfor %}
+  {% block stylesheet %}
+    {% for css_file in jupyterlab_css %}
+      <link href="{{ css_file }}" rel="stylesheet">
+    {% endfor %}
+  {% endblock %}
 
   <script id='jupyter-config-data' type="application/json">{
   "baseUrl": "{{base_url | urlencode}}",
@@ -21,7 +23,7 @@ Distributed under the terms of the Modified BSD License.
   "notebookPath": "{{notebook_path | urlencode}}"
   }</script>
 
-  <link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">
+  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
 
   {% for bundle_file in jupyterlab_bundles %}
   <script src="{{ bundle_file }}" type="text/javascript" charset="utf-8"></script>
@@ -31,10 +33,14 @@ Distributed under the terms of the Modified BSD License.
   <script type="text/javascript" src="{{mathjax_url}}?config={{mathjax_config}}&amp;delayStartupUntil=configured" charset="utf-8"></script>
   {% endif %}
 
+  {% block meta %}
+  {% endblock %}
+
 </head>
 
 <body>
 
+{% block script %}
 <script>
   var lab = jupyter.require("{{ jupyterlab_main }}");
   var plugins = [];
@@ -46,6 +52,7 @@ Distributed under the terms of the Modified BSD License.
   lab.registerPlugins(plugins);
   lab.start();
 </script>
+{% endblock %}
 
 </body>
 


### PR DESCRIPTION
This adds the following blocks, named after the ones from `notebook`'s `page.html`. 

- `title`
- `stylesheet`
- `favicon`
- `meta`
- `script`

For integrators, these extension points are nice, especially as the underlying things change: we ran into this a lot on nbviewer, and this list seems to have most of what's needed.

This was never particularly pretty with `notebook`, but the approach still works: here's an example of how this might be used, assuming the basic output of the cookiecutter, `./static` (which actually contains the extension as built) and `./templates` (which just contains a `lab.html`):
```python
from os.path import (
    dirname,
    join
)

from notebook.utils import url_path_join
from notebook.base.handlers import FileFindHandler

from jupyterlab import FILE_LOADER

from ._version import *

HERE = dirname(__file__)
TEMPLATES = join(HERE, "templates")
STATIC = join(HERE, "static")


def _jupyter_labextension_paths():
    return [dict(name="my-theme-labextension", src="static")]


def _jupyter_server_extension_paths():
    return [dict(module="mytheme")]


def load_jupyter_server_extension(nb_app):
    """Load the mytheme extension"""
    nb_app.log.info("[mytheme] enabled")

    webapp = nb_app.web_app
    base_url = webapp.settings['base_url']
    loader = FILE_LOADER

    loader.searchpath = [TEMPLATES] + loader.searchpath

    webapp.add_handlers(".*$", [
        (url_path_join(base_url, "static", "mytheme", "(.*)"),
            FileFindHandler, {'path': STATIC})
    ])
```