### PR TITLE
Use a dialog to start a console

### DIFF
--- a/src/console/plugin.ts
+++ b/src/console/plugin.ts
@@ -210,6 +210,8 @@ function activateConsole(app: JupyterLab, services: IServiceManager, rendermime:
   command = 'console:create';
   commands.addCommand(command, {
     execute: (args: ICreateConsoleArgs) => {
+      args = args || {};
+
       let name = `Console ${++count}`;
 
       // If we get a session, use it.

--- a/src/filebrowser/dialogs.ts
+++ b/src/filebrowser/dialogs.ts
@@ -291,7 +291,7 @@ class CreateFromHandler extends Widget {
           return widget;
         });
       }
-      this._model.deleteFile(this._orig);
+      this._model.deleteFile(this._orig.path);
       return null;
     });
   }

--- a/src/landing/plugin.ts
+++ b/src/landing/plugin.ts
@@ -95,7 +95,7 @@ function activateLanding(app: JupyterLab, services: IServiceManager, pathTracker
 
   img = body.getElementsByClassName('jp-ImageCodeConsole')[0];
   img.addEventListener('click', () => {
-    app.commands.execute(`console:create-${services.kernelspecs.default}`, void 0);
+    app.commands.execute('console:create', void 0);
   });
 
   img = body.getElementsByClassName('jp-ImageTextEditor')[0];


### PR DESCRIPTION
Fixes #918.  I opened #1042 to track the error in rendering the foreign input at the end of the demo.


![new-console](https://cloud.githubusercontent.com/assets/2096628/19161842/0da0443e-8bbb-11e6-9706-37cb33d9fe26.gif)
