### PR TITLE
Allow for strings or json objects in mimedata

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fs-extra": "^0.26.4",
     "istanbul-instrumenter-loader": "^0.1.3",
     "json-loader": "^0.5.4",
+    "json-to-html": "^0.1.2",
     "karma": "^0.13.19",
     "karma-chrome-launcher": "^0.2.2",
     "karma-coverage": "^0.5.3",

--- a/src/notebook/notebook/nbformat.ts
+++ b/src/notebook/notebook/nbformat.ts
@@ -88,8 +88,7 @@ namespace nbformat {
    */
   export
   interface MimeBundle extends JSONObject {
-    [key: string]: multilineString;
-    'application/json'?: any;
+    [key: string]: multilineString | JSONObject;
   }
   /* tslint:enable */
 

--- a/src/notebook/notebook/nbformat.ts
+++ b/src/notebook/notebook/nbformat.ts
@@ -6,7 +6,7 @@
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
 import {
-  JSONObject
+  JSONObject, isObject
 } from 'phosphor/lib/algorithm/json';
 
 
@@ -91,6 +91,55 @@ namespace nbformat {
     [key: string]: multilineString | JSONObject;
   }
   /* tslint:enable */
+
+
+  /**
+   * Validate a mime type/value pair.
+   *
+   * @param type - The mimetype name.
+   *
+   * @param value - The value associated with the type.
+   *
+   * @returns Whether the type/value pair are valid.
+   */
+  export
+  function validateMimeValue(type: string, value: multilineString | JSONObject): boolean {
+    // Check if "application/json" or "application/foo+json"
+    const jsonTest = /^application\/(.*?)+\+json$/;
+    const isJSONType = type === 'application/json' || jsonTest.test(type);
+
+    let isString = (x: any) => {
+      return Object.prototype.toString.call(x) === '[object String]';
+    };
+
+    // If it is an array, make sure if is not a JSON type and it is an
+    // array of strings.
+    if (Array.isArray(value)) {
+      if (isJSONType) {
+        return false;
+      }
+      let valid = true;
+      (value as string[]).forEach(v => {
+        if (!isString(v)) {
+          valid = false;
+        }
+      });
+      return valid;
+    }
+
+    // If it is a string, make sure we are not a JSON type.
+    if (isString(value)) {
+      return !isJSONType;
+    }
+
+    // It is not a string, make sure it is a JSON type.
+    if (!isJSONType) {
+      return false;
+    }
+
+    // It is a JSON type, make sure it is a valid JSON object.
+    return isObject(value);
+  }
 
 
   /**

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -181,7 +181,6 @@ class OutputAreaModel implements IDisposable {
     }
     if (nbformat.validateMimeValue(mimetype, value)) {
       output.data[mimetype] = value;
-      this.list.set(index, output);
     } else {
       console.warn(`Refusing to add invalid mime value of type ${mimetype} to output`);
     }

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -164,18 +164,27 @@ class OutputAreaModel implements IDisposable {
    * @param mimetype - The mimetype to add.
    *
    * @param value - The value to add.
+   *
+   * #### Notes
+   * The output must be contained in the model, or an error will be thrown.
+   * Only non-existent types can be added.
+   * Types are validated before being added.
    */
   addMimeData(output: nbformat.IDisplayData | nbformat.IExecuteResult, mimetype: string, value: string | JSONObject): void {
     let index = this.list.indexOf(output);
     if (index === -1) {
       throw new Error(`Cannot add data to non-tracked bundle`);
     }
-    if (mimetype in output) {
+    if (mimetype in output.data) {
       console.warn(`Cannot add existing key '${mimetype}' to bundle`);
       return;
     }
-    output.data[mimetype] = value;
-    this.list.set(index, output);
+    if (nbformat.validateMimeValue(mimetype, value)) {
+      output.data[mimetype] = value;
+      this.list.set(index, output);
+    } else {
+      console.warn(`Refusing to add invalid mime value of type ${mimetype} to output`);
+    }
   }
 
   /**

--- a/src/notebook/output-area/model.ts
+++ b/src/notebook/output-area/model.ts
@@ -6,6 +6,10 @@ import {
 } from 'jupyter-js-services';
 
 import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
+
+import {
   IDisposable
 } from 'phosphor/lib/core/disposable';
 
@@ -161,7 +165,7 @@ class OutputAreaModel implements IDisposable {
    *
    * @param value - The value to add.
    */
-  addMimeData(output: nbformat.IDisplayData | nbformat.IExecuteResult, mimetype: string, value: string): void {
+  addMimeData(output: nbformat.IDisplayData | nbformat.IExecuteResult, mimetype: string, value: string | JSONObject): void {
     let index = this.list.indexOf(output);
     if (index === -1) {
       throw new Error(`Cannot add data to non-tracked bundle`);

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -343,10 +343,10 @@ class OutputAreaWidget extends Widget {
     let layout = this.layout as PanelLayout;
     let widget = layout.widgets.at(index) as OutputWidget;
     let output = this._model.get(index);
-    let injector: (mimetype: string, value: string) => void;
+    let injector: (mimetype: string, value: string | JSONObject) => void;
     if (output.output_type === 'display_data' ||
         output.output_type === 'execute_result') {
-      injector = (mimetype: string, value: string) => {
+      injector = (mimetype: string, value: string | JSONObject) => {
         this._model.addMimeData(
           output as nbformat.IDisplayData, mimetype, value
         );

--- a/src/notebook/output-area/widget.ts
+++ b/src/notebook/output-area/widget.ts
@@ -347,9 +347,11 @@ class OutputAreaWidget extends Widget {
     if (output.output_type === 'display_data' ||
         output.output_type === 'execute_result') {
       injector = (mimetype: string, value: string | JSONObject) => {
+        this._injecting = true;
         this._model.addMimeData(
           output as nbformat.IDisplayData, mimetype, value
         );
+        this._injecting = false;
       };
     }
     let trusted = this._trusted;
@@ -390,7 +392,9 @@ class OutputAreaWidget extends Widget {
       }
       break;
     case 'set':
-      this.updateChild(args.newIndex);
+      if (!this._injecting) {
+        this.updateChild(args.newIndex);
+      }
       break;
     default:
       break;
@@ -461,6 +465,7 @@ class OutputAreaWidget extends Widget {
   private _model: OutputAreaModel = null;
   private _rendermime: RenderMime = null;
   private _renderer: OutputAreaWidget.IRenderer = null;
+  private _injecting = false;
 }
 
 

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -100,7 +100,7 @@ class RenderMime {
    * trusted (see [[preferredMimetype]]), and then pass a sanitizer to the
    * renderer if the output should be sanitized.
    */
-  render(options: RenderMime.IRenderOptions<string>): Widget {
+  render(options: RenderMime.IRenderOptions<string | JSONObject>): Widget {
     let { trusted, bundle, injector } = options;
     let mimetype = this.preferredMimetype(bundle, trusted);
     if (!mimetype) {

--- a/src/rendermime/index.ts
+++ b/src/rendermime/index.ts
@@ -128,7 +128,7 @@ class RenderMime {
    * "safely"  (see [[RenderMime.IRenderer.isSafe]]) or can  be "sanitized"
    * (see [[RenderMime.IRenderer.isSanitizable]]).
    */
-  preferredMimetype(bundle: RenderMime.MimeMap<string>, trusted=false): string {
+  preferredMimetype(bundle: RenderMime.MimeMap<string | JSONObject>, trusted=false): string {
     for (let m of this.order) {
       if (m in bundle) {
         let renderer = this._renderers[m];

--- a/test/src/notebook/cells/model.spec.ts
+++ b/test/src/notebook/cells/model.spec.ts
@@ -406,7 +406,10 @@ describe('notebook/cells/model', () => {
           outputs: [
             {
               output_type: 'display_data',
-              data: { 'text/plain': 'foo' },
+              data: {
+                'text/plain': 'foo',
+                'application/json': { 'bar': 1 }
+              },
               metadata: {}
             } as nbformat.IDisplayData
           ],
@@ -414,8 +417,11 @@ describe('notebook/cells/model', () => {
           metadata: { trusted: false }
         };
         let model = new CodeCellModel(cell);
-        expect(model.toJSON()).to.not.equal(cell);
-        expect(model.toJSON()).to.eql(cell);
+        let serialized = model.toJSON();
+        expect(serialized).to.not.equal(cell);
+        expect(serialized).to.eql(cell);
+        let output = serialized.outputs[0] as any;
+        expect(output.data['application/json']['bar']).to.be(1);
       });
 
     });

--- a/test/src/notebook/notebook/nbformat.spec.ts
+++ b/test/src/notebook/notebook/nbformat.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import expect = require('expect.js');
+
+import {
+  nbformat
+} from '../../../../lib/notebook/notebook/nbformat';
+
+
+const VALIDATE = nbformat.validateMimeValue;
+
+
+describe('notebook/nbformat', () => {
+
+  describe('validateMimeValue', () => {
+
+    it('should return true for a valid json object', () => {
+      expect(VALIDATE('application/json', { 'foo': 1 })).to.be(true);
+    });
+
+    it('should return true for a valid json-like object', () => {
+      expect(VALIDATE('application/foo+json', { 'foo': 1 })).to.be(true);
+    });
+
+    it('should return true for a valid string object', () => {
+      expect(VALIDATE('text/plain', 'foo')).to.be(true);
+    });
+
+    it('should return true for a valid array of strings object', () => {
+      expect(VALIDATE('text/plain', ['foo', 'bar'])).to.be(true);
+    });
+
+    it('should return false for a json type with string data', () => {
+      expect(VALIDATE('application/foo+json', 'bar')).to.be(false);
+    });
+
+    it('should return false for a string type with json data', () => {
+      expect(VALIDATE('foo/bar', { 'foo': 1 })).to.be(false);
+    });
+
+  });
+
+});

--- a/test/src/notebook/output-area/model.spec.ts
+++ b/test/src/notebook/output-area/model.spec.ts
@@ -241,6 +241,59 @@ describe('notebook/output-area/model', () => {
 
     });
 
+    describe('#addMimeData', () => {
+
+      it('should add a mime type to an output data bundle', () => {
+        let model = new OutputAreaModel();
+        model.add({
+         output_type: 'display_data',
+         data: { 'text/plain': 'hello, world' },
+         metadata: {}
+        });
+        let output = model.get(0) as nbformat.IDisplayData;
+        model.addMimeData(output, 'application/json', { 'foo': 1 });
+        output = model.get(0) as nbformat.IDisplayData;
+        expect((output.data['application/json'] as any)['foo']).to.be(1);
+      });
+
+      it('should refuse to add to an output not contained in the model', () => {
+        let model = new OutputAreaModel();
+        let output: nbformat.IDisplayData = {
+         output_type: 'display_data',
+         data: { },
+         metadata: {}
+        };
+        expect(() => { model.addMimeData(output, 'text/plain', 'foo'); }).to.throwError();
+      });
+
+      it('should refuse to add an existing mime type', () => {
+        let model = new OutputAreaModel();
+        model.add({
+         output_type: 'display_data',
+         data: { 'text/plain': 'hello, world' },
+         metadata: {}
+        });
+        let output = model.get(0) as nbformat.IDisplayData;
+        model.addMimeData(output, 'text/plain', 'foo');
+        output = model.get(0) as nbformat.IDisplayData;
+        expect(output.data['text/plain']).to.be('hello, world');
+      });
+
+      it('should refuse to add an invalid mime type/value pair', () => {
+        let model = new OutputAreaModel();
+        model.add({
+         output_type: 'display_data',
+         data: { 'text/plain': 'hello, world' },
+         metadata: {}
+        });
+        let output = model.get(0) as nbformat.IDisplayData;
+        model.addMimeData(output, 'application/json', 'foo');
+        output = model.get(0) as nbformat.IDisplayData;
+        expect(output.data['application/json']).to.be(void 0);
+      });
+
+    });
+
   });
 
 });

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -3,8 +3,6 @@
 
 import expect = require('expect.js');
 
-import json2html = require('json-to-html');
-
 import {
   JSONObject
 } from 'phosphor/lib/algorithm/json';

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -3,6 +3,8 @@
 
 import expect = require('expect.js');
 
+import json2html = require('json2html');
+
 import {
   Widget
 } from 'phosphor/lib/ui/widget';
@@ -98,6 +100,34 @@ describe('rendermime/index', () => {
         let widget = r.render({ bundle });
         expect(widget.node.innerHTML.indexOf('svg')).to.not.be(-1);
         expect(widget.node.innerHTML.indexOf('script')).to.be(-1);
+      });
+
+      it('should render json data', () => {
+        let bundle: RenderMime.MimeMap<JSONObject> = {
+          'application/json': { 'foo': 1 }
+        };
+        let r = defaultRenderMime();
+        let widget = r.render({ bundle });
+        expect(widget.node.textContent).to.be('foo');
+      });
+
+      it('should accept an injector', () => {
+        let called = 0;
+        let injector = (mimetype: string, value: string | JSONObject) => {
+          if (mimetype === 'text/plain') {
+            expect(value as string).to.be('foo');
+            called++;
+          } else if (mimetype === 'application/json') {
+            expect((value as JSONObject)['foo']).to.be(1);
+            called++;
+          }
+        };
+        let bundle: RenderMime.MimeMap<string> = {
+          'foo/bar': '1'
+        };
+        let r = defaultRenderMime();
+        r.render({ bundle, injector });
+        expect(called).to.be(2);
       });
 
     });

--- a/test/src/rendermime/rendermime.spec.ts
+++ b/test/src/rendermime/rendermime.spec.ts
@@ -3,7 +3,11 @@
 
 import expect = require('expect.js');
 
-import json2html = require('json2html');
+import json2html = require('json-to-html');
+
+import {
+  JSONObject
+} from 'phosphor/lib/algorithm/json';
 
 import {
   Widget
@@ -108,7 +112,7 @@ describe('rendermime/index', () => {
         };
         let r = defaultRenderMime();
         let widget = r.render({ bundle });
-        expect(widget.node.textContent).to.be('foo');
+        expect(widget.node.textContent).to.be('{\n  "foo": 1\n}');
       });
 
       it('should accept an injector', () => {

--- a/test/src/typings.d.ts
+++ b/test/src/typings.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/codemirror/codemirror.d.ts"/>
+/// <reference path="../../typings/json-to-html/json-to-html.d.ts"/>
 /// <reference types="expect.js" />
 /// <reference types="typescript" />
 /// <reference types="mocha" />

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+import json2html = require('json-to-html');
+
 import {
   simulate
 } from 'simulate-event';
@@ -8,6 +10,10 @@ import {
 import {
   createServiceManager, utils, IServiceManager
 } from 'jupyter-js-services';
+
+import {
+  Widget
+} from 'phosphor/lib/ui/widget';
 
 import {
   TextModelFactory, IDocumentModel
@@ -133,6 +139,7 @@ namespace Private {
 
   export
   const notebookFactory = new NotebookModelFactory();
+
 
   class JSONRenderer extends HTMLRenderer {
     /**

--- a/test/src/utils.ts
+++ b/test/src/utils.ts
@@ -134,14 +134,50 @@ namespace Private {
   export
   const notebookFactory = new NotebookModelFactory();
 
+  class JSONRenderer extends HTMLRenderer {
+    /**
+     * The mimetypes this renderer accepts.
+     */
+    mimetypes = ['application/json'];
+
+    /**
+     * Render the transformed mime bundle.
+     */
+    render(options: RenderMime.IRendererOptions<string>): Widget {
+      options.source = json2html(options.source);
+      return super.render(options);
+    }
+  }
+
+
+  class InjectionRenderer extends TextRenderer {
+    /**
+     * The mimetypes this renderer accepts.
+     */
+    mimetypes = ['foo/bar'];
+
+    /**
+     * Render the transformed mime bundle.
+     */
+    render(options: RenderMime.IRendererOptions<string>): Widget {
+      if (options.injector) {
+        options.injector('text/plain', 'foo');
+        options.injector('application/json', { 'foo': 1 } );
+      }
+      return super.render(options);
+    }
+  }
+
   const TRANSFORMERS = [
     new JavascriptRenderer(),
+    new JSONRenderer(),
     new MarkdownRenderer(),
     new HTMLRenderer(),
     new PDFRenderer(),
     new ImageRenderer(),
     new SVGRenderer(),
     new LatexRenderer(),
+    new InjectionRenderer(),
     new TextRenderer()
   ];
 

--- a/typings/json-to-html/json-to-html.d.ts
+++ b/typings/json-to-html/json-to-html.d.ts
@@ -1,0 +1,9 @@
+// Type definitions for json2html v0.1.2
+// https://github.com/frozzare/json-to-html
+// Definitions by: Steven Silvester <https://github.com/blink1073>
+
+
+declare module 'json-to-html' {
+    function render(value: any): string;
+    export = render;
+}


### PR DESCRIPTION
Fixes #1013, fixes #1031.

Adds a validator function to `nbformat` for valid mime type/data pairing.
Adds tests for handling JSON values.
Adds tests for handling mime bundle injection.