### PR TITLE
Bail on a failed webpack build in tests

### DIFF
--- a/test/webpack.conf.js
+++ b/test/webpack.conf.js
@@ -7,6 +7,7 @@ module.exports = {
     filename: "bundle.js",
     publicPath: "./test/build/"
   },
+  bail: true,
   devtool: 'inline-source-map',
   module: {
     loaders: [


### PR DESCRIPTION
This avoids swallowed errors.