### PR TITLE
Provide FocusTracker for console plugin

### DIFF
--- a/examples/lab/index.js
+++ b/examples/lab/index.js
@@ -16,7 +16,7 @@ lab.registerPlugins([
   require('jupyterlab/lib/about/plugin').aboutExtension,
   require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
   require('jupyterlab/lib/commandpalette/plugin').commandPaletteProvider,
-  require('jupyterlab/lib/console/plugin').consoleExtension,
+  require('jupyterlab/lib/console/plugin').consoleTrackerProvider,
   require('jupyterlab/lib/console/codemirror/plugin').rendererProvider,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,
   require('jupyterlab/lib/editorwidget/plugin').editorHandlerProvider,

--- a/jupyterlab/extensions.js
+++ b/jupyterlab/extensions.js
@@ -5,7 +5,7 @@ module.exports = [
   require('jupyterlab/lib/about/plugin').aboutExtension,
   require('jupyterlab/lib/clipboard/plugin').clipboardProvider,
   require('jupyterlab/lib/commandpalette/plugin').commandPaletteProvider,
-  require('jupyterlab/lib/console/plugin').consoleExtension,
+  require('jupyterlab/lib/console/plugin').consoleTrackerProvider,
   require('jupyterlab/lib/console/codemirror/plugin').rendererProvider,
   require('jupyterlab/lib/csvwidget/plugin').csvHandlerExtension,
   require('jupyterlab/lib/docregistry/plugin').docRegistryProvider,

--- a/src/console/index.ts
+++ b/src/console/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
+export * from './tracker';
 export * from './content';
 export * from './panel';

--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -54,16 +54,17 @@ import {
 } from '../services';
 
 import {
-  ConsolePanel, ConsoleContent
-} from './';
+  IConsoleTracker, ConsolePanel, ConsoleContent
+} from './index';
 
 
 /**
- * The console extension.
+ * The console widget tracker provider.
  */
 export
-const consoleExtension: JupyterLabPlugin<void> = {
-  id: 'jupyter.extensions.console',
+const consoleTrackerProvider: JupyterLabPlugin<IConsoleTracker> = {
+  id: 'jupyter.services.console-tracker',
+  provides: IConsoleTracker,
   requires: [
     IServiceManager,
     IRenderMime,
@@ -103,7 +104,7 @@ interface ICreateConsoleArgs extends JSONObject {
 /**
  * Activate the console extension.
  */
-function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, renderer: ConsoleContent.IRenderer): void {
+function activateConsole(app: JupyterLab, services: IServiceManager, rendermime: IRenderMime, mainMenu: IMainMenu, inspector: IInspector, palette: ICommandPalette, pathTracker: IPathTracker, renderer: ConsoleContent.IRenderer): IConsoleTracker {
   let tracker = new FocusTracker<ConsolePanel>();
   let manager = services.sessions;
   let { commands, keymap } = app;
@@ -380,6 +381,7 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   menu.addItem({ command });
 
   mainMenu.addMenu(menu, {rank: 50});
+  return tracker;
 }
 
 

--- a/src/console/tracker.ts
+++ b/src/console/tracker.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  Token
+} from 'phosphor/lib/core/token';
+
+import {
+  FocusTracker
+} from 'phosphor/lib/ui/focustracker';
+
+import {
+  ConsolePanel
+} from './';
+
+
+/* tslint:disable */
+/**
+ * The console tracker token.
+ */
+export
+const IConsoleTracker = new Token<IConsoleTracker>('jupyter.services.console-handler');
+/* tslint:enable */
+
+
+/**
+ * A class that tracks console widgets.
+ */
+export
+interface IConsoleTracker extends FocusTracker<ConsolePanel> {}


### PR DESCRIPTION
See related issue #1014.

With this change the console plugin provides an `IConsoleTracker extends FocusTracker<ConsolePanel>` as a service. Implementation is aligned to the `INotebookTracker` from notebook plugin. 