### PR TITLE
MNT: Add fields for hub config info in JSON blob.

### DIFF
--- a/jupyterlab/lab.html
+++ b/jupyterlab/lab.html
@@ -17,6 +17,8 @@ Distributed under the terms of the Modified BSD License.
 
   <script id='jupyter-config-data' type="application/json">{
   "baseUrl": "{{base_url | urlencode}}",
+  "hubHost": "{{hub_host | urlencode}}",
+  "hubPrefix": "{{hub_prefix | urlencode}}",
   "wsUrl": "{{ws_url| urlencode}}",
   "notebookPath": "{{notebook_path | urlencode}}"
   }</script>


### PR DESCRIPTION
@ellisonbg, @jasongrout and I discussed whether the plugin adding JupyterHub links to JupyterLab should ship as a built-in JupyterLab plugin or a JupyterLab extension packaged with JupyterHub. It seems pretty clear that it's better to package it with JupyterHub.


The goal of this PR is to make it possible for an extension to add JupyterHub navigation links. The extension will need access to two pieces of configuration: the hub host and the hub prefix. Currently, the server does not have generic way to expose this information to JupyterLab.

This PR adds two fields to a JSON blob `lab.html` specifically to solve the problem of exposing them without making any changes to the server. In a future release of the server, we can add the ability to inject arbitrary configuration into that JSON blob and we can remove that hub-specific code from JupyterLab.