### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ questions about these issues.
 ## General Guidelines
 
 For general documentation about contributing to Jupyter projects, see the
-[Project Jupyter Contributor Documentation](http://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
+[Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html).
 
 All source code is written in [TypeScript](http://www.typescriptlang.org/Handbook). See the [Style Guide](https://github.com/jupyter/jupyterlab/wiki/TypeScript-Style-Guide).
 
@@ -136,7 +136,7 @@ The JupyterLab application is made up of two major parts:
 - an npm package
 - a Jupyter server extension (Python package)
 
-Each part is named `jupyterlab`. The [developer tutorial documentation](http://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
+Each part is named `jupyterlab`. The [developer tutorial documentation](https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
 provides additional architecture information.
 
 ## The NPM Package

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Build Status](https://travis-ci.org/jupyter/jupyterlab.svg?branch=master)](https://travis-ci.org/jupyter/jupyterlab)
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/jupyter/jupyterlab/lab)
-[![Documentation Status](https://readthedocs.org/projects/jupyterlab-tutorial/badge/?version=latest)](http://jupyterlab-tutorial.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/jupyterlab-tutorial/badge/?version=latest)](https://jupyterlab-tutorial.readthedocs.io/en/latest/?badge=latest)
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter)
 
 An extensible computational environment for Jupyter.
@@ -94,6 +94,6 @@ and you may participate in development discussions or get live help on [Gitter](
 
 - [Reporting Issues](https://github.com/jupyter/jupyterlab/issues)
 - [API Docs](http://jupyter.github.io/jupyterlab/)
-- [Architecture tutorial](http://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
-- [Documentation for Project Jupyter](http://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
+- [Architecture tutorial](https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html)
+- [Documentation for Project Jupyter](https://jupyter.readthedocs.io/en/latest/index.html) | [PDF](https://media.readthedocs.org/pdf/jupyter/latest/jupyter.pdf)
 - [Project Jupyter website](https://jupyter.org)

--- a/src/faq/plugin.ts
+++ b/src/faq/plugin.ts
@@ -182,7 +182,7 @@ function activateFAQ(app: JupyterLab, palette: ICommandPalette): void {
   kernelLink.className = 'jp-FAQ-a';
   let kernelLinkText = document.createTextNode('this');
   kernelLink.appendChild(kernelLinkText);
-  kernelLink.href = 'http://jupyter.readthedocs.io/en/latest/install-kernel.html';
+  kernelLink.href = 'https://jupyter.readthedocs.io/en/latest/install-kernel.html';
   kernelLink.target = '_blank';
   featuresQ1Ans.appendChild(kernelLink);
 
@@ -282,7 +282,7 @@ function activateFAQ(app: JupyterLab, palette: ICommandPalette): void {
   tutorialLink.className = 'jp-FAQ-a';
   let tutorialLinkText = document.createTextNode('tutorial walkthrough');
   tutorialLink.appendChild(tutorialLinkText);
-  tutorialLink.href = 'http://jupyterlab-tutorial.readthedocs.io/en/latest/index.html';
+  tutorialLink.href = 'https://jupyterlab-tutorial.readthedocs.io/en/latest/index.html';
   tutorialLink.target = '_blank';
   developerQ3Ans.appendChild(tutorialLink);
 

--- a/src/notebook/notebook/actions.ts
+++ b/src/notebook/notebook/actions.ts
@@ -949,7 +949,7 @@ namespace Private {
    * #### Notes
    * Payloads are deprecated and there are no official interfaces for them in
    * the kernel type definitions.
-   * See [Payloads (DEPRECATED)](http://jupyter-client.readthedocs.io/en/latest/messaging.html#payloads-deprecated).
+   * See [Payloads (DEPRECATED)](https://jupyter-client.readthedocs.io/en/latest/messaging.html#payloads-deprecated).
    */
   function handlePayload(content: KernelMessage.IExecuteOkReply, parent: Notebook, child: BaseCellWidget) {
     let setNextInput = content.payload.filter(i => {

--- a/src/notebook/notebook/nbformat.ts
+++ b/src/notebook/notebook/nbformat.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 // Notebook format interfaces
-// https://nbformat.readthedocs.org/en/latest/format_description.html
+// https://nbformat.readthedocs.io/en/latest/format_description.html
 // https://github.com/jupyter/nbformat/blob/master/nbformat/v4/nbformat.v4.schema.json
 
 import {
@@ -161,7 +161,7 @@ namespace nbformat {
      * This is not strictly part of the nbformat spec, but it is added by
      * the contents manager.
      *
-     * See http://jupyter-notebook.readthedocs.org/en/latest/security.html.
+     * See https://jupyter-notebook.readthedocs.io/en/latest/security.html.
      */
     trusted: boolean;
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.