### PR TITLE
Fix binder by excluding conda default channel

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: jupyterlab
 channels:
+  - nodefaults
   - conda-forge
 dependencies:
   - jupyterlab


### PR DESCRIPTION
The configuration file for the server extension was being overridden by the `_nb_ext_conf` package from the default channel.