### PR TITLE
Tighten typing restriction of nbformat.ICell

### DIFF
--- a/src/notebook/cells/model.ts
+++ b/src/notebook/cells/model.ts
@@ -353,12 +353,12 @@ class CodeCellModel extends CellModel implements ICodeCellModel {
   /**
    * Construct a new code cell with optional original cell content.
    */
-  constructor(cell?: nbformat.IBaseCell) {
+  constructor(cell?: nbformat.ICell) {
     super(cell);
     this._outputs = new OutputAreaModel();
     if (cell && cell.cell_type === 'code') {
-      this.executionCount = (cell as nbformat.ICodeCell).execution_count;
-      for (let output of (cell as nbformat.ICodeCell).outputs) {
+      this.executionCount = cell.execution_count;
+      for (let output of cell.outputs) {
         this._outputs.add(output);
       }
     }

--- a/src/notebook/cells/widget.ts
+++ b/src/notebook/cells/widget.ts
@@ -432,7 +432,7 @@ class CodeCellWidget extends BaseCellWidget {
    * Execute the cell given a kernel.
    */
   execute(kernel: IKernel): Promise<KernelMessage.IExecuteReplyMsg> {
-    let model = this.model as ICodeCellModel;
+    let model = this.model;
     let code = model.source;
     if (!code.trim()) {
       model.executionCount = null;

--- a/src/notebook/notebook/model.ts
+++ b/src/notebook/notebook/model.ts
@@ -502,7 +502,7 @@ namespace NotebookModel {
      * @returns A new code cell. If a source cell is provided, the
      *   new cell will be intialized with the data from the source.
      */
-    createCodeCell(source?: nbformat.IBaseCell): ICodeCellModel {
+    createCodeCell(source?: nbformat.ICell): ICodeCellModel {
       return new CodeCellModel(source);
     }
 

--- a/src/notebook/notebook/nbformat.ts
+++ b/src/notebook/notebook/nbformat.ts
@@ -288,7 +288,7 @@ namespace nbformat {
    * A cell union type.
    */
   export
-  type ICell = IBaseCell | IRawCell | IMarkdownCell | ICodeCell;
+  type ICell = IRawCell | IMarkdownCell | ICodeCell;
 
 
   /**


### PR DESCRIPTION
By narrowing `nbformat.ICell` to not include the base class, type guards can effectively differentiate between the different cell types based on the `cell.cell_type` field.

The narrowed definition should be sufficient for all uses, as all cells should conform to one of the three cell types.